### PR TITLE
fix(e2e): fix Jest E2E config to pass full smoke test suite

### DIFF
--- a/apps/mcp-server/test/jest-e2e.json
+++ b/apps/mcp-server/test/jest-e2e.json
@@ -1,20 +1,40 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "..",
   "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
+  "testRegex": "test/.*\\.e2e-spec\\.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
+    "^.+\\.(t|j)s$": [
+      "ts-jest",
+      {
+        "tsconfig": {
+          "module": "commonjs",
+          "moduleResolution": "node",
+          "resolvePackageJsonExports": false,
+          "emitDecoratorMetadata": true,
+          "experimentalDecorators": true,
+          "esModuleInterop": true,
+          "allowSyntheticDefaultImports": true,
+          "target": "ES2022",
+          "strictNullChecks": true,
+          "skipLibCheck": true
+        }
+      }
+    ]
   },
+  "automock": false,
+  "modulePathIgnorePatterns": ["<rootDir>/src/__mocks__"],
+  "setupFiles": ["<rootDir>/node_modules/reflect-metadata/Reflect.js"],
   "moduleNameMapper": {
-    "^@engram/database$": "<rootDir>/../../../packages/database/src/index.ts",
-    "^@engram/redis$": "<rootDir>/../../../packages/redis/src/index.ts",
-    "^@engram/vector-store$": "<rootDir>/../../../packages/vector-store/src/index.ts",
-    "^@engram/config$": "<rootDir>/../../../packages/config/src/index.ts",
-    "^@engram/core$": "<rootDir>/../../../packages/core/src/index.ts",
-    "^@engram/memory-stm$": "<rootDir>/../../../packages/memory-stm/src/index.ts",
-    "^@engram/memory-ltm$": "<rootDir>/../../../packages/memory-ltm/src/index.ts",
-    "^(.*)\\.js$": "$1"
+    "^reflect-metadata$": "<rootDir>/node_modules/reflect-metadata/Reflect.js",
+    "^@engram/database$": "<rootDir>/../../packages/database/src/index.ts",
+    "^@engram/redis$": "<rootDir>/../../packages/redis/src/index.ts",
+    "^@engram/vector-store$": "<rootDir>/../../packages/vector-store/src/index.ts",
+    "^@engram/config$": "<rootDir>/../../packages/config/src/index.ts",
+    "^@engram/core$": "<rootDir>/../../packages/core/src/index.ts",
+    "^@engram/memory-stm$": "<rootDir>/../../packages/memory-stm/src/index.ts",
+    "^@engram/memory-ltm$": "<rootDir>/../../packages/memory-ltm/src/index.ts",
+    "^(\\..+)\\.js$": "$1"
   },
   "testTimeout": 30000
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,9 +21,9 @@ services:
       POSTGRES_USER: engram_test
       POSTGRES_PASSWORD: test_password
     ports:
-      - "5433:5432"
+      - '5433:5432'
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U engram_test -d engram_test"]
+      test: ['CMD-SHELL', 'pg_isready -U engram_test -d engram_test']
       interval: 5s
       timeout: 3s
       retries: 10
@@ -34,9 +34,9 @@ services:
     image: redis:7-alpine
     container_name: engram-redis-test
     ports:
-      - "6380:6379"
+      - '6380:6379'
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
       timeout: 3s
       retries: 10
@@ -44,16 +44,16 @@ services:
       - engram-test-network
 
   qdrant-test:
-    image: qdrant/qdrant:v1.7.0
+    image: qdrant/qdrant:v1.14.1
     container_name: engram-qdrant-test
     ports:
-      - "6335:6333"
-      - "6336:6334"
+      - '6335:6333'
+      - '6336:6334'
     environment:
       QDRANT__SERVICE__HTTP_PORT: 6333
       QDRANT__SERVICE__GRPC_PORT: 6334
     healthcheck:
-      test: ["CMD-SHELL", "timeout 5 bash -c '</dev/tcp/localhost/6333' || exit 1"]
+      test: ['CMD-SHELL', "timeout 5 bash -c '</dev/tcp/localhost/6333' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary

Fixes two blocking issues that prevented the E2E test suite from running.

### Fix 1: `moduleNameMapper` too greedy for bare package names

The `^(.*)\\.js$` → `$1` pattern stripped `.js` from bare package names like `ipaddr.js` (an Express/NestJS transitive dependency), causing Jest to fail to resolve it. Changed to `^(\\..+)\\.js$` which only strips `.js` from relative paths (starting with `.`).

### Fix 2: `src/__mocks__/@engram/redis.ts` auto-loaded as Jest manual mock

Jest was automatically applying `src/__mocks__/@engram/redis.ts` as a manual mock for the `@engram/redis` node module. The mock is an undecorated stub (`export class RedisModule {}`), so NestJS DI failed to resolve `RedisService`. Fixed with `automock: false` + `modulePathIgnorePatterns: ["<rootDir>/src/__mocks__"]`.

### Fix 3: Qdrant image version

Bumped `docker-compose.test.yml` Qdrant image from `v1.7.0` to `v1.14.1` to match `@qdrant/js-client-rest@1.15.1`.

## Test Results

```
Test Suites: 2 passed, 2 total
Tests:       3 passed, 3 total (E2E)

Test Suites: 10 passed, 10 total
Tests:       97 passed, 97 total (unit)
```

Closes #73 E2E pre-work.