### PR TITLE
feat(db): Organization & Membership models + tenant scoping

### DIFF
--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -16,10 +16,39 @@ export const MemoryType = {
 
 export type MemoryTypeValues = (typeof MemoryType)[keyof typeof MemoryType];
 
+// Organization roles
+export const MembershipRole = {
+  OWNER: 'owner',
+  ADMIN: 'admin',
+  MEMBER: 'member',
+} as const;
+
+export type MembershipRoleValues = (typeof MembershipRole)[keyof typeof MembershipRole];
+
+// Core Organization interface
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Core Membership interface
+export interface Membership {
+  id: string;
+  userId: string;
+  organizationId: string;
+  role: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 // Core Memory interface (matches Prisma generated types)
 export interface Memory {
   id: string;
   userId: string;
+  organizationId?: string | null;
   content: string;
   metadata?: Record<string, unknown> | null;
   tags: string[];

--- a/packages/memory-ltm/src/memory-ltm.service.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.ts
@@ -29,6 +29,7 @@ import {
 type PrismaMemory = {
   id: string;
   userId: string;
+  organizationId: string | null;
   content: string;
   metadata: unknown; // Using unknown for type safety; must be type-checked before use
   tags: string[];
@@ -86,6 +87,7 @@ export class MemoryLtmService {
       const memory = await (this.prisma as any).memory.create({
         data: {
           userId: validatedInput.userId,
+          organizationId: validatedInput.organizationId ?? null,
           content: validatedInput.content,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           metadata: validatedInput.metadata as any,
@@ -266,6 +268,10 @@ export class MemoryLtmService {
         type: MemoryType.LONG_TERM,
       };
 
+      if (validatedOptions.organizationId) {
+        whereClause.organizationId = validatedOptions.organizationId;
+      }
+
       // Add filters
       if (validatedOptions.tags && validatedOptions.tags.length > 0) {
         whereClause.tags = {
@@ -355,6 +361,10 @@ export class MemoryLtmService {
         userId: userId,
         type: MemoryType.LONG_TERM,
       };
+
+      if (filters?.organizationId) {
+        whereClause.organizationId = filters.organizationId;
+      }
 
       // Add filters if provided
       if (filters?.tags && filters.tags.length > 0) {
@@ -810,6 +820,7 @@ export class MemoryLtmService {
   private mapToLtmMemory(memory: PrismaMemory): LtmMemory {
     return {
       ...memory,
+      organizationId: memory.organizationId ?? undefined,
       type: 'long-term' as const,
       expiresAt: null,
       metadata: memory.metadata as Record<string, unknown> | null,

--- a/packages/memory-ltm/src/memory-ltm.tenant.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.tenant.spec.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryLtmService } from './memory-ltm.service';
+import { MemoryType } from '@engram/database';
+
+const ORG_A = 'cm0aaaaaaaaaaaaaaaaaaaaaaaa';
+const ORG_B = 'cm0bbbbbbbbbbbbbbbbbbbbbbbbb';
+const USER_A = 'cldx4k8xp000108l83h4y8v2q';
+const USER_B = 'cldx4k8xp000208l84b5c9w3r';
+
+type MockMemory = {
+  id: string;
+  userId: string;
+  organizationId: string | null;
+  content: string;
+  metadata: null;
+  tags: string[];
+  type: string;
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: null;
+  embedding: number[];
+};
+
+const makeMemory = (overrides: Partial<MockMemory>): MockMemory => ({
+  id: 'mem-1',
+  userId: USER_A,
+  organizationId: ORG_A,
+  content: 'test content',
+  metadata: null,
+  tags: [],
+  type: MemoryType.LONG_TERM,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  expiresAt: null,
+  embedding: [],
+  ...overrides,
+});
+
+describe('MemoryLtmService — tenant isolation', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let service: MemoryLtmService;
+
+  const memOrgA = makeMemory({ id: 'mem-a1', userId: USER_A, organizationId: ORG_A });
+  const memOrgB = makeMemory({ id: 'mem-b1', userId: USER_B, organizationId: ORG_B });
+
+  beforeEach(() => {
+    const db = [memOrgA, memOrgB];
+
+    prisma = {
+      memory: {
+        count: vi
+          .fn()
+          .mockImplementation(({ where }) =>
+            Promise.resolve(
+              db.filter(
+                (m) =>
+                  (!where.userId || m.userId === where.userId) &&
+                  (!where.organizationId || m.organizationId === where.organizationId) &&
+                  m.type === where.type
+              ).length
+            )
+          ),
+        create: vi
+          .fn()
+          .mockImplementation(({ data }: { data: Partial<MockMemory> }) =>
+            Promise.resolve({ ...makeMemory({}), ...data, id: 'mem-new' })
+          ),
+        findFirst: vi
+          .fn()
+          .mockImplementation(({ where }) =>
+            Promise.resolve(
+              db.find(
+                (m) =>
+                  m.id === where.id &&
+                  m.userId === where.userId &&
+                  (!where.organizationId || m.organizationId === where.organizationId) &&
+                  m.type === where.type
+              ) ?? null
+            )
+          ),
+        findMany: vi
+          .fn()
+          .mockImplementation(({ where }) =>
+            Promise.resolve(
+              db.filter(
+                (m) =>
+                  (!where.userId || m.userId === where.userId) &&
+                  (!where.organizationId || m.organizationId === where.organizationId) &&
+                  m.type === where.type
+              )
+            )
+          ),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        update: vi.fn(),
+      },
+      $transaction: vi.fn(),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    service = new MemoryLtmService(prisma as any);
+  });
+
+  describe('list — org scope filter', () => {
+    it('returns only org A memories when organizationId=ORG_A', async () => {
+      const result = await service.list(USER_A, { organizationId: ORG_A });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.organizationId).toBe(ORG_A);
+    });
+
+    it('returns zero results for org A user querying org B', async () => {
+      const result = await service.list(USER_A, { organizationId: ORG_B });
+      expect(result.items).toHaveLength(0);
+    });
+
+    it('returns only org B memories when organizationId=ORG_B', async () => {
+      const result = await service.list(USER_B, { organizationId: ORG_B });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.organizationId).toBe(ORG_B);
+    });
+  });
+
+  describe('count — org scope filter', () => {
+    it('counts only memories belonging to the specified org', async () => {
+      const countA = await service.count(USER_A, { organizationId: ORG_A });
+      const countB = await service.count(USER_B, { organizationId: ORG_B });
+      expect(countA).toBe(1);
+      expect(countB).toBe(1);
+    });
+
+    it("returns 0 when user tries to count another org's memories", async () => {
+      const count = await service.count(USER_A, { organizationId: ORG_B });
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('create — organizationId persisted', () => {
+    it('stores the organizationId on the created memory', async () => {
+      await service.create({ userId: USER_A, organizationId: ORG_A, content: 'new memory' });
+
+      expect(prisma.memory.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ organizationId: ORG_A }),
+      });
+    });
+
+    it('stores null organizationId when no org is provided', async () => {
+      await service.create({ userId: USER_A, content: 'unscoped memory' });
+
+      expect(prisma.memory.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ organizationId: null }),
+      });
+    });
+  });
+
+  describe('organizationId filter wired into where clause', () => {
+    it('passes organizationId to prisma.memory.findMany when provided', async () => {
+      await service.list(USER_A, { organizationId: ORG_A });
+
+      expect(prisma.memory.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ organizationId: ORG_A }),
+        })
+      );
+    });
+
+    it('passes organizationId to prisma.memory.count when provided', async () => {
+      await service.count(USER_A, { organizationId: ORG_A });
+
+      expect(prisma.memory.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ organizationId: ORG_A }),
+        })
+      );
+    });
+
+    it('omits organizationId from where clause when not provided', async () => {
+      await service.list(USER_A);
+
+      const call = prisma.memory.findMany.mock.calls[0]![0];
+      expect(call.where).not.toHaveProperty('organizationId');
+    });
+  });
+});

--- a/packages/memory-ltm/src/types.ts
+++ b/packages/memory-ltm/src/types.ts
@@ -23,6 +23,7 @@ export interface LtmMemory extends Memory {
 // LTM creation input
 export interface CreateLtmMemoryData {
   userId: string;
+  organizationId?: string;
   content: string;
   metadata?: Record<string, unknown>;
   tags?: string[];
@@ -39,6 +40,7 @@ export interface UpdateLtmMemoryData {
 export interface LtmQueryOptions {
   limit?: number;
   cursor?: string;
+  organizationId?: string;
   tags?: string[];
   dateFrom?: Date;
   dateTo?: Date;
@@ -124,6 +126,7 @@ export interface ReindexResult extends ReindexProgress {
 // Create LTM memory schema
 export const createLtmMemorySchema = z.object({
   userId: userIdSchema,
+  organizationId: z.string().cuid2().optional(),
   content: z.string().min(1, 'Content cannot be empty').max(10240, 'Content cannot exceed 10KB'),
   metadata: z.record(z.string(), z.unknown()).optional().nullable(),
   tags: z.array(z.string()).optional().default([]),
@@ -144,6 +147,7 @@ export const updateLtmMemorySchema = z.object({
 export const ltmQueryOptionsSchema = z.object({
   limit: z.number().int().min(1).max(100).optional().default(20),
   cursor: cursorIdSchema.optional(),
+  organizationId: z.string().cuid2().optional(),
   tags: z.array(z.string()).optional(),
   dateFrom: z.date().optional(),
   dateTo: z.date().optional(),

--- a/prisma/migrations/20260614203624_add_org_membership_tenant/migration.sql
+++ b/prisma/migrations/20260614203624_add_org_membership_tenant/migration.sql
@@ -1,0 +1,49 @@
+-- AlterTable
+ALTER TABLE "memories" ADD COLUMN     "organizationId" TEXT;
+
+-- CreateTable
+CREATE TABLE "organizations" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "organizations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "memberships" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'member',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "memberships_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "organizations_slug_key" ON "organizations"("slug");
+
+-- CreateIndex
+CREATE INDEX "memberships_organizationId_idx" ON "memberships"("organizationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "memberships_userId_organizationId_key" ON "memberships"("userId", "organizationId");
+
+-- CreateIndex
+CREATE INDEX "memories_organizationId_idx" ON "memories"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "memories_organizationId_type_idx" ON "memories"("organizationId", "type");
+
+-- AddForeignKey
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "memories" ADD CONSTRAINT "memories_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,37 @@ datasource db {
   extensions = [vector]
 }
 
+model Organization {
+  id        String   @id @default(cuid(2))
+  name      String
+  slug      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relationships
+  memberships Membership[]
+  memories    Memory[]
+
+  @@map("organizations")
+}
+
+model Membership {
+  id             String       @id @default(cuid(2))
+  userId         String
+  organizationId String
+  role           String       @default("member") // 'owner' | 'admin' | 'member'
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  // Relationships
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, organizationId])
+  @@index([organizationId])
+  @@map("memberships")
+}
+
 model User {
   id        String   @id @default(cuid(2))
   email     String   @unique
@@ -18,22 +49,24 @@ model User {
   updatedAt DateTime @updatedAt
 
   // Relationships
-  memories  Memory[]
+  memberships Membership[]
+  memories    Memory[]
 
   @@map("users")
 }
 
 model Memory {
-  id        String   @id @default(cuid(2))
-  userId    String
-  content   String   @db.Text // Support up to 10KB content
-  metadata  Json?
-  tags      String[]
-  type      String   // 'short-term' | 'long-term'
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  expiresAt DateTime? // For short-term memories only
-  embedding Float[]   // Vector embedding (1536 dims for text-embedding-3-small)
+  id             String   @id @default(cuid(2))
+  userId         String
+  organizationId String?
+  content        String   @db.Text // Support up to 10KB content
+  metadata       Json?
+  tags           String[]
+  type           String   // 'short-term' | 'long-term'
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  expiresAt      DateTime? // For short-term memories only
+  embedding      Float[]   // Vector embedding (1536 dims for text-embedding-3-small)
 
   // Native pgvector column used by the pgvector VectorStore backend. Managed via
   // raw SQL (see migration 20260601090000_pgvector_provider); typed as
@@ -41,11 +74,14 @@ model Memory {
   embeddingVec Unsupported("vector(1536)")? @map("embedding_vec")
 
   // Relationships
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
 
   // Indexes for performance
   @@index([userId])
   @@index([userId, type])
+  @@index([organizationId])
+  @@index([organizationId, type])
   @@index([expiresAt])
   @@map("memories")
 }


### PR DESCRIPTION
## Summary

- Adds `Organization` (id, name, slug unique) and `Membership` (userId, organizationId, role) Prisma models with a clean migration
- Adds nullable `organizationId` FK + composite index on `Memory`; all existing rows unaffected
- Exports `Organization`, `Membership`, and `MembershipRole` from `@engram/database`
- Accepts `organizationId` in `CreateLtmMemoryData`, `LtmQueryOptions`, and Zod schemas; filters `list`/`count` queries when provided
- 10 new cross-tenant isolation tests verify org-scoped denial and that the field flows through the where clause

This is the DB foundation for the auth/multi-tenancy epic. STM namespacing and making `organizationId` required are scoped to #131.

## Test plan

- [x] `pnpm --filter @engram/memory-ltm test` — 82 tests pass
- [x] `pnpm build` — clean
- [x] `pnpm typecheck` — clean
- [x] Migration applied cleanly against local Postgres

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)