### PR TITLE
fix(rank): address unresolved PR #157 review comments

### DIFF
--- a/packages/memory-ltm/src/memory-ltm.semantic.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.semantic.spec.ts
@@ -172,8 +172,8 @@ describe('MemoryLtmService — vector lifecycle & semantic search', () => {
     });
 
     it('re-ranks results by blended score and drops hits without a backing row', async () => {
-      // 'a' has higher recency; 'b' has higher similarity — blended result depends on weights.
-      // Both use the same createdAt so recency is equal; similarity dominates → 'b' first.
+      // Both memories share the same createdAt so recency scores are equal.
+      // 'b' has higher similarity (0.9 vs 0.7); similarity dominates → 'b' first.
       vectorStore.search.mockResolvedValue([
         { id: 'b', score: 0.9 },
         { id: 'missing', score: 0.8 },

--- a/packages/memory-ltm/src/memory-ltm.semantic.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.semantic.spec.ts
@@ -189,6 +189,33 @@ describe('MemoryLtmService — vector lifecycle & semantic search', () => {
       expect(results.map((r) => r.memory.id)).toEqual(['b', 'a']);
     });
 
+    it('uses default weights when rankingWeights contains undefined values', async () => {
+      vectorStore.search.mockResolvedValue([{ id: mockMemoryId, score: 0.8 }]);
+      prisma.memory.findMany.mockResolvedValue([buildMemory()]);
+
+      // Passing { similarity: undefined } must not produce NaN scores
+      const results = await service.semanticSearch(mockUserId, 'query', {
+        rankingWeights: { similarity: undefined as unknown as number },
+      });
+
+      expect(results).toHaveLength(1);
+      expect(Number.isFinite(results[0]?.score)).toBe(true);
+      expect(results[0]?.score).toBeGreaterThan(0);
+    });
+
+    it('falls back to default half-life for invalid recencyHalfLifeDays values', async () => {
+      vectorStore.search.mockResolvedValue([{ id: mockMemoryId, score: 0.8 }]);
+      prisma.memory.findMany.mockResolvedValue([buildMemory()]);
+
+      for (const invalid of [0, -10, Infinity, -Infinity, NaN]) {
+        const results = await service.semanticSearch(mockUserId, 'query', {
+          recencyHalfLifeDays: invalid,
+        });
+        expect(results).toHaveLength(1);
+        expect(Number.isFinite(results[0]?.score)).toBe(true);
+      }
+    });
+
     it('returns an empty array when the query is blank', async () => {
       const results = await service.semanticSearch(mockUserId, '   ');
       expect(results).toEqual([]);

--- a/packages/memory-ltm/src/memory-ltm.service.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.ts
@@ -547,11 +547,17 @@ export class MemoryLtmService {
     // Over-fetch so re-ranking has enough candidates; cap to avoid overwhelming the store.
     const fetchLimit = Math.min(limit * 3, 100);
 
+    const rw = options?.rankingWeights;
     const weights: RankingWeights = {
-      ...DEFAULT_RANKING_WEIGHTS,
-      ...options?.rankingWeights,
+      similarity: rw?.similarity ?? DEFAULT_RANKING_WEIGHTS.similarity,
+      recency: rw?.recency ?? DEFAULT_RANKING_WEIGHTS.recency,
+      importance: rw?.importance ?? DEFAULT_RANKING_WEIGHTS.importance,
     };
-    const halfLifeDays = options?.recencyHalfLifeDays ?? 30;
+    const rawHalfLife = options?.recencyHalfLifeDays;
+    const halfLifeDays =
+      typeof rawHalfLife === 'number' && Number.isFinite(rawHalfLife) && rawHalfLife > 0
+        ? rawHalfLife
+        : 30;
 
     try {
       const embeddingResult = await this.embeddingsService

--- a/packages/memory-ltm/src/rank.spec.ts
+++ b/packages/memory-ltm/src/rank.spec.ts
@@ -35,7 +35,35 @@ describe('rankResults', () => {
 
   it('throws when all weights are zero', () => {
     const r = makeResult({ id: 'a', score: 0.9 });
-    expect(() => rankResults([r], { similarity: 0, recency: 0, importance: 0 }, 30, NOW)).toThrow();
+    expect(() => rankResults([r], { similarity: 0, recency: 0, importance: 0 }, 30, NOW)).toThrow(
+      'Ranking weights must not all be zero'
+    );
+  });
+
+  it('throws when halfLifeDays is zero or negative', () => {
+    const r = makeResult({ id: 'a', score: 0.9 });
+    expect(() => rankResults([r], DEFAULT_RANKING_WEIGHTS, 0, NOW)).toThrow(
+      'halfLifeDays must be a positive finite number'
+    );
+    expect(() => rankResults([r], DEFAULT_RANKING_WEIGHTS, -5, NOW)).toThrow(
+      'halfLifeDays must be a positive finite number'
+    );
+    expect(() => rankResults([r], DEFAULT_RANKING_WEIGHTS, Infinity, NOW)).toThrow(
+      'halfLifeDays must be a positive finite number'
+    );
+  });
+
+  it('throws when a weight is negative or non-finite', () => {
+    const r = makeResult({ id: 'a', score: 0.9 });
+    expect(() =>
+      rankResults([r], { similarity: -1, recency: 0.2, importance: 0.1 }, 30, NOW)
+    ).toThrow('Ranking weights must be non-negative finite numbers');
+    expect(() =>
+      rankResults([r], { similarity: NaN, recency: 0.2, importance: 0.1 }, 30, NOW)
+    ).toThrow('Ranking weights must be non-negative finite numbers');
+    expect(() =>
+      rankResults([r], { similarity: Infinity, recency: 0.2, importance: 0.1 }, 30, NOW)
+    ).toThrow('Ranking weights must be non-negative finite numbers');
   });
 
   it('with pure similarity weight, preserves similarity ordering', () => {

--- a/packages/memory-ltm/src/rank.ts
+++ b/packages/memory-ltm/src/rank.ts
@@ -64,13 +64,27 @@ export function rankResults(
   halfLifeDays = 30,
   now: Date = new Date()
 ): SemanticSearchResult[] {
-  const total = weights.similarity + weights.recency + weights.importance;
+  if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {
+    throw new Error('halfLifeDays must be a positive finite number');
+  }
+  const { similarity, recency, importance } = weights;
+  if (
+    !Number.isFinite(similarity) ||
+    similarity < 0 ||
+    !Number.isFinite(recency) ||
+    recency < 0 ||
+    !Number.isFinite(importance) ||
+    importance < 0
+  ) {
+    throw new Error('Ranking weights must be non-negative finite numbers');
+  }
+  const total = similarity + recency + importance;
   if (total === 0) {
     throw new Error('Ranking weights must not all be zero');
   }
-  const wSim = weights.similarity / total;
-  const wRec = weights.recency / total;
-  const wImp = weights.importance / total;
+  const wSim = similarity / total;
+  const wRec = recency / total;
+  const wImp = importance / total;
 
   return results
     .map(({ memory, score: similarityScore }) => {

--- a/packages/memory-ltm/src/types.ts
+++ b/packages/memory-ltm/src/types.ts
@@ -68,15 +68,16 @@ export interface SemanticSearchOptions {
   /**
    * Half-life in calendar days for the recency decay component.
    * A memory created exactly `recencyHalfLifeDays` ago receives a recency
-   * score of 0.5. Defaults to 30 days.
+   * score of 0.5. Must be a positive finite number; defaults to 30 days.
+   * Non-positive or non-finite values are silently replaced with the default.
    */
   recencyHalfLifeDays?: number;
 }
 
-// A semantic-search hit: a memory plus its similarity score
+// A semantic-search hit: a memory plus its relevance score
 export interface SemanticSearchResult {
   memory: LtmMemory;
-  /** Similarity score from the vector store (higher is more similar). */
+  /** Blended relevance score after ranking (similarity + recency + importance). Raw vector-store similarity before ranking is applied. Higher is more relevant. */
   score: number;
 }
 

--- a/packages/memory-ltm/src/types.ts
+++ b/packages/memory-ltm/src/types.ts
@@ -77,7 +77,7 @@ export interface SemanticSearchOptions {
 // A semantic-search hit: a memory plus its relevance score
 export interface SemanticSearchResult {
   memory: LtmMemory;
-  /** Blended relevance score after ranking (similarity + recency + importance). Raw vector-store similarity before ranking is applied. Higher is more relevant. */
+  /** Blended relevance score combining similarity, recency, and importance (always in [0, 1] after ranking). Higher is more relevant. */
   score: number;
 }
 


### PR DESCRIPTION
## Summary

Addresses 5 unresolved Copilot review comments from #157 (merged).

- **Input validation in `rankResults`**: throws on `halfLifeDays ≤ 0`, non-finite, or negative weights — previously these produced `NaN` scores and unpredictable ordering
- **Weight merge fix**: replaced `{ ...DEFAULT_RANKING_WEIGHTS, ...options?.rankingWeights }` spread with per-key `??` merge so `undefined` values in a partial override can't silently clobber defaults
- **`recencyHalfLifeDays` sanitisation**: service layer clamps `0`, negative, and non-finite values to the default `30` instead of passing them through to `rankResults`
- **`SemanticSearchResult.score` doc**: updated from "Similarity score from the vector store" to accurately describe the blended relevance score
- **`recencyHalfLifeDays` doc**: documents the positive-finite constraint and the fallback behaviour
- **Test comment fix**: removed the self-contradictory first sentence ("'a' has higher recency") that contradicted the line immediately following it

## Test plan

- [x] 2 new unit tests covering `halfLifeDays ≤ 0` and negative/non-finite weight error paths
- [x] All 70 `@engram/memory-ltm` tests pass (`pnpm --filter @engram/memory-ltm test`)
- [x] Typecheck clean (`pnpm --filter @engram/memory-ltm typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)