### PR TITLE
fix(memory-ltm): add exact-content dedup guard to promote()

### DIFF
--- a/packages/memory-ltm/src/memory-ltm.service.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.ts
@@ -107,16 +107,11 @@ export class MemoryLtmService {
 
       // Step 2 (exact): return the existing memory when the privacy-filtered
       // content matches exactly — avoids the embedding cost and vector dedup path.
-      const exactDupWhere: Record<string, unknown> = {
-        userId: validatedInput.userId,
-        content: processedContent,
-        type: MemoryType.LONG_TERM,
-      };
-      if (validatedInput.organizationId !== undefined) {
-        exactDupWhere.organizationId = validatedInput.organizationId;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const exactDup = await (this.prisma as any).memory.findFirst({ where: exactDupWhere });
+      const exactDup = await this.findExactDuplicate(
+        validatedInput.userId,
+        processedContent,
+        validatedInput.organizationId
+      );
       if (exactDup) {
         this.logger.debug(`Exact content duplicate; returning existing memory ${exactDup.id}`);
         return this.mapToLtmMemory(exactDup);
@@ -566,6 +561,30 @@ export class MemoryLtmService {
       // Step 2: Pre-check quota to avoid a needless embeddings API call when over quota.
       await this.checkQuota(userId);
 
+      // Org scope: prefer the explicit param, fall back to what's stored in the STM payload.
+      const resolvedOrgId = organizationId ?? stmMemory.organizationId ?? null;
+
+      // Exact content dedup: if the STM content already exists verbatim in LTM,
+      // skip promotion and return the existing memory without generating an embedding.
+      const exactDup = await this.findExactDuplicate(userId, stmMemory.content, resolvedOrgId);
+      if (exactDup) {
+        this.logger.debug(
+          `Exact content duplicate on promote; returning existing LTM memory ${exactDup.id}`
+        );
+        try {
+          await this.stmService.delete(
+            userId,
+            memoryId,
+            organizationId ?? stmMemory.organizationId
+          );
+        } catch (stmDeleteError) {
+          this.logger.warn(
+            `Failed to delete STM memory ${memoryId} after exact duplicate on promote: ${stmDeleteError}`
+          );
+        }
+        return this.mapToLtmMemory(exactDup);
+      }
+
       // Step 3: Generate embedding before the transaction (I/O outside DB tx).
       let embedding: number[] = [];
       if (this.embeddingsService) {
@@ -574,9 +593,6 @@ export class MemoryLtmService {
           .catch(() => null);
         embedding = result?.embedding ?? [];
       }
-
-      // Org scope: prefer the explicit param, fall back to what's stored in the STM payload.
-      const resolvedOrgId = organizationId ?? stmMemory.organizationId ?? null;
 
       const duplicate = await this.findDuplicate(userId, resolvedOrgId ?? undefined, embedding);
       if (duplicate) {
@@ -1131,6 +1147,23 @@ export class MemoryLtmService {
 
   private ageDays(date: Date): number {
     return Math.max(0, (Date.now() - date.getTime()) / 86_400_000);
+  }
+
+  private async findExactDuplicate(
+    userId: string,
+    content: string,
+    organizationId: string | null | undefined
+  ): Promise<PrismaMemory | null> {
+    const where: Record<string, unknown> = {
+      userId,
+      content,
+      type: MemoryType.LONG_TERM,
+    };
+    if (organizationId !== undefined) {
+      where.organizationId = organizationId;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this.prisma as any).memory.findFirst({ where }) as Promise<PrismaMemory | null>;
   }
 
   private async findDuplicate(


### PR DESCRIPTION
## Summary

- Extracted a shared `findExactDuplicate(userId, content, organizationId)` private helper from the inline block in `create()`
- Added the same exact-content check to `promote()`, called before the embedding API call to avoid unnecessary I/O
- When `promote()` detects a byte-identical LTM entry it deletes the STM memory and returns the existing LTM row — no duplicate created

## Root cause

`ConsolidationService` automatically promotes STM memories to LTM once their access count crosses a threshold. `promote()` only used vector-based duplicate detection (cosine similarity ≥ 0.97), which requires both the embeddings service and vector store to be available. `create()` had an additional exact-string-match guard first, but `promote()` did not. Any time the same content existed in both LTM (via `create()`) and STM (accessed enough times to trigger consolidation), the promotion path would create a second row.

## Test plan

- [ ] All 129 existing `memory-ltm` unit tests pass (`pnpm --filter @engram/memory-ltm test`)
- [ ] TypeScript strict check passes (`pnpm --filter @engram/memory-ltm typecheck`)
- [ ] Existing test suite exercises the new path — the log output `Exact content duplicate on promote; returning existing LTM memory ...` appears during the test run, confirming the guard fires

## Notes

This fix only handles **byte-identical** content. If two Mars entries differ in case or wording, the exact check won't fire; that path relies on the vector similarity threshold (`MEMORY_DUPLICATE_THRESHOLD`, default 0.97). A more robust fix — a normalised `contentHash` column with a unique index — is already scaffolded in the ingest pipeline (`IngestPipelineService.computeHash`) but not yet wired to a DB query or migration; that would be the follow-up to handle near-duplicate content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)