### PR TITLE
docs(readme): add Roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **A Modular Agentic Memory MCP Server**
 
+> Quick link: See the project roadmap in [docs/roadmap.md](docs/roadmap.md)
+
 ## 🎯 Vision
 
 ENGRAM is a production-grade Model Context Protocol (MCP) server that provides sophisticated memory management capabilities for AI agents and LLM applications. It implements a neural-temporal approach to context management, enabling short-term and long-term memory, semantic search, memory reconciliation, and intelligent insight generation.


### PR DESCRIPTION
Closes #35

Adds a prominent link near the top of README to `docs/roadmap.md` for quick discovery of the current plan.