### PR TITLE
feat(search): add time-range filters to recall tool (#110)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(git fetch *)",
       "Bash(gh run *)",
       "Bash(git checkout *)",
-      "Bash(git pull *)"
+      "Bash(git pull *)",
+      "Bash(gh issue *)"
     ],
     "deny": [],
     "ask": []

--- a/apps/mcp-server/src/memory/dto/recall.dto.ts
+++ b/apps/mcp-server/src/memory/dto/recall.dto.ts
@@ -6,15 +6,26 @@ import { z } from 'zod';
  *
  * Performs semantic (vector) recall over a user's long-term memories.
  */
-export const recallToolSchema = z.object({
-  userId: userIdSchema,
-  query: z
-    .string()
-    .min(1, 'Query cannot be empty')
-    .max(2048, 'Query cannot exceed 2048 characters'),
-  limit: z.number().int().min(1).max(50).optional().default(10),
-  scope: z.string().max(256).optional(),
-  tags: z.array(z.string()).max(50).optional(),
-});
+export const recallToolSchema = z
+  .object({
+    userId: userIdSchema,
+    query: z
+      .string()
+      .min(1, 'Query cannot be empty')
+      .max(2048, 'Query cannot exceed 2048 characters'),
+    limit: z.number().int().min(1).max(50).optional().default(10),
+    scope: z.string().max(256).optional(),
+    tags: z.array(z.string()).max(50).optional(),
+    createdFrom: z.coerce.date().optional(),
+    createdTo: z.coerce.date().optional(),
+  })
+  .refine(
+    (val) =>
+      !val.createdFrom || !val.createdTo || val.createdFrom <= val.createdTo,
+    {
+      message: 'createdFrom must be before or equal to createdTo',
+      path: ['createdFrom'],
+    },
+  );
 
 export type RecallToolInput = z.infer<typeof recallToolSchema>;

--- a/apps/mcp-server/src/memory/memory.controller.spec.ts
+++ b/apps/mcp-server/src/memory/memory.controller.spec.ts
@@ -177,7 +177,7 @@ describe('MemoryController', () => {
           createdFrom: '2025-06-01T00:00:00Z',
           createdTo: '2025-01-01T00:00:00Z',
         }),
-      ).rejects.toThrow(/Failed to recall memories/);
+      ).rejects.toThrow(/createdFrom must be before or equal to createdTo/);
     });
 
     it('should reject invalid input', async () => {

--- a/apps/mcp-server/src/memory/memory.controller.spec.ts
+++ b/apps/mcp-server/src/memory/memory.controller.spec.ts
@@ -132,6 +132,8 @@ describe('MemoryController', () => {
         limit: 5,
         scope: 'project-a',
         tags: ['greeting'],
+        createdFrom: undefined,
+        createdTo: undefined,
       });
 
       const payload = parseResponsePayload<{
@@ -143,6 +145,39 @@ describe('MemoryController', () => {
       expect(payload.count).toBe(1);
       expect(payload.results[0]!.score).toBe(0.92);
       expect(payload.results[0]!.memory.id).toBe('ltm-1');
+    });
+
+    it('should pass date-range filters to the service', async () => {
+      const userId = 'clm0000000000000000000000';
+      mockMemoryService.recall.mockResolvedValue([]);
+
+      await controller.recall({
+        userId,
+        query: 'recent notes',
+        createdFrom: '2025-01-01T00:00:00Z',
+        createdTo: '2025-06-01T00:00:00Z',
+      });
+
+      expect(mockMemoryService.recall).toHaveBeenCalledWith(
+        userId,
+        'recent notes',
+        expect.objectContaining({
+          createdFrom: new Date('2025-01-01T00:00:00Z'),
+          createdTo: new Date('2025-06-01T00:00:00Z'),
+        }),
+      );
+    });
+
+    it('should reject when createdFrom is after createdTo', async () => {
+      const userId = 'clm0000000000000000000000';
+      await expect(
+        controller.recall({
+          userId,
+          query: 'notes',
+          createdFrom: '2025-06-01T00:00:00Z',
+          createdTo: '2025-01-01T00:00:00Z',
+        }),
+      ).rejects.toThrow(/Failed to recall memories/);
     });
 
     it('should reject invalid input', async () => {

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -353,6 +353,8 @@ export class MemoryController {
           limit: validatedInput.limit,
           scope: validatedInput.scope,
           tags: validatedInput.tags,
+          createdFrom: validatedInput.createdFrom,
+          createdTo: validatedInput.createdTo,
         },
       );
 

--- a/apps/mcp-server/src/memory/memory.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.service.spec.ts
@@ -500,7 +500,23 @@ describe('MemoryService', () => {
           limit: undefined,
           scope: undefined,
           tags: undefined,
+          createdFrom: undefined,
+          createdTo: undefined,
         },
+      );
+    });
+
+    it('should forward date-range filters to the LTM service', async () => {
+      const createdFrom = new Date('2025-01-01T00:00:00Z');
+      const createdTo = new Date('2025-06-01T00:00:00Z');
+      ltmService.semanticSearch.mockResolvedValue([]);
+
+      await service.recall('user-1', 'query', { createdFrom, createdTo });
+
+      expect(ltmService.semanticSearch).toHaveBeenCalledWith(
+        'user-1',
+        'query',
+        expect.objectContaining({ createdFrom, createdTo }),
       );
     });
   });

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -69,7 +69,13 @@ type LtmServiceContract = {
   semanticSearch: (
     userId: string,
     query: string,
-    options?: { limit?: number; scope?: string; tags?: string[] },
+    options?: {
+      limit?: number;
+      scope?: string;
+      tags?: string[];
+      createdFrom?: Date;
+      createdTo?: Date;
+    },
   ) => Promise<Array<{ memory: Memory; score: number }>>;
   reindex: (options?: {
     userId?: string;
@@ -123,6 +129,8 @@ export interface RecallOptions {
   limit?: number;
   scope?: string;
   tags?: string[];
+  createdFrom?: Date;
+  createdTo?: Date;
 }
 
 export interface RecallResult {
@@ -373,6 +381,8 @@ export class MemoryService {
       limit: options.limit,
       scope: options.scope,
       tags: options.tags,
+      createdFrom: options.createdFrom,
+      createdTo: options.createdTo,
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds `createdFrom` / `createdTo` optional fields to the `recall` MCP tool input schema
- ISO-8601 strings are coerced to `Date` via `z.coerce.date()`; a cross-field refine rejects inverted ranges (`createdFrom > createdTo`)
- Filters threaded through `MemoryController` → `MemoryService` → `MemoryLtmService.semanticSearch()` → vector store payload constraints

## Test plan

- [x] `memory.controller.spec.ts` — new test: ISO strings coerced and forwarded; new test: inverted range rejected
- [x] `memory.service.spec.ts` — updated default-options assertion; new test: date fields forwarded to LTM service
- [x] Existing `memory-ltm.semantic.spec.ts` already covers `createdFrom`/`createdTo` at the LTM layer
- [x] All 170 mcp-server tests pass; typecheck clean

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)