### PR TITLE
docs(agents): move token efficiency section to top of AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,14 @@ title: ENGRAM Agent Instructions
 description: Simple project rules for agents and contributors working in ENGRAM
 ---
 
+## Token Efficiency
+
+IMPORTANT: Always prioritize token efficiency in your responses and explanations.
+
+- Always use the `caveman` skill for shorter responses, lower token usage, and condensed explanations.
+- Trigger phrases include: "caveman mode", "talk like caveman", "less tokens", "be brief", "save tokens", and "condense".
+- Keep technical accuracy intact while reducing verbosity.
+
 ## Project Summary
 
 ENGRAM is a TypeScript monorepo for an MCP memory server. The main app is a
@@ -18,14 +26,6 @@ Start with [README.md](README.md) for setup commands.
 4. Use strict TypeScript. Do not add `any` unless there is no safer option.
 5. Add or update tests when behavior changes.
 6. Do not commit generated secrets, local `.env` files, or credentials.
-
-## Token Efficiency
-
-IMPORTANT: Always prioritize token efficiency in your responses and explanations.
-
-- Always use the `caveman` skill for shorter responses, lower token usage, and condensed explanations.
-- Trigger phrases include: "caveman mode", "talk like caveman", "less tokens", "be brief", "save tokens", and "condense".
-- Keep technical accuracy intact while reducing verbosity.
 
 ## Project Layout
 


### PR DESCRIPTION
Moves the Token Efficiency section from the middle of AGENTS.md to the top so agents read it before any other instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)