### PR TITLE
feat(perf): load test script + capacity guide (#145)

### DIFF
--- a/docs/CAPACITY.md
+++ b/docs/CAPACITY.md
@@ -1,0 +1,149 @@
+---
+title: Capacity & Scaling Guide
+description: Load testing results, throughput baselines, and scaling guidance for ENGRAM
+---
+
+## Overview
+
+This document captures ENGRAM's memory-pipeline capacity characteristics and
+provides guidance on scaling each component. Run the load test script to
+reproduce measurements against your own infrastructure.
+
+```bash
+# Full 10-second test, 8 concurrent workers
+node scripts/load-test.mjs --duration-ms 10000 --concurrency 8 --output artifacts/load-report.json
+
+# Quick smoke test
+node scripts/load-test.mjs --duration-ms 3000 --concurrency 4
+```
+
+`DATABASE_URL` must be set and point to a Postgres instance with the `vector`
+extension available (`pgvector/pgvector:pg16+` Docker image).
+
+---
+
+## Scenarios
+
+| Scenario | What it measures |
+| -------- | ---------------- |
+| **Write** | Concurrent `memories` INSERTs via Prisma (no external embedding call — fake vectors) |
+| **Recall** | Concurrent pgvector HNSW kNN searches (`ORDER BY embedding_vec <=> $query LIMIT 10`) |
+
+---
+
+## Baseline Thresholds
+
+| Metric | Target | Action if exceeded |
+| ------ | ------ | ------------------ |
+| Write p95 | < 100 ms | Tune connection pool or switch to batch inserts |
+| Recall p95 | < 50 ms | Tune HNSW `ef_search` / add RAM |
+| Write ops/sec | > 100 | Enable PgBouncer or batching |
+| Recall ops/sec | > 50 | Add read replica for search traffic |
+
+---
+
+## Bottleneck Map
+
+### 1. Embedding generation (write path)
+
+**Primary bottleneck in production.** Every memory creation calls the OpenAI
+Embeddings API (or a local provider). At 8 concurrent workers, embedding latency
+(~100–500 ms/call) dominates over Postgres write latency (~5–20 ms).
+
+Mitigations:
+- **Redis cache** — already wired in `EmbeddingsService`; 30-day TTL. Cache hit
+  rate is exported via `getPrometheusMetrics()` (`engram_embeddings_cacheHits_total`).
+- **Batch embeddings** — OpenAI `/v1/embeddings` accepts up to 2048 texts per
+  request. Use `bulk ingest` (#127) to amortize API overhead.
+- **Local provider** — `EMBEDDING_PROVIDER=local` uses a deterministic hash
+  embedding with no external call. Suitable for development and tests.
+
+### 2. Postgres connection pool
+
+Default NestJS/Prisma configuration opens one connection per process. Under
+high concurrency (> 20 workers) connection wait time becomes visible in write
+p99.
+
+Mitigations:
+- Set `connection_limit` in `DATABASE_URL`:
+  `postgresql://...?connection_limit=20&pool_timeout=10`
+- Deploy **PgBouncer** in transaction-pooling mode in front of Postgres for
+  > 50 concurrent clients.
+
+### 3. HNSW index quality
+
+The `embedding_vec` column uses an HNSW index with default parameters
+(`m=16`, `ef_construction=64`). Recall quality and search speed are both
+sensitive to these parameters.
+
+Guidance:
+- For datasets < 100 K vectors: defaults are fine. Recall p95 < 20 ms.
+- For datasets 100 K – 1 M vectors: increase `ef_search` to 100–200:
+  ```sql
+  SET hnsw.ef_search = 128;
+  ```
+- For > 1 M vectors: evaluate migrating to Qdrant, which handles large
+  collections with better memory control (`VECTOR_BACKEND=qdrant`).
+
+### 4. Redis (STM + embedding cache)
+
+Redis is used for STM keys and the embedding cache. Neither path is typically
+a bottleneck at < 500 concurrent clients. If Redis CPU becomes visible, enable
+cluster mode or move embedding cache to a separate Redis instance.
+
+---
+
+## Scaling Playbook
+
+### Horizontal scaling (stateless compute)
+
+The MCP server is stateless — all state lives in Postgres, Redis, and Qdrant.
+Add server instances behind a load balancer and set a shared `DATABASE_URL`,
+`REDIS_URL`, and `QDRANT_URL`. No session stickiness is required.
+
+### Read replica for recall
+
+Vector search is read-only and often the highest-traffic path. Route `recall`
+tool calls to a Postgres read replica:
+
+```
+RECALL_DATABASE_URL=postgresql://replica-host/engram
+```
+
+The `MemoryLtmService` can be updated to use a separate read-only Prisma
+client for search queries.
+
+### Vertical scaling thresholds
+
+| Component | When to scale up |
+| --------- | ---------------- |
+| Postgres | RAM < 2 × working set (HNSW index must fit in shared_buffers) |
+| Redis | Memory usage > 80% of `maxmemory` |
+| Qdrant | RAM < 1.5 × total vector bytes |
+
+### Connection pool sizing
+
+```
+max_connections = (num_cpu_cores × 2) + num_disk_spindles
+```
+
+For a 4-core server: `max_connections = 9`. Set Prisma's `connection_limit`
+to `max_connections - 2` (reserve 2 for admin / migrations).
+
+---
+
+## Running in CI
+
+The load test is intentionally **not** wired into default CI because it
+requires sustained database resources and ~30+ seconds to complete. Run it
+manually before a release or on a nightly schedule:
+
+```bash
+DATABASE_URL=postgresql://... node scripts/load-test.mjs \
+  --duration-ms 30000 \
+  --concurrency 16 \
+  --output artifacts/load-report.json
+```
+
+For vector-search latency gates that run in every PR, see `pnpm bench:ci`
+(runs `bench-vector-backends.mjs` with a p95 ≤ 120 ms threshold).

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "eval": "turbo run eval --filter=@engram/eval",
+    "load:test": "node scripts/load-test.mjs",
     "bench:backends": "node scripts/bench-vector-backends.mjs",
     "bench:ci": "node scripts/bench-vector-backends.mjs --iterations 80 --warmup 20 --p95 120 --output artifacts/bench-results.json",
     "bench:baseline:fetch": "node scripts/fetch-benchmark-baseline.mjs --out artifacts/bench-baseline.json",

--- a/scripts/load-test.mjs
+++ b/scripts/load-test.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+/**
+ * Load test for the ENGRAM memory pipeline.
+ *
+ * Runs concurrent write (memory create) and recall (vector search) scenarios
+ * against a live Postgres+pgvector instance and reports throughput and latency.
+ * No OpenAI key required — embeddings are deterministic fake vectors.
+ *
+ * Usage:
+ *   node scripts/load-test.mjs [options]
+ *
+ * Options:
+ *   --duration-ms <ms>    Duration of each scenario (default: 10000)
+ *   --concurrency <n>     Parallel workers per scenario (default: 8)
+ *   --output <path>       Write JSON report to file (optional)
+ *
+ * Environment:
+ *   DATABASE_URL          Required — Postgres connection string
+ */
+
+import { performance } from 'node:perf_hooks';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+function parseArgs(argv) {
+  const args = { durationMs: 10_000, concurrency: 8, output: undefined };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    switch (flag) {
+      case '--duration-ms':
+        args.durationMs = Number.parseInt(value ?? '', 10);
+        i += 1;
+        break;
+      case '--concurrency':
+      case '-c':
+        args.concurrency = Number.parseInt(value ?? '', 10);
+        i += 1;
+        break;
+      case '--output':
+      case '-o':
+        args.output = value;
+        i += 1;
+        break;
+      default:
+        break;
+    }
+  }
+  return args;
+}
+
+function percentile(values, p) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, index))];
+}
+
+function summarize(samples, elapsedMs) {
+  if (samples.length === 0) {
+    return { count: 0, opsPerSec: 0, min: 0, mean: 0, p50: 0, p95: 0, p99: 0, max: 0 };
+  }
+  const mean = samples.reduce((sum, v) => sum + v, 0) / samples.length;
+  return {
+    count: samples.length,
+    opsPerSec: Number(((samples.length / elapsedMs) * 1000).toFixed(1)),
+    min: Number(Math.min(...samples).toFixed(2)),
+    mean: Number(mean.toFixed(2)),
+    p50: Number(percentile(samples, 50).toFixed(2)),
+    p95: Number(percentile(samples, 95).toFixed(2)),
+    p99: Number(percentile(samples, 99).toFixed(2)),
+    max: Number(Math.max(...samples).toFixed(2)),
+  };
+}
+
+function fakeEmbedding(seed, dims = 1536) {
+  const vec = new Array(dims).fill(0);
+  vec[seed % dims] = 1;
+  vec[(seed * 7 + 3) % dims] = 0.5;
+  const norm = Math.sqrt(1.25);
+  return vec.map((v) => v / norm);
+}
+
+async function runWriteScenario(prisma, userId, durationMs, concurrency) {
+  const samples = [];
+  const errors = [];
+  let seed = 0;
+  const deadline = performance.now() + durationMs;
+
+  async function worker() {
+    while (performance.now() < deadline) {
+      const mySeed = seed++;
+      const t0 = performance.now();
+      try {
+        await prisma.memory.create({
+          data: {
+            id: randomUUID(),
+            userId,
+            content: `load-test memory ${mySeed}: the quick brown fox jumps over the lazy dog`,
+            metadata: null,
+            tags: ['load-test'],
+            type: 'long-term',
+            embedding: fakeEmbedding(mySeed),
+          },
+        });
+        samples.push(performance.now() - t0);
+      } catch (err) {
+        errors.push(err instanceof Error ? err.message : String(err));
+      }
+    }
+  }
+
+  const started = performance.now();
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  return { samples, errors, elapsedMs: performance.now() - started };
+}
+
+async function runRecallScenario(prisma, userId, durationMs, concurrency) {
+  const samples = [];
+  const errors = [];
+  let seed = 0;
+  const deadline = performance.now() + durationMs;
+
+  async function worker() {
+    while (performance.now() < deadline) {
+      const vec = fakeEmbedding(seed++);
+      const literal = `[${vec.join(',')}]`;
+      const t0 = performance.now();
+      try {
+        await prisma.$queryRawUnsafe(
+          'SELECT "id", "content" FROM "memories" WHERE "userId" = $2 AND "embedding_vec" IS NOT NULL ORDER BY "embedding_vec" <=> $1::vector LIMIT 10',
+          literal,
+          userId,
+        );
+        samples.push(performance.now() - t0);
+      } catch (err) {
+        errors.push(err instanceof Error ? err.message : String(err));
+      }
+    }
+  }
+
+  const started = performance.now();
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  return { samples, errors, elapsedMs: performance.now() - started };
+}
+
+async function main() {
+  const { durationMs, concurrency, output } = parseArgs(process.argv.slice(2));
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error('DATABASE_URL is required');
+
+  const userId = `load-test-${Date.now()}`;
+  const userEmail = `${userId}@engram.load`;
+  const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: databaseUrl }) });
+
+  console.log(`ENGRAM load test  duration=${durationMs}ms  concurrency=${concurrency}`);
+
+  try {
+    await prisma.$connect();
+
+    await prisma.$executeRawUnsafe('CREATE EXTENSION IF NOT EXISTS vector');
+    await prisma.$executeRawUnsafe(
+      'ALTER TABLE "memories" ADD COLUMN IF NOT EXISTS "embedding_vec" vector(1536)',
+    );
+    await prisma.$executeRawUnsafe(
+      'CREATE INDEX IF NOT EXISTS "memories_embedding_vec_hnsw" ON "memories" USING hnsw ("embedding_vec" vector_cosine_ops)',
+    );
+    await prisma.user.upsert({
+      where: { email: userEmail },
+      update: {},
+      create: { id: userId, email: userEmail },
+    });
+
+    // --- Write scenario ---
+    console.log('\n[1/3] Write scenario (concurrent memory create)...');
+    const writeResult = await runWriteScenario(prisma, userId, durationMs, concurrency);
+    const writeStats = summarize(writeResult.samples, writeResult.elapsedMs);
+    console.log(
+      `      ops=${writeStats.count}  ops/sec=${writeStats.opsPerSec}  ` +
+        `p50=${writeStats.p50}ms  p95=${writeStats.p95}ms  p99=${writeStats.p99}ms`,
+    );
+    if (writeResult.errors.length > 0) {
+      console.warn(`      write errors: ${writeResult.errors.length}`);
+    }
+
+    // Backfill embedding_vec so the recall scenario has indexed vectors to search.
+    console.log('\n[2/3] Backfilling embedding_vec for indexed recall...');
+    const memories = await prisma.memory.findMany({ where: { userId } });
+    for (let i = 0; i < memories.length; i++) {
+      const literal = `[${fakeEmbedding(i).join(',')}]`;
+      await prisma.$executeRawUnsafe(
+        'UPDATE "memories" SET "embedding_vec" = $1::vector WHERE "id" = $2',
+        literal,
+        memories[i].id,
+      );
+    }
+    console.log(`      backfilled ${memories.length} vectors`);
+
+    // --- Recall scenario ---
+    console.log('\n[3/3] Recall scenario (concurrent vector search)...');
+    const recallResult = await runRecallScenario(prisma, userId, durationMs, concurrency);
+    const recallStats = summarize(recallResult.samples, recallResult.elapsedMs);
+    console.log(
+      `      ops=${recallStats.count}  ops/sec=${recallStats.opsPerSec}  ` +
+        `p50=${recallStats.p50}ms  p95=${recallStats.p95}ms  p99=${recallStats.p99}ms`,
+    );
+    if (recallResult.errors.length > 0) {
+      console.warn(`      recall errors: ${recallResult.errors.length}`);
+    }
+
+    console.log('\nBottleneck notes:');
+    if (writeStats.p95 > 100) {
+      console.log('  - Write p95 > 100ms: check Postgres connection pool size and I/O throughput');
+    }
+    if (recallStats.p95 > 50) {
+      console.log('  - Recall p95 > 50ms: HNSW index may need tuning (ef_search, m) or more RAM');
+    }
+    if (writeStats.opsPerSec < 100) {
+      console.log(
+        '  - Write throughput < 100 ops/sec: consider connection pooling (PgBouncer) or batching',
+      );
+    }
+    if (recallStats.opsPerSec < 50) {
+      console.log('  - Recall throughput < 50 ops/sec: consider read replicas for search traffic');
+    }
+
+    const report = {
+      generatedAt: new Date().toISOString(),
+      config: { durationMs, concurrency },
+      write: { ...writeStats, errorCount: writeResult.errors.length },
+      recall: { ...recallStats, errorCount: recallResult.errors.length },
+    };
+
+    if (output) {
+      await mkdir(dirname(output), { recursive: true });
+      await writeFile(output, JSON.stringify(report, null, 2), 'utf8');
+      console.log(`\nLoad test report written to ${output}`);
+    }
+  } finally {
+    await prisma.memory.deleteMany({ where: { userId } });
+    await prisma.user.deleteMany({ where: { id: userId } });
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error('Load test failed:', error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/load-test.mjs
+++ b/scripts/load-test.mjs
@@ -50,6 +50,14 @@ function parseArgs(argv) {
         break;
     }
   }
+
+  if (!Number.isFinite(args.durationMs) || args.durationMs <= 0) {
+    throw new Error(`--duration-ms must be a positive number, got: ${args.durationMs}`);
+  }
+  if (!Number.isFinite(args.concurrency) || args.concurrency <= 0) {
+    throw new Error(`--concurrency must be a positive number, got: ${args.concurrency}`);
+  }
+
   return args;
 }
 
@@ -64,16 +72,18 @@ function summarize(samples, elapsedMs) {
   if (samples.length === 0) {
     return { count: 0, opsPerSec: 0, min: 0, mean: 0, p50: 0, p95: 0, p99: 0, max: 0 };
   }
+  const min = samples.reduce((a, b) => (b < a ? b : a), Infinity);
+  const max = samples.reduce((a, b) => (b > a ? b : a), -Infinity);
   const mean = samples.reduce((sum, v) => sum + v, 0) / samples.length;
   return {
     count: samples.length,
     opsPerSec: Number(((samples.length / elapsedMs) * 1000).toFixed(1)),
-    min: Number(Math.min(...samples).toFixed(2)),
+    min: Number(min.toFixed(2)),
     mean: Number(mean.toFixed(2)),
     p50: Number(percentile(samples, 50).toFixed(2)),
     p95: Number(percentile(samples, 95).toFixed(2)),
     p99: Number(percentile(samples, 99).toFixed(2)),
-    max: Number(Math.max(...samples).toFixed(2)),
+    max: Number(max.toFixed(2)),
   };
 }
 
@@ -132,7 +142,7 @@ async function runRecallScenario(prisma, userId, durationMs, concurrency) {
       const t0 = performance.now();
       try {
         await prisma.$queryRawUnsafe(
-          'SELECT "id", "content" FROM "memories" WHERE "userId" = $2 AND "embedding_vec" IS NOT NULL ORDER BY "embedding_vec" <=> $1::vector LIMIT 10',
+          'SELECT "id" FROM "memories" WHERE "userId" = $2 AND "embedding_vec" IS NOT NULL ORDER BY "embedding_vec" <=> $1::vector LIMIT 10',
           literal,
           userId,
         );
@@ -159,6 +169,9 @@ async function main() {
 
   console.log(`ENGRAM load test  duration=${durationMs}ms  concurrency=${concurrency}`);
 
+  let writeResult;
+  let recallResult;
+
   try {
     await prisma.$connect();
 
@@ -177,7 +190,7 @@ async function main() {
 
     // --- Write scenario ---
     console.log('\n[1/3] Write scenario (concurrent memory create)...');
-    const writeResult = await runWriteScenario(prisma, userId, durationMs, concurrency);
+    writeResult = await runWriteScenario(prisma, userId, durationMs, concurrency);
     const writeStats = summarize(writeResult.samples, writeResult.elapsedMs);
     console.log(
       `      ops=${writeStats.count}  ops/sec=${writeStats.opsPerSec}  ` +
@@ -188,21 +201,25 @@ async function main() {
     }
 
     // Backfill embedding_vec so the recall scenario has indexed vectors to search.
+    // Fetch only IDs to avoid loading large content/embedding fields into memory.
     console.log('\n[2/3] Backfilling embedding_vec for indexed recall...');
-    const memories = await prisma.memory.findMany({ where: { userId } });
-    for (let i = 0; i < memories.length; i++) {
+    const memoryIds = await prisma.memory.findMany({
+      where: { userId },
+      select: { id: true },
+    });
+    for (let i = 0; i < memoryIds.length; i++) {
       const literal = `[${fakeEmbedding(i).join(',')}]`;
       await prisma.$executeRawUnsafe(
         'UPDATE "memories" SET "embedding_vec" = $1::vector WHERE "id" = $2',
         literal,
-        memories[i].id,
+        memoryIds[i].id,
       );
     }
-    console.log(`      backfilled ${memories.length} vectors`);
+    console.log(`      backfilled ${memoryIds.length} vectors`);
 
     // --- Recall scenario ---
     console.log('\n[3/3] Recall scenario (concurrent vector search)...');
-    const recallResult = await runRecallScenario(prisma, userId, durationMs, concurrency);
+    recallResult = await runRecallScenario(prisma, userId, durationMs, concurrency);
     const recallStats = summarize(recallResult.samples, recallResult.elapsedMs);
     console.log(
       `      ops=${recallStats.count}  ops/sec=${recallStats.opsPerSec}  ` +
@@ -241,9 +258,18 @@ async function main() {
       console.log(`\nLoad test report written to ${output}`);
     }
   } finally {
-    await prisma.memory.deleteMany({ where: { userId } });
-    await prisma.user.deleteMany({ where: { id: userId } });
-    await prisma.$disconnect();
+    // Best-effort cleanup — swallow errors so the original failure is not masked.
+    try {
+      await prisma.memory.deleteMany({ where: { userId } });
+      await prisma.user.deleteMany({ where: { id: userId } });
+    } catch {
+      // ignore cleanup errors
+    }
+    try {
+      await prisma.$disconnect();
+    } catch {
+      // ignore disconnect errors
+    }
   }
 }
 


### PR DESCRIPTION
Add scripts/load-test.mjs that exercises concurrent write (memory create)
and recall (vector kNN search) scenarios against a live Postgres+pgvector
instance, reporting ops/sec and p50/p95/p99 latency per scenario.

Add docs/CAPACITY.md documenting throughput baselines, the bottleneck map
(embedding generation, connection pool, HNSW index), and a scaling playbook
(horizontal scale-out, read replicas, PgBouncer, vertical thresholds).

Add `pnpm load:test` script alias.

Closes #145

https://claude.ai/code/session_01NGccXzcbb3MS4XNWfVmFw7