### PR TITLE
test: expand unit test coverage across memory and Redis packages

### DIFF
--- a/apps/mcp-server/src/memory/memory.controller.spec.ts
+++ b/apps/mcp-server/src/memory/memory.controller.spec.ts
@@ -8,6 +8,7 @@ describe('MemoryController', () => {
   let memoryService: MemoryService;
 
   const mockMemoryService = {
+    createMemory: jest.fn(),
     createStm: jest.fn(),
     createLtm: jest.fn(),
     getMemory: jest.fn(),
@@ -328,6 +329,312 @@ describe('MemoryController', () => {
       expect(mockReindexQueueService.retry).toHaveBeenCalledWith(
         '2ec89f7a-6e83-48f0-901d-b9fbd58fa8e1',
       );
+    });
+  });
+
+  describe('createMemory', () => {
+    const userId = 'clm0000000000000000000000';
+    const memoryId = 'clm1111111111111111111111';
+
+    it('creates a short-term memory and returns its id in the response', async () => {
+      mockMemoryService.createMemory.mockResolvedValue({
+        id: memoryId,
+        type: 'short-term',
+        content: 'hello world',
+      });
+
+      const response = await controller.createMemory({
+        userId,
+        content: 'hello world',
+        type: 'short-term',
+        ttl: 300,
+      });
+
+      expect(mockMemoryService.createMemory).toHaveBeenCalledWith({
+        userId,
+        content: 'hello world',
+        type: 'short-term',
+        metadata: undefined,
+        tags: [],
+        ttl: 300,
+      });
+      expect(response.content[0]?.text).toContain(memoryId);
+      expect(response.content[0]?.text).toContain('short-term');
+    });
+
+    it('creates a long-term memory', async () => {
+      mockMemoryService.createMemory.mockResolvedValue({
+        id: memoryId,
+        type: 'long-term',
+      });
+
+      const response = await controller.createMemory({
+        userId,
+        content: 'important note',
+        type: 'long-term',
+      });
+
+      expect(response.content[0]?.text).toContain('long-term');
+    });
+
+    it('rejects missing required content field', async () => {
+      await expect(
+        controller.createMemory({ userId, type: 'short-term' }),
+      ).rejects.toThrow(/Failed to create memory/);
+    });
+
+    it('rejects content that exceeds the 10KB limit', async () => {
+      await expect(
+        controller.createMemory({
+          userId,
+          content: 'x'.repeat(10241),
+          type: 'long-term',
+        }),
+      ).rejects.toThrow(/Failed to create memory/);
+    });
+
+    it('wraps service errors', async () => {
+      mockMemoryService.createMemory.mockRejectedValue(
+        new Error('quota exceeded'),
+      );
+
+      await expect(
+        controller.createMemory({
+          userId,
+          content: 'hello',
+          type: 'long-term',
+        }),
+      ).rejects.toThrow(/Failed to create memory: quota exceeded/);
+    });
+  });
+
+  describe('getMemory', () => {
+    const userId = 'clm0000000000000000000000';
+    const memoryId = 'clm1111111111111111111111';
+
+    it('returns the serialised memory when found', async () => {
+      const memory = {
+        id: memoryId,
+        userId,
+        content: 'hello',
+        type: 'long-term',
+      };
+      mockMemoryService.getMemory.mockResolvedValue(memory);
+
+      const response = await controller.getMemory({ userId, memoryId });
+
+      const payload = parseResponsePayload<{ id: string; content: string }>(
+        response,
+      );
+      expect(payload.id).toBe(memoryId);
+      expect(payload.content).toBe('hello');
+      expect(mockMemoryService.getMemory).toHaveBeenCalledWith(
+        userId,
+        memoryId,
+      );
+    });
+
+    it('returns a not-found message when memory is absent', async () => {
+      mockMemoryService.getMemory.mockResolvedValue(null);
+
+      const response = await controller.getMemory({ userId, memoryId });
+
+      expect(response.content[0]?.text).toContain('not found');
+    });
+
+    it('rejects invalid userId', async () => {
+      await expect(
+        controller.getMemory({ userId: 'not-a-cuid', memoryId }),
+      ).rejects.toThrow(/Failed to get memory/);
+    });
+  });
+
+  describe('listMemories', () => {
+    const userId = 'clm0000000000000000000000';
+
+    it('lists memories with default options', async () => {
+      mockMemoryService.listMemories.mockResolvedValue({
+        items: [{ id: 'clm1111111111111111111111', content: 'hello' }],
+        totalCount: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+
+      const response = await controller.listMemories({ userId });
+
+      expect(mockMemoryService.listMemories).toHaveBeenCalledWith(userId, {
+        limit: 20,
+        cursor: undefined,
+        tags: undefined,
+        search: undefined,
+      });
+
+      const payload = parseResponsePayload<{
+        memories: unknown[];
+        pagination: { totalCount: number; hasNextPage: boolean };
+      }>(response);
+      expect(payload.memories).toHaveLength(1);
+      expect(payload.pagination.totalCount).toBe(1);
+      expect(payload.pagination.hasNextPage).toBe(false);
+    });
+
+    it('passes filtering options through to the service', async () => {
+      mockMemoryService.listMemories.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+
+      await controller.listMemories({
+        userId,
+        limit: 5,
+        tags: ['work'],
+        search: 'meeting notes',
+      });
+
+      expect(mockMemoryService.listMemories).toHaveBeenCalledWith(userId, {
+        limit: 5,
+        cursor: undefined,
+        tags: ['work'],
+        search: 'meeting notes',
+      });
+    });
+
+    it('rejects invalid userId', async () => {
+      await expect(
+        controller.listMemories({ userId: 'not-a-cuid' }),
+      ).rejects.toThrow(/Failed to list memories/);
+    });
+  });
+
+  describe('updateMemory', () => {
+    const userId = 'clm0000000000000000000000';
+    const memoryId = 'clm1111111111111111111111';
+
+    it('updates memory and includes it in the response text', async () => {
+      const updated = { id: memoryId, userId, content: 'new content' };
+      mockMemoryService.updateMemory.mockResolvedValue(updated);
+
+      const response = await controller.updateMemory({
+        userId,
+        memoryId,
+        content: 'new content',
+      });
+
+      expect(mockMemoryService.updateMemory).toHaveBeenCalledWith(
+        userId,
+        memoryId,
+        {
+          content: 'new content',
+          metadata: undefined,
+          tags: undefined,
+          ttl: undefined,
+        },
+      );
+      expect(response.content[0]?.text).toContain(memoryId);
+    });
+
+    it('rejects invalid memoryId', async () => {
+      await expect(
+        controller.updateMemory({ userId, memoryId: 'not-a-cuid' }),
+      ).rejects.toThrow(/Failed to update memory/);
+    });
+
+    it('wraps service errors', async () => {
+      mockMemoryService.updateMemory.mockRejectedValue(
+        new Error('memory not found'),
+      );
+
+      await expect(
+        controller.updateMemory({ userId, memoryId }),
+      ).rejects.toThrow(/Failed to update memory: memory not found/);
+    });
+  });
+
+  describe('deleteMemory', () => {
+    const userId = 'clm0000000000000000000000';
+    const memoryId = 'clm1111111111111111111111';
+
+    it('returns a success message when memory is deleted', async () => {
+      mockMemoryService.deleteMemory.mockResolvedValue(true);
+
+      const response = await controller.deleteMemory({ userId, memoryId });
+
+      expect(response.content[0]?.text).toContain('Successfully deleted');
+      expect(mockMemoryService.deleteMemory).toHaveBeenCalledWith(
+        userId,
+        memoryId,
+      );
+    });
+
+    it('returns a not-found message when nothing was deleted', async () => {
+      mockMemoryService.deleteMemory.mockResolvedValue(false);
+
+      const response = await controller.deleteMemory({ userId, memoryId });
+
+      expect(response.content[0]?.text).toContain('not found');
+    });
+
+    it('rejects invalid userId', async () => {
+      await expect(
+        controller.deleteMemory({ userId: 'not-a-cuid', memoryId }),
+      ).rejects.toThrow(/Failed to delete memory/);
+    });
+  });
+
+  describe('promoteMemory', () => {
+    const userId = 'clm0000000000000000000000';
+    const memoryId = 'clm1111111111111111111111';
+
+    it('promotes memory to long-term and returns confirmation', async () => {
+      const promoted = {
+        id: memoryId,
+        userId,
+        type: 'long-term',
+        content: 'hello',
+      };
+      mockMemoryService.promoteMemory.mockResolvedValue(promoted);
+
+      const response = await controller.promoteMemory({ userId, memoryId });
+
+      expect(mockMemoryService.promoteMemory).toHaveBeenCalledWith(
+        userId,
+        memoryId,
+      );
+      expect(response.content[0]?.text).toContain('Successfully promoted');
+      expect(response.content[0]?.text).toContain(memoryId);
+    });
+
+    it('rejects invalid input', async () => {
+      await expect(
+        controller.promoteMemory({ userId: 'not-a-cuid', memoryId }),
+      ).rejects.toThrow(/Failed to promote memory/);
+    });
+
+    it('wraps service errors', async () => {
+      mockMemoryService.promoteMemory.mockRejectedValue(
+        new Error('quota exceeded'),
+      );
+
+      await expect(
+        controller.promoteMemory({ userId, memoryId }),
+      ).rejects.toThrow(/Failed to promote memory: quota exceeded/);
+    });
+  });
+
+  describe('assertAdminAuthorized', () => {
+    it('throws when MCP_ADMIN_TOKEN env var is not configured', async () => {
+      const original = process.env.MCP_ADMIN_TOKEN;
+      delete process.env.MCP_ADMIN_TOKEN;
+
+      try {
+        await expect(
+          controller.reindexMemories({ adminToken: 'test-admin-token-12345' }),
+        ).rejects.toThrow(/MCP_ADMIN_TOKEN is not configured/);
+      } finally {
+        process.env.MCP_ADMIN_TOKEN = original;
+      }
     });
   });
 });

--- a/apps/mcp-server/src/memory/memory.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.service.spec.ts
@@ -163,6 +163,16 @@ describe('MemoryService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should rethrow non-StmMemoryNotFoundError from STM without calling LTM', async () => {
+      const redisError = new Error('Redis connection failed');
+      stmService.findById.mockRejectedValue(redisError);
+
+      await expect(service.getMemory('user-1', 'stm-123')).rejects.toThrow(
+        'Redis connection failed',
+      );
+      expect(ltmService.get).not.toHaveBeenCalled();
+    });
   });
 
   describe('listMemories', () => {
@@ -201,6 +211,114 @@ describe('MemoryService', () => {
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0]).toEqual(mockLtmMemory);
+    });
+
+    it('should sort combined results by createdAt descending', async () => {
+      const older = {
+        ...mockStmMemory,
+        id: 'older',
+        createdAt: new Date('2024-01-01'),
+      };
+      const newer = {
+        ...mockLtmMemory,
+        id: 'newer',
+        createdAt: new Date('2024-06-01'),
+      };
+
+      stmService.list.mockResolvedValue({
+        items: [older],
+        totalCount: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+      ltmService.list.mockResolvedValue({
+        items: [newer],
+        totalCount: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+
+      const result = await service.listMemories('user-1', { limit: 20 });
+
+      expect(result.items[0]?.id).toBe('newer');
+      expect(result.items[1]?.id).toBe('older');
+    });
+
+    it('should apply the limit after combining results from both stores', async () => {
+      const ltmItems = Array.from({ length: 5 }, (_, i) => ({
+        ...mockLtmMemory,
+        id: `ltm-${i}`,
+        createdAt: new Date(Date.now() - i * 1000),
+      }));
+
+      stmService.list.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+      ltmService.list.mockResolvedValue({
+        items: ltmItems,
+        totalCount: 5,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+
+      const result = await service.listMemories('user-1', { limit: 3 });
+
+      expect(result.items).toHaveLength(3);
+      expect(result.hasNextPage).toBe(true);
+    });
+
+    it('should set startCursor and endCursor from paginated items', async () => {
+      const first = {
+        ...mockLtmMemory,
+        id: 'first-id',
+        createdAt: new Date('2024-06-01'),
+      };
+      const last = {
+        ...mockLtmMemory,
+        id: 'last-id',
+        createdAt: new Date('2024-01-01'),
+      };
+
+      stmService.list.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+      ltmService.list.mockResolvedValue({
+        items: [first, last],
+        totalCount: 2,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+
+      const result = await service.listMemories('user-1');
+
+      expect(result.startCursor).toBe('first-id');
+      expect(result.endCursor).toBe('last-id');
+    });
+
+    it('should return empty cursors when no items are returned', async () => {
+      stmService.list.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+      ltmService.list.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+
+      const result = await service.listMemories('user-1');
+
+      expect(result.startCursor).toBeUndefined();
+      expect(result.endCursor).toBeUndefined();
     });
   });
 
@@ -259,6 +377,16 @@ describe('MemoryService', () => {
         }),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('should rethrow non-StmMemoryNotFoundError from STM without calling LTM', async () => {
+      const redisError = new Error('Redis connection failed');
+      stmService.findById.mockRejectedValue(redisError);
+
+      await expect(
+        service.updateMemory('user-1', 'stm-123', { content: 'new' }),
+      ).rejects.toThrow('Redis connection failed');
+      expect(ltmService.get).not.toHaveBeenCalled();
+    });
   });
 
   describe('deleteMemory', () => {
@@ -293,6 +421,39 @@ describe('MemoryService', () => {
       const result = await service.deleteMemory('user-1', 'not-found');
 
       expect(result).toBe(false);
+    });
+
+    it('should delete from both stores when memory exists in both', async () => {
+      stmService.delete.mockResolvedValue(undefined);
+      ltmService.delete.mockResolvedValue(true);
+
+      const result = await service.deleteMemory('user-1', 'dual-store-id');
+
+      expect(stmService.delete).toHaveBeenCalledWith('user-1', 'dual-store-id');
+      expect(ltmService.delete).toHaveBeenCalledWith('user-1', 'dual-store-id');
+      expect(result).toBe(true);
+    });
+
+    it('should rethrow non-StmMemoryNotFoundError from STM without calling LTM', async () => {
+      const redisError = new Error('Redis connection failed');
+      stmService.delete.mockRejectedValue(redisError);
+
+      await expect(service.deleteMemory('user-1', 'stm-123')).rejects.toThrow(
+        'Redis connection failed',
+      );
+      expect(ltmService.delete).not.toHaveBeenCalled();
+    });
+
+    it('should rethrow non-LtmMemoryNotFoundError from LTM', async () => {
+      stmService.delete.mockRejectedValue(
+        new StmMemoryNotFoundError('ltm-456'),
+      );
+      const dbError = new Error('Database connection failed');
+      ltmService.delete.mockRejectedValue(dbError);
+
+      await expect(service.deleteMemory('user-1', 'ltm-456')).rejects.toThrow(
+        'Database connection failed',
+      );
     });
   });
 
@@ -354,7 +515,7 @@ describe('MemoryService', () => {
         cursor: null,
       };
 
-      (ltmService.reindex as any).mockResolvedValue(summary);
+      ltmService.reindex.mockResolvedValue(summary);
 
       const result = await service.reindex({ userId: 'user-1', batchSize: 50 });
 
@@ -374,7 +535,7 @@ describe('MemoryService', () => {
         cursor: null,
       };
 
-      (ltmService.reindex as any).mockResolvedValue(summary);
+      ltmService.reindex.mockResolvedValue(summary);
 
       const result = await service.reindex();
 

--- a/apps/mcp-server/src/memory/reindex-queue.service.spec.ts
+++ b/apps/mcp-server/src/memory/reindex-queue.service.spec.ts
@@ -92,6 +92,130 @@ describe('ReindexQueueService', () => {
     expect(cancelled?.events.at(-1)?.type).toBe('job_cancelled');
   });
 
+  it('returns null when getting a non-existent job', async () => {
+    redis.get.mockResolvedValue(null);
+
+    const result = await service.get('non-existent-job');
+
+    expect(result).toBeNull();
+  });
+
+  it('flags a running job for cancellation without terminating it immediately', async () => {
+    const runningJob: ReindexJobStatus = {
+      jobId: 'job-running',
+      state: 'running',
+      createdAt: new Date().toISOString(),
+      startedAt: new Date().toISOString(),
+      cancelRequested: false,
+      events: [],
+      options: { batchSize: 10 },
+      summary: {
+        processed: 2,
+        indexed: 2,
+        skipped: 0,
+        failed: 0,
+        cursor: 'c-2',
+      },
+    };
+    redis.get.mockResolvedValue(JSON.stringify(runningJob));
+    redis.set.mockResolvedValue(undefined);
+
+    const result = await service.cancel('job-running');
+
+    expect(result?.cancelRequested).toBe(true);
+    expect(result?.state).toBe('running');
+    expect(result?.events.at(-1)?.type).toBe('cancellation_requested');
+  });
+
+  it('returns the job as-is when cancelling an already-completed job', async () => {
+    const completedJob: ReindexJobStatus = {
+      jobId: 'job-done',
+      state: 'completed',
+      createdAt: new Date().toISOString(),
+      events: [],
+      options: {},
+      summary: {
+        processed: 5,
+        indexed: 5,
+        skipped: 0,
+        failed: 0,
+        cursor: null,
+      },
+    };
+    redis.get.mockResolvedValue(JSON.stringify(completedJob));
+
+    const result = await service.cancel('job-done');
+
+    expect(result?.state).toBe('completed');
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it('returns the job as-is when retrying a job that is not failed or cancelled', async () => {
+    const runningJob: ReindexJobStatus = {
+      jobId: 'job-running',
+      state: 'running',
+      createdAt: new Date().toISOString(),
+      events: [],
+      options: {},
+      summary: {
+        processed: 0,
+        indexed: 0,
+        skipped: 0,
+        failed: 0,
+        cursor: null,
+      },
+    };
+    redis.get.mockResolvedValue(JSON.stringify(runningJob));
+
+    const result = await service.retry('job-running');
+
+    expect(result?.state).toBe('running');
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it('marks job as failed when reindex throws a runtime error', async () => {
+    memoryService.reindex.mockRejectedValue(
+      new Error('embedding service unavailable'),
+    );
+
+    let latest: ReindexJobStatus | null = null;
+    redis.set.mockImplementation((_key, value) => {
+      latest = JSON.parse(value) as ReindexJobStatus;
+      return Promise.resolve();
+    });
+    redis.get.mockImplementation(() => {
+      return Promise.resolve(latest ? JSON.stringify(latest) : null);
+    });
+
+    await service.enqueue({ batchSize: 10 });
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(latest?.state).toBe('failed');
+    expect(latest?.terminalReason).toBe('failed_runtime');
+    expect(latest?.error).toContain('embedding service unavailable');
+    expect(latest?.events.at(-1)?.type).toBe('job_failed');
+  });
+
+  it('skips processing if job was cancelled before the worker starts', async () => {
+    let latest: ReindexJobStatus | null = null;
+    redis.set.mockImplementation((_key, value) => {
+      latest = JSON.parse(value) as ReindexJobStatus;
+      return Promise.resolve();
+    });
+    redis.get.mockImplementation(() => {
+      return Promise.resolve(latest ? JSON.stringify(latest) : null);
+    });
+
+    const job = await service.enqueue({ batchSize: 10 });
+    await service.cancel(job.jobId);
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(latest?.state).toBe('cancelled');
+    expect(memoryService.reindex).not.toHaveBeenCalled();
+  });
+
   it('retries failed jobs from their cursor', async () => {
     const jobs = new Map<string, ReindexJobStatus>();
     redis.set.mockImplementation((key, value) => {

--- a/packages/redis/src/redis.service.spec.ts
+++ b/packages/redis/src/redis.service.spec.ts
@@ -17,6 +17,7 @@ const mockRedisClient = {
   ping: vi.fn(),
   connect: vi.fn(),
   disconnect: vi.fn(),
+  scan: vi.fn(),
   status: 'ready',
 } as unknown as Redis;
 
@@ -357,6 +358,84 @@ describe('RedisService', () => {
       mockRedisClient.disconnect = vi.fn().mockRejectedValue(error);
 
       await expect(service.disconnect()).rejects.toThrow('Disconnect failed');
+    });
+  });
+
+  describe('delMany', () => {
+    it('should return 0 without calling Redis when given an empty array', async () => {
+      const result = await service.delMany([]);
+
+      expect(mockRedisClient.del).not.toHaveBeenCalled();
+      expect(result).toBe(0);
+    });
+
+    it('should delete multiple keys and return the count', async () => {
+      mockRedisClient.del = vi.fn().mockResolvedValue(2);
+
+      const result = await service.delMany(['key-a', 'key-b']);
+
+      expect(mockRedisClient.del).toHaveBeenCalledWith('key-a', 'key-b');
+      expect(result).toBe(2);
+    });
+
+    it('should throw error when Redis operation fails', async () => {
+      const error = new Error('Redis connection failed');
+      mockRedisClient.del = vi.fn().mockRejectedValue(error);
+
+      await expect(service.delMany(['key-a'])).rejects.toThrow('Redis connection failed');
+    });
+  });
+
+  describe('scan', () => {
+    it('should call scan with match and count options', async () => {
+      mockRedisClient.scan = vi.fn().mockResolvedValue(['0', ['key-1', 'key-2']]);
+
+      const result = await service.scan('0', { match: 'user:*', count: 100 });
+
+      expect(mockRedisClient.scan).toHaveBeenCalledWith('0', 'MATCH', 'user:*', 'COUNT', 100);
+      expect(result.cursor).toBe('0');
+      expect(result.keys).toEqual(['key-1', 'key-2']);
+    });
+
+    it('should call scan with match option only', async () => {
+      mockRedisClient.scan = vi.fn().mockResolvedValue(['42', ['key-1']]);
+
+      const result = await service.scan('0', { match: 'memory:*' });
+
+      expect(mockRedisClient.scan).toHaveBeenCalledWith('0', 'MATCH', 'memory:*');
+      expect(result.cursor).toBe('42');
+    });
+
+    it('should call scan with count option only', async () => {
+      mockRedisClient.scan = vi.fn().mockResolvedValue(['0', []]);
+
+      await service.scan('0', { count: 50 });
+
+      expect(mockRedisClient.scan).toHaveBeenCalledWith('0', 'COUNT', 50);
+    });
+
+    it('should call plain scan when no options are given', async () => {
+      mockRedisClient.scan = vi.fn().mockResolvedValue(['0', []]);
+
+      await service.scan('0');
+
+      expect(mockRedisClient.scan).toHaveBeenCalledWith('0');
+    });
+
+    it('should return cursor and keys from Redis response', async () => {
+      mockRedisClient.scan = vi.fn().mockResolvedValue(['next-cursor', ['k1', 'k2', 'k3']]);
+
+      const result = await service.scan('0', { match: '*' });
+
+      expect(result.cursor).toBe('next-cursor');
+      expect(result.keys).toHaveLength(3);
+    });
+
+    it('should throw error when Redis operation fails', async () => {
+      const error = new Error('Redis connection failed');
+      mockRedisClient.scan = vi.fn().mockRejectedValue(error);
+
+      await expect(service.scan('0', { match: '*' })).rejects.toThrow('Redis connection failed');
     });
   });
 });


### PR DESCRIPTION
Add tests for six untested MCP tools, error re-throw paths,
listMemories edge cases, job lifecycle branches, and Redis
scan/delMany. Fix two pre-existing no-explicit-any violations.

https://claude.ai/code/session_01YXsXFy8jFhL9gZ82Kr1hJs