### PR TITLE
feat(memory): contradiction detection & reconciliation (#120)

### DIFF
--- a/packages/memory-ltm/src/contradiction-detection.service.spec.ts
+++ b/packages/memory-ltm/src/contradiction-detection.service.spec.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ContradictionDetectionService,
+  DEFAULT_CONTRADICTION_THRESHOLD,
+  DEFAULT_CONTRADICTION_THRESHOLD_MAX,
+} from './contradiction-detection.service';
+import type { ContradictionCandidate } from './types';
+
+const THRESHOLD = DEFAULT_CONTRADICTION_THRESHOLD;
+const THRESHOLD_MAX = DEFAULT_CONTRADICTION_THRESHOLD_MAX;
+const IN_BAND = (THRESHOLD + THRESHOLD_MAX) / 2; // score inside contradiction band
+const BELOW_BAND = THRESHOLD - 0.01;
+const AT_MAX = THRESHOLD_MAX; // score at/above max is in duplicate zone, not contradiction band
+
+function candidate(id: string, score: number, content: string): ContradictionCandidate {
+  return { id, score, content };
+}
+
+describe('ContradictionDetectionService', () => {
+  let service: ContradictionDetectionService;
+
+  beforeEach(() => {
+    service = new ContradictionDetectionService();
+  });
+
+  describe('getLowThreshold / getHighThreshold', () => {
+    it('returns the default thresholds', () => {
+      expect(service.getLowThreshold()).toBe(THRESHOLD);
+      expect(service.getHighThreshold()).toBe(THRESHOLD_MAX);
+    });
+  });
+
+  describe('detect()', () => {
+    it('returns null when candidates array is empty', () => {
+      expect(service.detect('I like Python', [])).toBeNull();
+    });
+
+    it('returns null when all candidates are below the similarity band', () => {
+      const c = candidate('m1', BELOW_BAND, "I don't like Python");
+      expect(service.detect('I like Python', [c])).toBeNull();
+    });
+
+    it('returns null when candidate is at or above the duplicate threshold (not a contradiction)', () => {
+      const c = candidate('m1', AT_MAX, "I don't like Python");
+      expect(service.detect('I like Python', [c])).toBeNull();
+    });
+
+    it('returns null when in-band candidates do not contradict', () => {
+      const c = candidate('m1', IN_BAND, 'I like Python and use it daily');
+      expect(service.detect('I enjoy Python for scripting', [c])).toBeNull();
+    });
+
+    describe('negation asymmetry', () => {
+      it('detects when new memory has negation and existing does not', () => {
+        const c = candidate('m1', IN_BAND, 'I like Python');
+        const result = service.detect("I don't like Python", [c]);
+        expect(result).not.toBeNull();
+        expect(result!.memoryId).toBe('m1');
+        expect(result!.reason).toBe('negation asymmetry');
+        expect(result!.action).toBe('superseded');
+      });
+
+      it('detects when existing memory has negation and new does not', () => {
+        const c = candidate('m1', IN_BAND, "I don't use TypeScript");
+        const result = service.detect('I use TypeScript', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('negation asymmetry');
+      });
+
+      it('does not flag when both have negation', () => {
+        const c = candidate('m1', IN_BAND, 'I never use JavaScript');
+        const result = service.detect("I don't use JavaScript either", [c]);
+        expect(result).toBeNull();
+      });
+
+      it('does not flag when neither has negation', () => {
+        const c = candidate('m1', IN_BAND, 'I use Python');
+        expect(service.detect('I use Python daily', [c])).toBeNull();
+      });
+
+      it('matches "cannot" as negation', () => {
+        const c = candidate('m1', IN_BAND, 'I can handle this');
+        const result = service.detect('I cannot handle this anymore', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('negation asymmetry');
+      });
+
+      it('matches "no longer" as negation', () => {
+        const c = candidate('m1', IN_BAND, 'I work at Acme Corp');
+        const result = service.detect('I no longer work at Acme Corp', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('negation asymmetry');
+      });
+    });
+
+    describe('change indicators', () => {
+      it('detects change indicator in new memory only', () => {
+        const c = candidate('m1', IN_BAND, 'I use JavaScript for backend work');
+        const result = service.detect('I switched to TypeScript for backend work', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('change indicator in new memory');
+      });
+
+      it('detects "now I" as change indicator', () => {
+        const c = candidate('m1', IN_BAND, 'I prefer tabs for indentation');
+        const result = service.detect('Now I prefer spaces for indentation', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('change indicator in new memory');
+      });
+
+      it('does not flag when both have change indicators', () => {
+        const c = candidate('m1', IN_BAND, 'I changed to using tabs');
+        const result = service.detect('I switched to using spaces', [c]);
+        // both have change indicators so neither negation nor change-only applies
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('polar opposites', () => {
+      it('detects like/dislike', () => {
+        const c = candidate('m1', IN_BAND, 'I like early mornings');
+        const result = service.detect('I dislike early mornings', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('polar opposite: like/dislike');
+      });
+
+      it('detects prefer/avoid', () => {
+        const c = candidate('m1', IN_BAND, 'I prefer async code patterns');
+        const result = service.detect('I avoid async code patterns', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('polar opposite: prefer/avoid');
+      });
+
+      it('detects love/hate', () => {
+        const c = candidate('m1', IN_BAND, 'I love dark mode');
+        const result = service.detect('I hate dark mode', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('polar opposite: love/hate');
+      });
+
+      it('detects agree/disagree', () => {
+        const c = candidate('m1', IN_BAND, 'I agree with that approach');
+        const result = service.detect('I disagree with that approach', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('polar opposite: agree/disagree');
+      });
+
+      it('detects reverse direction (new has A, old has B)', () => {
+        const c = candidate('m1', IN_BAND, 'I dislike meetings');
+        const result = service.detect('I like meetings when they are short', [c]);
+        expect(result).not.toBeNull();
+        expect(result!.reason).toBe('polar opposite: like/dislike');
+      });
+    });
+
+    it('uses score and sets action=superseded', () => {
+      const c = candidate('abc', IN_BAND, 'I like Python');
+      const result = service.detect("I don't like Python", [c]);
+      expect(result!.memoryId).toBe('abc');
+      expect(result!.score).toBe(IN_BAND);
+      expect(result!.action).toBe('superseded');
+    });
+
+    it('returns first matching candidate when multiple are in band', () => {
+      const c1 = candidate('first', IN_BAND, 'I like Python');
+      const c2 = candidate('second', IN_BAND + 0.01, 'I prefer Python');
+      const result = service.detect("I don't like Python anymore", [c1, c2]);
+      expect(result!.memoryId).toBe('first');
+    });
+  });
+
+  describe('annotateContradictor()', () => {
+    it('adds contradictionMatches to empty metadata', () => {
+      const match = {
+        memoryId: 'm1',
+        score: 0.85,
+        action: 'superseded' as const,
+        reason: 'negation asymmetry',
+      };
+      const result = service.annotateContradictor(null, match, 'I like Python');
+      expect(Array.isArray(result['contradictionMatches'])).toBe(true);
+      const entries = result['contradictionMatches'] as unknown[];
+      expect(entries).toHaveLength(1);
+      const entry = entries[0] as Record<string, unknown>;
+      expect(entry['memoryId']).toBe('m1');
+      expect(entry['action']).toBe('superseded');
+      expect(entry['reason']).toBe('negation asymmetry');
+      expect(typeof entry['detectedAt']).toBe('string');
+    });
+
+    it('appends to existing contradictionMatches', () => {
+      const existing = { contradictionMatches: [{ memoryId: 'old' }] };
+      const match = {
+        memoryId: 'new',
+        score: 0.85,
+        action: 'superseded' as const,
+        reason: 'change indicator in new memory',
+      };
+      const result = service.annotateContradictor(existing, match, 'summary');
+      expect((result['contradictionMatches'] as unknown[]).length).toBe(2);
+    });
+
+    it('truncates summary to 120 characters', () => {
+      const longSummary = 'a'.repeat(200);
+      const match = { memoryId: 'm1', score: 0.85, action: 'superseded' as const, reason: 'test' };
+      const result = service.annotateContradictor(null, match, longSummary);
+      const entry = (result['contradictionMatches'] as Array<Record<string, unknown>>)[0];
+      expect((entry['summary'] as string).length).toBe(120);
+    });
+  });
+
+  describe('annotateSuperseded()', () => {
+    it('sets status=superseded with audit fields', () => {
+      const result = service.annotateSuperseded(null, 'new-id', 'negation asymmetry');
+      expect(result['status']).toBe('superseded');
+      expect(result['supersededBy']).toBe('new-id');
+      expect(result['supersededReason']).toBe('negation asymmetry');
+      expect(typeof result['supersededAt']).toBe('string');
+    });
+
+    it('merges with existing metadata without clobbering other fields', () => {
+      const meta = { importance: 0.7, tags: ['work'] };
+      const result = service.annotateSuperseded(meta, 'new-id', 'reason');
+      expect(result['importance']).toBe(0.7);
+      expect(result['tags']).toEqual(['work']);
+      expect(result['status']).toBe('superseded');
+    });
+  });
+});

--- a/packages/memory-ltm/src/contradiction-detection.service.ts
+++ b/packages/memory-ltm/src/contradiction-detection.service.ts
@@ -1,0 +1,141 @@
+import { Injectable } from '@nestjs/common';
+import type { ContradictionMatch, ContradictionCandidate } from './types';
+
+export const DEFAULT_CONTRADICTION_THRESHOLD = 0.8;
+export const DEFAULT_CONTRADICTION_THRESHOLD_MAX = 0.97; // below duplicate zone
+
+@Injectable()
+export class ContradictionDetectionService {
+  private readonly thresholdLow: number;
+  private readonly thresholdHigh: number;
+
+  constructor() {
+    this.thresholdLow = this.resolveThreshold(
+      process.env.MEMORY_CONTRADICTION_THRESHOLD,
+      DEFAULT_CONTRADICTION_THRESHOLD
+    );
+    this.thresholdHigh = this.resolveThreshold(
+      process.env.MEMORY_CONTRADICTION_THRESHOLD_MAX,
+      DEFAULT_CONTRADICTION_THRESHOLD_MAX
+    );
+  }
+
+  /**
+   * Find the first candidate that contradicts newContent using heuristics.
+   *
+   * Candidates are filtered to the [thresholdLow, thresholdHigh) similarity
+   * band before heuristic checks run — high similarity ensures shared subject
+   * matter while staying below the duplicate zone.
+   */
+  detect(newContent: string, candidates: ContradictionCandidate[]): ContradictionMatch | null {
+    const inBand = candidates.filter(
+      (c) => c.score >= this.thresholdLow && c.score < this.thresholdHigh
+    );
+
+    for (const candidate of inBand) {
+      const reason = this.checkHeuristics(newContent, candidate.content);
+      if (reason) {
+        return {
+          memoryId: candidate.id,
+          score: candidate.score,
+          action: 'superseded',
+          reason,
+        };
+      }
+    }
+    return null;
+  }
+
+  /** Annotate the new memory's metadata to record the contradiction it introduces. */
+  annotateContradictor(
+    metadata: Record<string, unknown> | null | undefined,
+    match: ContradictionMatch,
+    existingContentSummary: string
+  ): Record<string, unknown> {
+    const next = { ...(metadata ?? {}) };
+    const existing = Array.isArray(next['contradictionMatches'])
+      ? (next['contradictionMatches'] as unknown[])
+      : [];
+    next['contradictionMatches'] = [
+      ...existing,
+      {
+        memoryId: match.memoryId,
+        score: match.score,
+        action: match.action,
+        reason: match.reason,
+        summary: existingContentSummary.slice(0, 120),
+        detectedAt: new Date().toISOString(),
+      },
+    ];
+    return next;
+  }
+
+  /** Annotate the old memory's metadata to record that it was superseded. */
+  annotateSuperseded(
+    metadata: Record<string, unknown> | null | undefined,
+    supersededById: string,
+    reason: string
+  ): Record<string, unknown> {
+    const next = { ...(metadata ?? {}) };
+    next['status'] = 'superseded';
+    next['supersededBy'] = supersededById;
+    next['supersededReason'] = reason;
+    next['supersededAt'] = new Date().toISOString();
+    return next;
+  }
+
+  getLowThreshold(): number {
+    return this.thresholdLow;
+  }
+
+  getHighThreshold(): number {
+    return this.thresholdHigh;
+  }
+
+  private checkHeuristics(newContent: string, existingContent: string): string | null {
+    const newLow = newContent.toLowerCase();
+    const existLow = existingContent.toLowerCase();
+
+    // Negation asymmetry: one side uses negation, the other does not.
+    const negationRe =
+      /\b(not|don't|doesn't|didn't|never|isn't|aren't|won't|can't|cannot|no longer|stopped|quit)\b/i;
+    if (negationRe.test(newLow) !== negationRe.test(existLow)) {
+      return 'negation asymmetry';
+    }
+
+    // Change indicators: new memory signals an update superseding prior state.
+    const changeRe =
+      /\b(changed|now I|actually|instead|rather|switched|moved|no longer|updated|revised)\b/i;
+    if (changeRe.test(newLow) && !changeRe.test(existLow)) {
+      return 'change indicator in new memory';
+    }
+
+    // Polar-opposite word pairs within otherwise similar content.
+    const polarPairs: Array<[string, string]> = [
+      ['like', 'dislike'],
+      ['prefer', 'avoid'],
+      ['love', 'hate'],
+      ['always', 'never'],
+      ['agree', 'disagree'],
+      ['correct', 'incorrect'],
+      ['true', 'false'],
+    ];
+    for (const [a, b] of polarPairs) {
+      const newA = new RegExp(`\\b${a}\\b`, 'i').test(newLow);
+      const newB = new RegExp(`\\b${b}\\b`, 'i').test(newLow);
+      const exA = new RegExp(`\\b${a}\\b`, 'i').test(existLow);
+      const exB = new RegExp(`\\b${b}\\b`, 'i').test(existLow);
+      if ((newA && exB) || (newB && exA)) {
+        return `polar opposite: ${a}/${b}`;
+      }
+    }
+
+    return null;
+  }
+
+  private resolveThreshold(raw: string | undefined, fallback: number): number {
+    if (!raw) return fallback;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 && parsed <= 1 ? parsed : fallback;
+  }
+}

--- a/packages/memory-ltm/src/index.ts
+++ b/packages/memory-ltm/src/index.ts
@@ -3,6 +3,7 @@ export { MemoryLtmService } from './memory-ltm.service';
 export { MemoryLtmModule } from './memory-ltm.module';
 export { ImportanceScoringService } from './importance.service';
 export { DuplicateDetectionService } from './duplicate-detection.service';
+export { ContradictionDetectionService } from './contradiction-detection.service';
 
 // Stream B0 — Typed Ingest Pipeline
 export { IngestPipelineService } from './ingest/ingest-pipeline.service';
@@ -26,6 +27,9 @@ export type {
   ImportanceSignals,
   ImportanceScoreResult,
   DuplicateDetectionMatch,
+  ContradictionMatch,
+  ContradictionCandidate,
+  ContradictionAction,
   DecayPolicyOptions,
   DecayPolicyResult,
   CreateLtmMemoryValidated,

--- a/packages/memory-ltm/src/memory-ltm.module.ts
+++ b/packages/memory-ltm/src/memory-ltm.module.ts
@@ -5,6 +5,7 @@ import { VectorStoreModule } from '@engram/vector-store';
 import { MemoryLtmService } from './memory-ltm.service.js';
 import { ImportanceScoringService } from './importance.service.js';
 import { DuplicateDetectionService } from './duplicate-detection.service.js';
+import { ContradictionDetectionService } from './contradiction-detection.service.js';
 import { IngestPipelineService } from './ingest/ingest-pipeline.service.js';
 import { PrivacyFilterStep } from './ingest/privacy-filter.step.js';
 import { TopicDetectorStep } from './ingest/topic-detector.step.js';
@@ -15,6 +16,7 @@ import { TopicDetectorStep } from './ingest/topic-detector.step.js';
     MemoryLtmService,
     ImportanceScoringService,
     DuplicateDetectionService,
+    ContradictionDetectionService,
     IngestPipelineService,
     PrivacyFilterStep,
     TopicDetectorStep,
@@ -23,6 +25,7 @@ import { TopicDetectorStep } from './ingest/topic-detector.step.js';
     MemoryLtmService,
     ImportanceScoringService,
     DuplicateDetectionService,
+    ContradictionDetectionService,
     IngestPipelineService,
   ],
 })

--- a/packages/memory-ltm/src/memory-ltm.service.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.spec.ts
@@ -1066,14 +1066,14 @@ describe('MemoryLtmService', () => {
         prismaService.memory.findFirst
           .mockResolvedValueOnce(null)
           // findRawMemory for annotateContradictor
+          .mockResolvedValueOnce(oldMemory)
+          // findRawMemory inside markSuperseded
           .mockResolvedValueOnce(oldMemory);
         // candidate content fetch
         prismaService.memory.findMany.mockResolvedValue([
           { id: oldMemoryId, content: oldMemory.content },
         ]);
         prismaService.memory.create.mockResolvedValue(newMemory);
-        // markSuperseded: findUnique + update
-        prismaService.memory.findUnique = vi.fn().mockResolvedValue(oldMemory);
         prismaService.memory.update.mockResolvedValue(oldMemory);
 
         return new MemoryLtmService(
@@ -1119,7 +1119,7 @@ describe('MemoryLtmService', () => {
 
         expect(prismaService.memory.update).toHaveBeenCalledWith(
           expect.objectContaining({
-            where: { id: oldMemoryId },
+            where: expect.objectContaining({ id: oldMemoryId }),
             data: expect.objectContaining({
               metadata: expect.objectContaining({
                 status: 'superseded',
@@ -1152,7 +1152,6 @@ describe('MemoryLtmService', () => {
           { id: oldMemoryId, content: 'I use Python daily' },
         ]);
         prismaService.memory.create.mockResolvedValue(newMemory);
-        prismaService.memory.findUnique = vi.fn();
 
         const svc = new MemoryLtmService(
           prismaService as never,
@@ -1169,12 +1168,12 @@ describe('MemoryLtmService', () => {
 
         const createCall = prismaService.memory.create.mock.calls[0][0];
         expect(createCall.data.metadata).not.toHaveProperty('contradictionMatches');
-        expect(prismaService.memory.findUnique).not.toHaveBeenCalled();
+        expect(prismaService.memory.update).not.toHaveBeenCalled();
       });
 
       it('creates memory successfully when markSuperseded fails (non-fatal)', async () => {
         const svc = buildContradictionService();
-        prismaService.memory.findUnique = vi.fn().mockRejectedValue(new Error('DB error'));
+        prismaService.memory.update.mockRejectedValueOnce(new Error('DB error'));
 
         await expect(
           svc.create({ userId: mockUserId, content: "I don't like Python" })
@@ -1198,9 +1197,8 @@ describe('MemoryLtmService', () => {
         prismaService.memory.count.mockResolvedValue(0);
         prismaService.memory.findFirst.mockResolvedValueOnce(null);
         prismaService.memory.create.mockResolvedValue(newMemory);
-        // no contradiction service → findMany and findUnique should not be called
+        // no contradiction service → findMany and markSuperseded (update) should not be called
         prismaService.memory.findMany.mockResolvedValue([]);
-        prismaService.memory.findUnique = vi.fn();
 
         const svc = new MemoryLtmService(
           prismaService as never,
@@ -1215,7 +1213,7 @@ describe('MemoryLtmService', () => {
         await svc.create({ userId: mockUserId, content: "I don't like Python" });
 
         expect(prismaService.memory.findMany).not.toHaveBeenCalled();
-        expect(prismaService.memory.findUnique).not.toHaveBeenCalled();
+        expect(prismaService.memory.update).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/memory-ltm/src/memory-ltm.service.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.spec.ts
@@ -10,6 +10,7 @@ import {
 import { MemoryType } from '@engram/database';
 import { ImportanceScoringService } from './importance.service';
 import { DuplicateDetectionService } from './duplicate-detection.service';
+import { ContradictionDetectionService } from './contradiction-detection.service';
 import { IngestPipelineService } from './ingest/ingest-pipeline.service.js';
 import { PrivacyFilterStep } from './ingest/privacy-filter.step.js';
 import { TopicDetectorStep } from './ingest/topic-detector.step.js';
@@ -1032,6 +1033,190 @@ describe('MemoryLtmService', () => {
       await serviceWithDuplicate.promote(mockUserId, mockMemoryId);
 
       expect(stmService.delete).toHaveBeenCalledWith(mockUserId, mockMemoryId, undefined);
+    });
+
+    describe('contradiction detection in create()', () => {
+      const oldMemoryId = 'cldx4k8xp000308l84b5c9x4s';
+      const oldMemory = {
+        ...mockMemory,
+        id: oldMemoryId,
+        content: 'I like Python',
+        metadata: { importance: 0.5 },
+      };
+      const newMemory = { ...mockMemory, content: "I don't like Python" };
+
+      function buildContradictionService(): MemoryLtmService {
+        const importanceService = new ImportanceScoringService();
+        const duplicateService = new DuplicateDetectionService();
+        const contradictionService = new ContradictionDetectionService();
+        const vectorStore = {
+          backend: 'qdrant' as const,
+          upsert: vi.fn(),
+          delete: vi.fn(),
+          ensureReady: vi.fn(),
+          // First call: duplicate check (score 0.85 < 0.97 → no duplicate)
+          // Second call: contradiction check (same hit, 0.85 is in band)
+          search: vi.fn().mockResolvedValue([{ id: oldMemoryId, score: 0.85 }]),
+        };
+        const embeddingsService = {
+          generate: vi.fn().mockResolvedValue({ embedding: [0.1, 0.2, 0.3] }),
+        };
+        prismaService.memory.count.mockResolvedValue(0);
+        // exact-dup check → miss
+        prismaService.memory.findFirst
+          .mockResolvedValueOnce(null)
+          // findRawMemory for annotateContradictor
+          .mockResolvedValueOnce(oldMemory);
+        // candidate content fetch
+        prismaService.memory.findMany.mockResolvedValue([
+          { id: oldMemoryId, content: oldMemory.content },
+        ]);
+        prismaService.memory.create.mockResolvedValue(newMemory);
+        // markSuperseded: findUnique + update
+        prismaService.memory.findUnique = vi.fn().mockResolvedValue(oldMemory);
+        prismaService.memory.update.mockResolvedValue(oldMemory);
+
+        return new MemoryLtmService(
+          prismaService as never,
+          stmService as never,
+          embeddingsService as never,
+          vectorStore as never,
+          importanceService as never,
+          duplicateService as never,
+          undefined,
+          contradictionService as never
+        );
+      }
+
+      it('annotates new memory with contradictionMatches when contradiction is detected', async () => {
+        const svc = buildContradictionService();
+        const result = await svc.create({
+          userId: mockUserId,
+          content: "I don't like Python",
+        });
+
+        expect(prismaService.memory.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              metadata: expect.objectContaining({
+                contradictionMatches: expect.arrayContaining([
+                  expect.objectContaining({
+                    memoryId: oldMemoryId,
+                    action: 'superseded',
+                    reason: 'negation asymmetry',
+                  }),
+                ]),
+              }),
+            }),
+          })
+        );
+        expect(result.id).toBe(newMemory.id);
+      });
+
+      it('marks the older memory as superseded after the new memory is written', async () => {
+        const svc = buildContradictionService();
+        await svc.create({ userId: mockUserId, content: "I don't like Python" });
+
+        expect(prismaService.memory.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { id: oldMemoryId },
+            data: expect.objectContaining({
+              metadata: expect.objectContaining({
+                status: 'superseded',
+                supersededBy: newMemory.id,
+                supersededReason: 'negation asymmetry',
+              }),
+            }),
+          })
+        );
+      });
+
+      it('creates memory normally when no contradiction is found', async () => {
+        const importanceService = new ImportanceScoringService();
+        const duplicateService = new DuplicateDetectionService();
+        const contradictionService = new ContradictionDetectionService();
+        const vectorStore = {
+          backend: 'qdrant' as const,
+          upsert: vi.fn(),
+          delete: vi.fn(),
+          ensureReady: vi.fn(),
+          search: vi.fn().mockResolvedValue([{ id: oldMemoryId, score: 0.85 }]),
+        };
+        const embeddingsService = {
+          generate: vi.fn().mockResolvedValue({ embedding: [0.1, 0.2, 0.3] }),
+        };
+        prismaService.memory.count.mockResolvedValue(0);
+        prismaService.memory.findFirst.mockResolvedValueOnce(null);
+        // No heuristic match: old content also has no negation
+        prismaService.memory.findMany.mockResolvedValue([
+          { id: oldMemoryId, content: 'I use Python daily' },
+        ]);
+        prismaService.memory.create.mockResolvedValue(newMemory);
+        prismaService.memory.findUnique = vi.fn();
+
+        const svc = new MemoryLtmService(
+          prismaService as never,
+          stmService as never,
+          embeddingsService as never,
+          vectorStore as never,
+          importanceService as never,
+          duplicateService as never,
+          undefined,
+          contradictionService as never
+        );
+
+        await svc.create({ userId: mockUserId, content: 'I enjoy Python for scripting' });
+
+        const createCall = prismaService.memory.create.mock.calls[0][0];
+        expect(createCall.data.metadata).not.toHaveProperty('contradictionMatches');
+        expect(prismaService.memory.findUnique).not.toHaveBeenCalled();
+      });
+
+      it('creates memory successfully when markSuperseded fails (non-fatal)', async () => {
+        const svc = buildContradictionService();
+        prismaService.memory.findUnique = vi.fn().mockRejectedValue(new Error('DB error'));
+
+        await expect(
+          svc.create({ userId: mockUserId, content: "I don't like Python" })
+        ).resolves.not.toThrow();
+        expect(prismaService.memory.create).toHaveBeenCalled();
+      });
+
+      it('skips contradiction detection when service is not injected', async () => {
+        const importanceService = new ImportanceScoringService();
+        const duplicateService = new DuplicateDetectionService();
+        const vectorStore = {
+          backend: 'qdrant' as const,
+          upsert: vi.fn(),
+          delete: vi.fn(),
+          ensureReady: vi.fn(),
+          search: vi.fn().mockResolvedValue([{ id: oldMemoryId, score: 0.85 }]),
+        };
+        const embeddingsService = {
+          generate: vi.fn().mockResolvedValue({ embedding: [0.1, 0.2, 0.3] }),
+        };
+        prismaService.memory.count.mockResolvedValue(0);
+        prismaService.memory.findFirst.mockResolvedValueOnce(null);
+        prismaService.memory.create.mockResolvedValue(newMemory);
+        // no contradiction service → findMany and findUnique should not be called
+        prismaService.memory.findMany.mockResolvedValue([]);
+        prismaService.memory.findUnique = vi.fn();
+
+        const svc = new MemoryLtmService(
+          prismaService as never,
+          stmService as never,
+          embeddingsService as never,
+          vectorStore as never,
+          importanceService as never,
+          duplicateService as never
+          // contradictionDetectionService omitted
+        );
+
+        await svc.create({ userId: mockUserId, content: "I don't like Python" });
+
+        expect(prismaService.memory.findMany).not.toHaveBeenCalled();
+        expect(prismaService.memory.findUnique).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/memory-ltm/src/memory-ltm.service.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.ts
@@ -202,11 +202,16 @@ export class MemoryLtmService {
 
       // ── Step B1 (post-write): mark superseded memory (non-fatal) ───────
       if (contradiction) {
-        await this.markSuperseded(contradiction.memoryId, ltmMemory.id, contradiction.reason).catch(
-          (err: unknown) =>
-            this.logger.warn(
-              `Failed to mark memory ${contradiction.memoryId} as superseded: ${err instanceof Error ? err.message : String(err)}`
-            )
+        await this.markSuperseded(
+          contradiction.memoryId,
+          ltmMemory.id,
+          contradiction.reason,
+          validatedInput.userId,
+          validatedInput.organizationId
+        ).catch((err: unknown) =>
+          this.logger.warn(
+            `Failed to mark memory ${contradiction.memoryId} as superseded: ${err instanceof Error ? err.message : String(err)}`
+          )
         );
       }
 
@@ -1203,11 +1208,20 @@ export class MemoryLtmService {
     );
     if (hits.length === 0) return null;
 
-    // Fetch content for all hit candidates in one query.
+    // Fetch content for all hit candidates in one query, scoped to the same
+    // tenant so a vector-store misconfiguration cannot surface foreign rows.
     const hitIds = hits.map((h) => h.id);
+    const contentWhere: Record<string, unknown> = {
+      id: { in: hitIds },
+      userId,
+      type: MemoryType.LONG_TERM,
+    };
+    if (organizationId !== undefined) {
+      contentWhere.organizationId = organizationId;
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rows: { id: string; content: string }[] = await (this.prisma as any).memory.findMany({
-      where: { id: { in: hitIds } },
+      where: contentWhere,
       select: { id: true, content: true },
     });
     const contentMap = new Map(rows.map((r) => [r.id, r.content]));
@@ -1222,22 +1236,28 @@ export class MemoryLtmService {
   private async markSuperseded(
     memoryId: string,
     supersededById: string,
-    reason: string
+    reason: string,
+    userId: string,
+    organizationId: string | undefined
   ): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const existing = await (this.prisma as any).memory.findUnique({
-      where: { id: memoryId },
-      select: { metadata: true },
-    });
+    const existing = await this.findRawMemory(userId, memoryId, organizationId);
     if (!existing) return;
     const updatedMeta = this.contradictionDetectionService!.annotateSuperseded(
       existing.metadata as Record<string, unknown> | null,
       supersededById,
       reason
     );
+    const updateWhere: Record<string, unknown> = {
+      id: memoryId,
+      userId,
+      type: MemoryType.LONG_TERM,
+    };
+    if (organizationId !== undefined) {
+      updateWhere.organizationId = organizationId;
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (this.prisma as any).memory.update({
-      where: { id: memoryId },
+      where: updateWhere,
       data: { metadata: updatedMeta },
     });
     this.logger.debug(`Memory ${memoryId} marked superseded by ${supersededById}`);

--- a/packages/memory-ltm/src/memory-ltm.service.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.ts
@@ -7,6 +7,7 @@ import { VECTOR_STORE_TOKEN, type VectorStore, type VectorPayload } from '@engra
 import { rankResults, DEFAULT_RANKING_WEIGHTS, type RankingWeights } from './rank';
 import { ImportanceScoringService } from './importance.service';
 import { DuplicateDetectionService } from './duplicate-detection.service';
+import { ContradictionDetectionService } from './contradiction-detection.service';
 import { IngestPipelineService } from './ingest/ingest-pipeline.service.js';
 import { buildIngestContext } from './ingest/types.js';
 import {
@@ -27,6 +28,8 @@ import {
   DecayPolicyOptions,
   DecayPolicyResult,
   DuplicateDetectionMatch,
+  ContradictionMatch,
+  ContradictionCandidate,
   validateCreateLtmMemory,
   validateUpdateLtmMemory,
   validateLtmQueryOptions,
@@ -61,7 +64,8 @@ export class MemoryLtmService {
     private readonly vectorStore?: VectorStore,
     @Optional() private readonly importanceService?: ImportanceScoringService,
     @Optional() private readonly duplicateDetectionService?: DuplicateDetectionService,
-    @Optional() private readonly ingestPipeline?: IngestPipelineService
+    @Optional() private readonly ingestPipeline?: IngestPipelineService,
+    @Optional() private readonly contradictionDetectionService?: ContradictionDetectionService
   ) {
     this.config = { ...DEFAULT_LTM_CONFIG };
     // Use prisma to avoid unused variable warning
@@ -145,10 +149,34 @@ export class MemoryLtmService {
         );
       }
 
+      // ── Step B1: contradiction detection ──────────────────────────────
+      const contradiction = await this.findContradictionCandidate(
+        validatedInput.userId,
+        validatedInput.organizationId,
+        processedContent,
+        embedding
+      );
+
       // ── Step 5: ImportanceScorer (inline annotation) ───────────────────
-      const metadata = this.annotateImportance(processedMetadata, {
+      let contradictionAnnotatedMeta = processedMetadata;
+      if (contradiction) {
+        const existingRow = await this.findRawMemory(
+          validatedInput.userId,
+          contradiction.memoryId,
+          validatedInput.organizationId
+        );
+        if (existingRow) {
+          contradictionAnnotatedMeta = this.contradictionDetectionService!.annotateContradictor(
+            processedMetadata,
+            contradiction,
+            existingRow.content.slice(0, 120)
+          );
+        }
+      }
+
+      const metadata = this.annotateImportance(contradictionAnnotatedMeta, {
         content: processedContent,
-        metadata: processedMetadata,
+        metadata: contradictionAnnotatedMeta,
         tags: processedTags,
         accessCount: 0,
       });
@@ -171,6 +199,16 @@ export class MemoryLtmService {
 
       this.logger.debug(`LTM memory created: ${memory.id}`);
       const ltmMemory = this.mapToLtmMemory(memory);
+
+      // ── Step B1 (post-write): mark superseded memory (non-fatal) ───────
+      if (contradiction) {
+        await this.markSuperseded(contradiction.memoryId, ltmMemory.id, contradiction.reason).catch(
+          (err: unknown) =>
+            this.logger.warn(
+              `Failed to mark memory ${contradiction.memoryId} as superseded: ${err instanceof Error ? err.message : String(err)}`
+            )
+        );
+      }
 
       // ── Step 12: SearchIndexUpdate (non-fatal) ─────────────────────────
       await this.indexVector(ltmMemory, embedding);
@@ -1147,6 +1185,62 @@ export class MemoryLtmService {
       3
     );
     return this.duplicateDetectionService.findMatch(hits);
+  }
+
+  private async findContradictionCandidate(
+    userId: string,
+    organizationId: string | undefined,
+    content: string,
+    embedding: number[]
+  ): Promise<ContradictionMatch | null> {
+    if (!this.vectorStore || !this.contradictionDetectionService || embedding.length === 0) {
+      return null;
+    }
+    const hits = await this.vectorStore.search(
+      embedding,
+      { userId, organizationId, type: MemoryType.LONG_TERM },
+      5
+    );
+    if (hits.length === 0) return null;
+
+    // Fetch content for all hit candidates in one query.
+    const hitIds = hits.map((h) => h.id);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows: { id: string; content: string }[] = await (this.prisma as any).memory.findMany({
+      where: { id: { in: hitIds } },
+      select: { id: true, content: true },
+    });
+    const contentMap = new Map(rows.map((r) => [r.id, r.content]));
+
+    const candidates: ContradictionCandidate[] = hits
+      .filter((h) => contentMap.has(h.id))
+      .map((h) => ({ id: h.id, score: h.score, content: contentMap.get(h.id)! }));
+
+    return this.contradictionDetectionService.detect(content, candidates);
+  }
+
+  private async markSuperseded(
+    memoryId: string,
+    supersededById: string,
+    reason: string
+  ): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const existing = await (this.prisma as any).memory.findUnique({
+      where: { id: memoryId },
+      select: { metadata: true },
+    });
+    if (!existing) return;
+    const updatedMeta = this.contradictionDetectionService!.annotateSuperseded(
+      existing.metadata as Record<string, unknown> | null,
+      supersededById,
+      reason
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (this.prisma as any).memory.update({
+      where: { id: memoryId },
+      data: { metadata: updatedMeta },
+    });
+    this.logger.debug(`Memory ${memoryId} marked superseded by ${supersededById}`);
   }
 
   private async linkDuplicateAndReturn(

--- a/packages/memory-ltm/src/types.ts
+++ b/packages/memory-ltm/src/types.ts
@@ -154,6 +154,21 @@ export interface DuplicateDetectionMatch {
   score: number;
 }
 
+export type ContradictionAction = 'superseded' | 'flagged';
+
+export interface ContradictionMatch {
+  memoryId: string;
+  score: number;
+  action: ContradictionAction;
+  reason: string;
+}
+
+export interface ContradictionCandidate {
+  id: string;
+  score: number;
+  content: string;
+}
+
 export interface DecayPolicyOptions {
   userId?: string;
   batchSize?: number;


### PR DESCRIPTION
## Summary

- Adds `ContradictionDetectionService` with heuristic-based detection: negation asymmetry, change indicators, and polar-opposite word pairs
- Wires into `MemoryLtmService.create()` — when a contradiction is detected the new memory gets a `contradictionMatches` audit trail in metadata; the older memory is marked `status: superseded` with `supersededBy`/`supersededReason`/`supersededAt`
- Similarity band is configurable via `MEMORY_CONTRADICTION_THRESHOLD` (default 0.80) and `MEMORY_CONTRADICTION_THRESHOLD_MAX` (default 0.97, to stay below the duplicate zone)
- No schema migration needed — audit trail stored in JSONB `metadata`, following the same pattern as `duplicateMatches`

## Test plan

- [x] 26 unit tests in `contradiction-detection.service.spec.ts` covering: empty candidates, below-band / above-band filtering, each heuristic (negation asymmetry, change indicators, polar pairs), `annotateContradictor`, `annotateSuperseded`
- [x] Pre-existing importance/ingest/pipeline tests still pass (no regressions)
- [ ] Integration test with real vector store (requires running services — not wired in this PR)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)