### PR TITLE
docs(tools): document recall tool and add E2E recall test

### DIFF
--- a/apps/mcp-server/test/memory-system.e2e-spec.ts
+++ b/apps/mcp-server/test/memory-system.e2e-spec.ts
@@ -37,6 +37,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Server } from 'node:http';
 import request from 'supertest';
+import { PrismaService } from '@engram/database';
 import { AppModule } from '../src/app.module';
 import { MemoryService } from '../src/memory/memory.service';
 
@@ -56,6 +57,7 @@ suite('Memory System E2E', () => {
   let app: INestApplication;
   let httpServer: Server;
   let memoryService: MemoryService;
+  let prismaService: PrismaService;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -66,6 +68,7 @@ suite('Memory System E2E', () => {
     await app.init();
     httpServer = app.getHttpServer() as Server;
     memoryService = moduleFixture.get(MemoryService);
+    prismaService = moduleFixture.get(PrismaService);
   });
 
   afterAll(async () => {
@@ -98,20 +101,22 @@ suite('Memory System E2E', () => {
   // identical vectors, so the stored memory is the top result with score ≈ 1.0.
   // -------------------------------------------------------------------------
   describe('Recall (semantic search)', () => {
-    // Use a unique user ID per test run to avoid cross-test contamination.
-    const testUserId = `test-recall-${Date.now()}`;
+    let testUserId: string;
     const testContent =
       'Embeddings represent text as dense vectors in high-dimensional space.';
 
+    beforeAll(async () => {
+      // Create a real users row so memories.userId satisfies the FK constraint.
+      const user = await prismaService.user.create({
+        data: { email: `test-recall-${Date.now()}@e2e.local` },
+      });
+      testUserId = user.id;
+    });
+
     afterAll(async () => {
-      // Best-effort cleanup: clear all LTM memories created for the test user.
+      // Deleting the user cascades to its memories (onDelete: Cascade).
       try {
-        const result = await memoryService.listMemories(testUserId, {
-          limit: 100,
-        });
-        await Promise.all(
-          result.items.map((m) => memoryService.deleteMemory(testUserId, m.id)),
-        );
+        await prismaService.user.delete({ where: { id: testUserId } });
       } catch {
         // Non-fatal — test isolation via unique userId is sufficient.
       }

--- a/apps/mcp-server/test/memory-system.e2e-spec.ts
+++ b/apps/mcp-server/test/memory-system.e2e-spec.ts
@@ -28,12 +28,17 @@ process.env.DATABASE_URL =
   'postgresql://engram_test:test_password@localhost:5433/engram_test';
 process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6380';
 process.env.QDRANT_URL = process.env.QDRANT_URL ?? 'http://localhost:6335';
+// Use the deterministic local hash provider so E2E recall tests do not require
+// an OpenAI API key. The provider produces a stable 1536-dim vector for any
+// given text, guaranteeing a cosine score of 1.0 when query === stored content.
+process.env.EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER ?? 'local';
 
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Server } from 'node:http';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
+import { MemoryService } from '../src/memory/memory.service';
 
 // ---------------------------------------------------------------------------
 // Suite guard — skip gracefully when test infra is not available
@@ -50,6 +55,7 @@ const suite: (name: string, fn: () => void) => void = E2E_ENABLED
 suite('Memory System E2E', () => {
   let app: INestApplication;
   let httpServer: Server;
+  let memoryService: MemoryService;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -59,6 +65,7 @@ suite('Memory System E2E', () => {
     app = moduleFixture.createNestApplication();
     await app.init();
     httpServer = app.getHttpServer() as Server;
+    memoryService = moduleFixture.get(MemoryService);
   });
 
   afterAll(async () => {
@@ -80,6 +87,78 @@ suite('Memory System E2E', () => {
           expect([200, 503]).toContain(res.status);
           expect(res.body).toHaveProperty('status');
         });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Semantic recall — remember → recall round-trip
+  //
+  // Uses EMBEDDING_PROVIDER=local so the test is self-contained (no OpenAI key
+  // required). The local provider is deterministic: identical text produces
+  // identical vectors, so the stored memory is the top result with score ≈ 1.0.
+  // -------------------------------------------------------------------------
+  describe('Recall (semantic search)', () => {
+    // Use a unique user ID per test run to avoid cross-test contamination.
+    const testUserId = `test-recall-${Date.now()}`;
+    const testContent =
+      'Embeddings represent text as dense vectors in high-dimensional space.';
+
+    afterAll(async () => {
+      // Best-effort cleanup: clear all LTM memories created for the test user.
+      try {
+        const result = await memoryService.listMemories(testUserId, {
+          limit: 100,
+        });
+        await Promise.all(
+          result.items.map((m) => memoryService.deleteMemory(testUserId, m.id)),
+        );
+      } catch {
+        // Non-fatal — test isolation via unique userId is sufficient.
+      }
+    });
+
+    it('returns the stored memory as the top recall result', async () => {
+      // Store a long-term memory.
+      await memoryService.createMemory({
+        userId: testUserId,
+        content: testContent,
+        type: 'long-term',
+        tags: ['ml', 'embeddings'],
+      });
+
+      // Recall using the same content as the query. With the local embedding
+      // provider the vectors are identical, so score should be very close to 1.
+      const results = await memoryService.recall(testUserId, testContent, {
+        limit: 5,
+      });
+
+      expect(results.length).toBeGreaterThan(0);
+      const top = results[0]!;
+      expect(top.memory.content).toBe(testContent);
+      expect(top.memory.userId).toBe(testUserId);
+      expect(top.score).toBeGreaterThan(0.9);
+    });
+
+    it('returns an empty array for a user with no memories', async () => {
+      const results = await memoryService.recall(
+        'no-memories-user-xyz',
+        'anything',
+        { limit: 5 },
+      );
+      expect(results).toEqual([]);
+    });
+
+    it('scopes results to the requesting user', async () => {
+      // A different user should not see test user's memories.
+      const results = await memoryService.recall(
+        'other-user-xyz',
+        testContent,
+        {
+          limit: 5,
+        },
+      );
+      const leaked = results.filter((r) => r.memory.userId === testUserId);
+      expect(leaked).toHaveLength(0);
     });
   });
 });

--- a/packages/core/src/mcp/tools/README.md
+++ b/packages/core/src/mcp/tools/README.md
@@ -55,11 +55,11 @@ and returns ranked long-term memories with similarity scores.
 
 | Field  | Type            | Required | Default | Description                                       |
 | ------ | --------------- | -------- | ------- | ------------------------------------------------- |
-| userId | string (cuid)   | yes      |         | Tenant identifier — search is scoped to this user |
+| userId | string (cuid/cuid2) | yes      |         | Tenant identifier — search is scoped to this user |
 | query  | string (1–2048) | yes      |         | Natural-language query to embed and search        |
 | limit  | integer (1–50)  | no       | 10      | Maximum number of results to return               |
 | scope  | string (≤256)   | no       |         | Optional namespace filter (agent/session/project) |
-| tags   | string[] (≤50)  | no       |         | Restrict results to memories carrying all tags    |
+| tags   | string[] (≤50)  | no       |         | Filter by tags — pgvector requires all tags present (AND); Qdrant matches any tag (OR) |
 
 **Example response**
 

--- a/packages/core/src/mcp/tools/README.md
+++ b/packages/core/src/mcp/tools/README.md
@@ -10,6 +10,8 @@ server. Each tool has a name, description, Zod input schema, and async handler.
 
 ## Available Tools
 
+### Built-in (core package)
+
 | Tool   | Purpose                                |
 | ------ | -------------------------------------- |
 | `ping` | Test connectivity to the ENGRAM server |
@@ -22,6 +24,67 @@ server. Each tool has a name, description, Zod input schema, and async handler.
   "timestamp": "2025-10-03T09:30:00.000Z"
 }
 ```
+
+### Memory tools (mcp-server app)
+
+Memory tools are registered by the `mcp-server` app via `registerAdditionalTools`. See
+[`apps/mcp-server/src/memory/memory.controller.ts`](../../../../../apps/mcp-server/src/memory/memory.controller.ts)
+for the full handler implementations.
+
+| Tool                     | Purpose                                                        |
+| ------------------------ | -------------------------------------------------------------- |
+| `create_memory`          | Create a short-term or long-term memory                        |
+| `get_memory`             | Retrieve a memory by ID                                        |
+| `list_memories`          | List memories with pagination, tag, and text-search filters    |
+| `update_memory`          | Update content, metadata, or tags on an existing memory        |
+| `delete_memory`          | Delete a memory by ID                                          |
+| `promote_memory`         | Promote a short-term memory to long-term storage               |
+| `recall`                 | Semantic recall — find relevant long-term memories for a query |
+| `reindex_memories`       | Rebuild the vector store from Postgres (admin/maintenance)     |
+| `queue_reindex_memories` | Queue an asynchronous reindex job                              |
+| `get_reindex_status`     | Poll a queued reindex job's progress by job ID                 |
+| `cancel_reindex_job`     | Cancel a queued or running reindex job                         |
+| `retry_reindex_job`      | Retry a failed or cancelled reindex job from its last cursor   |
+
+#### `recall` — semantic search
+
+Embeds a natural-language query, runs a kNN search over the tenant-scoped vector index,
+and returns ranked long-term memories with similarity scores.
+
+**Input schema**
+
+| Field  | Type            | Required | Default | Description                                       |
+| ------ | --------------- | -------- | ------- | ------------------------------------------------- |
+| userId | string (cuid)   | yes      |         | Tenant identifier — search is scoped to this user |
+| query  | string (1–2048) | yes      |         | Natural-language query to embed and search        |
+| limit  | integer (1–50)  | no       | 10      | Maximum number of results to return               |
+| scope  | string (≤256)   | no       |         | Optional namespace filter (agent/session/project) |
+| tags   | string[] (≤50)  | no       |         | Restrict results to memories carrying all tags    |
+
+**Example response**
+
+```json
+{
+  "query": "what did I learn about embeddings?",
+  "count": 2,
+  "results": [
+    {
+      "score": 0.94,
+      "memory": {
+        "id": "clm...",
+        "userId": "clm...",
+        "content": "Embeddings represent text as dense vectors ...",
+        "tags": ["ml", "embeddings"],
+        "type": "long-term",
+        "createdAt": "2026-06-01T10:00:00.000Z"
+      }
+    }
+  ]
+}
+```
+
+Returns an empty `results` array when the vector store is not configured, the embeddings
+service is unavailable, or no memories match the query.
 
 ## Tool Shape
 


### PR DESCRIPTION
## Summary

- Updated `packages/core/src/mcp/tools/README.md` to list all 12 memory tools registered by the app, with a detailed schema and response example for the `recall` tool
- Added E2E smoke tests for the semantic recall round-trip (remember → recall) in `memory-system.e2e-spec.ts`, using `EMBEDDING_PROVIDER=local` so the tests are self-contained (no OpenAI key needed)
- The local embedding provider is deterministic (SHA-256 hash), so a recall query matching stored content returns a score >= 0.9; tenant isolation is also verified

The kNN search implementation in both Qdrant and pgvector backends, `MemoryLtmService.semanticSearch()`, `MemoryService.recall()`, and the `recall` MCP tool registration were already in place and fully tested.

Closes #108
Closes #109

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — all 18 tasks pass
- [x] `pnpm docs:check` — passes
- [ ] E2E: `E2E_ENABLED=true pnpm --filter mcp-server test:e2e` (requires docker infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)