### PR TITLE
feat(memory): scoping/namespaces for agent/session/project isolation (#124)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -48,7 +48,8 @@
       "Skill(run:*)",
       "Read(//home/qp/.claude/**)",
       "Bash(node --env-file=.env apps/mcp-server/dist/main.js)",
-      "Bash(echo \"PID: $!\")"
+      "Bash(echo \"PID: $!\")",
+      "Bash(gh repo *)"
     ],
     "deny": [],
     "ask": []

--- a/apps/mcp-server/src/memory/dto/context.dto.ts
+++ b/apps/mcp-server/src/memory/dto/context.dto.ts
@@ -80,3 +80,47 @@ export const loadContextToolSchema = z
   .strict();
 
 export type LoadContextToolInput = z.infer<typeof loadContextToolSchema>;
+
+/**
+ * Input schema for the `prompt_context` MCP tool.
+ *
+ * Assembles a token-budgeted, ranked context block from the most relevant
+ * long-term memories for a query. Uses ~4 chars/token heuristic (conservative
+ * for ASCII; may under-count for CJK/emoji content).
+ */
+export const promptContextToolSchema = z
+  .object({
+    userId: userIdSchema,
+    /** Natural-language query used to rank and retrieve relevant memories */
+    query: z
+      .string()
+      .min(1, 'Query cannot be empty')
+      .max(2048, 'Query cannot exceed 2048 characters'),
+    /**
+     * Maximum token budget for the assembled context block.
+     * ~4 chars/token (conservative for ASCII; may under-count for CJK/emoji).
+     * Default 2000 tokens (~8000 chars). Max 32000 tokens.
+     */
+    tokenBudget: z.coerce
+      .number()
+      .int()
+      .min(100)
+      .max(32000)
+      .optional()
+      .default(2000),
+    /** Maximum memories to retrieve before filtering and ranking (default 20, max 50) */
+    limit: z.coerce.number().int().min(1).max(50).optional().default(20),
+    /** Minimum similarity score [0–1] to include a memory (default 0.5) */
+    minScore: z.coerce.number().min(0).max(1).optional().default(0.5),
+    /** Optional scope filter */
+    scope: z.string().max(256).optional(),
+    /** Optional tag filter */
+    tags: z.array(z.string()).max(20).optional(),
+    /** Only include memories created on or after this date (ISO 8601) */
+    createdFrom: z.coerce.date().optional(),
+    /** Only include memories created on or before this date (ISO 8601) */
+    createdTo: z.coerce.date().optional(),
+  })
+  .strict();
+
+export type PromptContextToolInput = z.infer<typeof promptContextToolSchema>;

--- a/apps/mcp-server/src/memory/dto/create-memory.dto.ts
+++ b/apps/mcp-server/src/memory/dto/create-memory.dto.ts
@@ -8,6 +8,7 @@ export const createMemoryToolSchema = z.object({
     .min(1, 'Content cannot be empty')
     .max(10240, 'Content cannot exceed 10KB'),
   type: z.enum(['short-term', 'long-term']),
+  scope: z.string().min(1).max(256).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
   tags: z.array(z.string().min(1).max(100)).max(50).optional().default([]),
   ttl: z.coerce.number().int().min(60).max(604800).optional(),

--- a/apps/mcp-server/src/memory/dto/forget.dto.ts
+++ b/apps/mcp-server/src/memory/dto/forget.dto.ts
@@ -28,6 +28,11 @@ export const forgetToolSchema = z
     confirm: z.boolean().optional().default(false),
     /** Minimum similarity score [0–1] for a memory to be considered a match */
     minScore: z.coerce.number().min(0).max(1).optional().default(0.6),
+    /**
+     * Optional namespace; when set, only memories in this scope are searched
+     * and deleted, so a scoped caller cannot forget another scope's memories.
+     */
+    scope: z.string().min(1).max(256).optional(),
   })
   .strict();
 

--- a/apps/mcp-server/src/memory/dto/get-memory.dto.ts
+++ b/apps/mcp-server/src/memory/dto/get-memory.dto.ts
@@ -1,9 +1,13 @@
 import { memoryIdSchema, userIdSchema } from '@engram/database';
 import { z } from 'zod';
 
-export const getMemoryToolSchema = z.object({
-  userId: userIdSchema,
-  memoryId: memoryIdSchema,
-});
+export const getMemoryToolSchema = z
+  .object({
+    userId: userIdSchema,
+    memoryId: memoryIdSchema,
+    /** Optional namespace; when set, the memory is only returned if it lives in this scope. */
+    scope: z.string().min(1).max(256).optional(),
+  })
+  .strict();
 
 export type GetMemoryToolInput = z.infer<typeof getMemoryToolSchema>;

--- a/apps/mcp-server/src/memory/dto/list-memories.dto.ts
+++ b/apps/mcp-server/src/memory/dto/list-memories.dto.ts
@@ -6,6 +6,7 @@ export const listMemoriesToolSchema = z.object({
   type: z.enum(['short-term', 'long-term']).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional().default(20),
   cursor: cursorIdSchema.optional(),
+  scope: z.string().min(1).max(256).optional(),
   tags: z.array(z.string()).optional(),
   search: z.string().max(500).optional(),
 });

--- a/apps/mcp-server/src/memory/dto/remember.dto.ts
+++ b/apps/mcp-server/src/memory/dto/remember.dto.ts
@@ -25,6 +25,8 @@ export const rememberToolSchema = z
       .enum(['auto', 'short-term', 'long-term'])
       .optional()
       .default('auto'),
+    /** Optional namespace for agent/session/project isolation */
+    scope: z.string().min(1).max(256).optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
     tags: z.array(z.string().min(1).max(100)).max(50).optional().default([]),
     /** TTL in seconds; only used when type is 'short-term' or 'auto' routes to STM */

--- a/apps/mcp-server/src/memory/dto/update-memory.dto.ts
+++ b/apps/mcp-server/src/memory/dto/update-memory.dto.ts
@@ -1,17 +1,24 @@
 import { memoryIdSchema, userIdSchema } from '@engram/database';
 import { z } from 'zod';
 
-export const updateMemoryToolSchema = z.object({
-  userId: userIdSchema,
-  memoryId: memoryIdSchema,
-  content: z
-    .string()
-    .min(1, 'Content cannot be empty')
-    .max(10240, 'Content cannot exceed 10KB')
-    .optional(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
-  tags: z.array(z.string().min(1).max(100)).max(50).optional(),
-  ttl: z.coerce.number().int().min(60).max(604800).optional(),
-});
+export const updateMemoryToolSchema = z
+  .object({
+    userId: userIdSchema,
+    memoryId: memoryIdSchema,
+    content: z
+      .string()
+      .min(1, 'Content cannot be empty')
+      .max(10240, 'Content cannot exceed 10KB')
+      .optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+    tags: z.array(z.string().min(1).max(100)).max(50).optional(),
+    ttl: z.coerce.number().int().min(60).max(604800).optional(),
+    /**
+     * Optional namespace used to locate the memory. Scope is immutable, so this
+     * filters which memory is updated rather than changing its scope.
+     */
+    scope: z.string().min(1).max(256).optional(),
+  })
+  .strict();
 
 export type UpdateMemoryToolInput = z.infer<typeof updateMemoryToolSchema>;

--- a/apps/mcp-server/src/memory/memory.c1.controller.spec.ts
+++ b/apps/mcp-server/src/memory/memory.c1.controller.spec.ts
@@ -62,8 +62,8 @@ describe('MemoryController — C1 High-Level Agent UX Tools', () => {
     controller = module.get<MemoryController>(MemoryController);
   });
 
-  it('should expose 19 MCP tools', () => {
-    expect(controller.getMcpTools()).toHaveLength(19);
+  it('should expose 20 MCP tools', () => {
+    expect(controller.getMcpTools()).toHaveLength(20);
   });
 
   // ─── remember ───────────────────────────────────────────────────────────────

--- a/apps/mcp-server/src/memory/memory.c1.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.c1.service.spec.ts
@@ -236,6 +236,50 @@ describe('MemoryService — C1 High-Level Agent UX Methods', () => {
       expect(result.candidates).toHaveLength(1);
       expect(result.candidates[0]!.memoryId).toBe('clm2222222222222222222222');
     });
+
+    it('confines both the search and the deletions to the provided scope', async () => {
+      const mem1 = makeMemory({
+        id: 'clm2222222222222222222222',
+        content: 'scoped secret',
+        scope: 'agent:alpha',
+      });
+      ltmService.semanticSearch.mockResolvedValue([
+        { memory: mem1, score: 0.95 },
+      ]);
+      mockStmService.delete.mockRejectedValue(
+        new StmMemoryNotFoundError('clm2222222222222222222222'),
+      );
+      mockLtmService.delete.mockResolvedValue(true);
+
+      await service.forget({
+        userId: USER_ID,
+        query: 'secret',
+        limit: 5,
+        confirm: true,
+        minScore: 0.7,
+        scope: 'agent:alpha',
+      });
+
+      // The semantic search is scoped to the caller's namespace…
+      expect(ltmService.semanticSearch).toHaveBeenCalledWith(
+        USER_ID,
+        'secret',
+        expect.objectContaining({ scope: 'agent:alpha' }),
+      );
+      // …and the deletion carries that scope through to both stores.
+      expect(mockStmService.delete).toHaveBeenCalledWith(
+        USER_ID,
+        'clm2222222222222222222222',
+        undefined,
+        'agent:alpha',
+      );
+      expect(mockLtmService.delete).toHaveBeenCalledWith(
+        USER_ID,
+        'clm2222222222222222222222',
+        undefined,
+        'agent:alpha',
+      );
+    });
   });
 
   // ─── reflect ────────────────────────────────────────────────────────────────

--- a/apps/mcp-server/src/memory/memory.c1.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.c1.service.spec.ts
@@ -3,6 +3,7 @@ import { MemoryService } from './memory.service';
 import { MemoryStmService, StmMemoryNotFoundError } from '@engram/memory-stm';
 import { MemoryLtmService, ImportanceScoringService } from '@engram/memory-ltm';
 import type { LtmMemory } from '@engram/memory-ltm';
+import type { Memory } from '@engram/database';
 
 const USER_ID = 'clm0000000000000000000000';
 const MEM_ID = 'clm1111111111111111111111';
@@ -422,6 +423,155 @@ describe('MemoryService — C1 High-Level Agent UX Methods', () => {
       expect(result.context).toBe('(no memories)');
     });
   });
+
+  // ─── assemblePromptContext ───────────────────────────────────────────────────
+
+  describe('assemblePromptContext', () => {
+    it('returns formatted context block within token budget', async () => {
+      ltmService.semanticSearch.mockResolvedValue([
+        {
+          memory: makeMemory({
+            id: MEM_ID,
+            content: 'Use Redis for caching',
+            tags: ['infra'],
+          }),
+          score: 0.85,
+        },
+      ]);
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'caching strategy',
+        tokenBudget: 2000,
+        limit: 20,
+        minScore: 0.5,
+      });
+
+      expect(result.memoryCount).toBe(1);
+      expect(result.context).toContain('Use Redis for caching');
+      expect(result.estimatedTokens).toBeGreaterThan(0);
+      expect(result.estimatedTokens).toBeLessThanOrEqual(result.tokenBudget);
+      expect(result.tokenBudget).toBe(2000);
+      expect(result.truncated).toBe(false);
+      expect(result.candidatesFound).toBe(1);
+    });
+
+    it('returns empty context block when no memories pass minScore', async () => {
+      ltmService.semanticSearch.mockResolvedValue([
+        { memory: makeMemory({ id: MEM_ID }), score: 0.3 },
+      ]);
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'obscure topic',
+        tokenBudget: 2000,
+        limit: 20,
+        minScore: 0.5,
+      });
+
+      expect(result.memoryCount).toBe(0);
+      expect(result.context).toBe('(no memories)');
+      expect(result.truncated).toBe(false);
+      expect(result.candidatesFound).toBe(1);
+    });
+
+    it('truncates when memories exceed the token budget', async () => {
+      const longContent = 'x'.repeat(400); // ~100 tokens per entry
+      ltmService.semanticSearch.mockResolvedValue(
+        Array.from({ length: 10 }, (_, i) => ({
+          memory: makeMemory({ id: MEM_ID, content: longContent + String(i) }),
+          score: 0.9,
+        })),
+      );
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'anything',
+        tokenBudget: 200,
+        limit: 10,
+        minScore: 0.5,
+      });
+
+      expect(result.truncated).toBe(true);
+      expect(result.estimatedTokens).toBeLessThanOrEqual(result.tokenBudget);
+      expect(result.memoryCount).toBeGreaterThan(0);
+    });
+
+    it('enforces budget even for a single oversized memory', async () => {
+      const hugContent = 'y'.repeat(20000); // ~5000 tokens
+      ltmService.semanticSearch.mockResolvedValue([
+        { memory: makeMemory({ id: MEM_ID, content: hugContent }), score: 0.9 },
+      ]);
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'big memory',
+        tokenBudget: 300,
+        limit: 5,
+        minScore: 0.5,
+      });
+
+      expect(result.estimatedTokens).toBeLessThanOrEqual(result.tokenBudget);
+      expect(result.truncated).toBe(true);
+      expect(result.memoryCount).toBe(1);
+    });
+
+    it('passes scope through to semanticSearch', async () => {
+      ltmService.semanticSearch.mockResolvedValue([]);
+
+      await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'scoped query',
+        tokenBudget: 500,
+        limit: 10,
+        minScore: 0.5,
+        scope: 'project-x',
+      });
+
+      expect(ltmService.semanticSearch).toHaveBeenCalledWith(
+        USER_ID,
+        'scoped query',
+        expect.objectContaining({ scope: 'project-x' }),
+      );
+    });
+
+    it('echoes tokenBudget in result and reports candidatesFound=0 when no hits', async () => {
+      ltmService.semanticSearch.mockResolvedValue([]);
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'test',
+        tokenBudget: 750,
+        limit: 5,
+        minScore: 0.5,
+      });
+
+      expect(result.tokenBudget).toBe(750);
+      expect(result.candidatesFound).toBe(0);
+    });
+
+    it('passes createdFrom and createdTo through to semanticSearch', async () => {
+      ltmService.semanticSearch.mockResolvedValue([]);
+      const from = new Date('2025-01-01');
+      const to = new Date('2025-06-30');
+
+      await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'date-filtered query',
+        tokenBudget: 500,
+        limit: 10,
+        minScore: 0.5,
+        createdFrom: from,
+        createdTo: to,
+      });
+
+      expect(ltmService.semanticSearch).toHaveBeenCalledWith(
+        USER_ID,
+        'date-filtered query',
+        expect.objectContaining({ createdFrom: from, createdTo: to }),
+      );
+    });
+  });
 });
 
 // ─── C2: Bulk Ingestion ──────────────────────────────────────────────────────
@@ -656,5 +806,105 @@ describe('MemoryService — C2 Bulk Conversation Ingestion', () => {
       expect(combined).toContain('Para2');
       expect(combined).toContain('Para3');
     });
+  });
+});
+
+// ─── Static Token Helpers ─────────────────────────────────────────────────────
+
+const makeRawMemory = (overrides: Partial<Memory> = {}): Memory => ({
+  id: 'clm1111111111111111111111',
+  userId: 'clm0000000000000000000000',
+  content: 'Test memory content',
+  metadata: {},
+  tags: [],
+  embedding: [],
+  type: 'long-term',
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  expiresAt: null,
+  ...overrides,
+});
+
+describe('MemoryService.estimateTokens (static)', () => {
+  it('returns ceil(chars / 4) for a simple string', () => {
+    expect(MemoryService.estimateTokens('abcd')).toBe(1); // 4/4 = 1
+    expect(MemoryService.estimateTokens('abcde')).toBe(2); // ceil(5/4) = 2
+    expect(MemoryService.estimateTokens('')).toBe(0);
+    expect(MemoryService.estimateTokens('a'.repeat(100))).toBe(25);
+  });
+
+  it('always rounds up (ceil)', () => {
+    // every string of length n → ceil(n/4) ≥ n/4
+    for (const len of [1, 3, 5, 7, 99]) {
+      const result = MemoryService.estimateTokens('a'.repeat(len));
+      expect(result).toBeGreaterThanOrEqual(len / 4);
+    }
+  });
+});
+
+describe('MemoryService.buildTokenBudgetedBlock (static)', () => {
+  it('returns (no memories) for empty input', () => {
+    const result = MemoryService.buildTokenBudgetedBlock([], 1000);
+    expect(result.context).toBe('(no memories)');
+    expect(result.memoryCount).toBe(0);
+    expect(result.truncated).toBe(false);
+    expect(result.tokenBudget).toBe(1000);
+    expect(result.candidatesFound).toBe(0);
+  });
+
+  it('includes all memories when they fit in the budget', () => {
+    const memories = [
+      makeRawMemory({ content: 'short content A' }),
+      makeRawMemory({ content: 'short content B' }),
+    ];
+    const result = MemoryService.buildTokenBudgetedBlock(memories, 2000);
+    expect(result.memoryCount).toBe(2);
+    expect(result.truncated).toBe(false);
+    expect(result.estimatedTokens).toBeLessThanOrEqual(2000);
+  });
+
+  it('respects token budget: estimatedTokens ≤ tokenBudget', () => {
+    const bigContent = 'w'.repeat(10000);
+    const memories = Array.from({ length: 5 }, () =>
+      makeRawMemory({ content: bigContent }),
+    );
+    const budget = 300;
+    const result = MemoryService.buildTokenBudgetedBlock(memories, budget);
+    expect(result.estimatedTokens).toBeLessThanOrEqual(budget);
+  });
+
+  it('truncates a single memory larger than the budget', () => {
+    const hugContent = 'z'.repeat(50000); // ~12500 tokens
+    const result = MemoryService.buildTokenBudgetedBlock(
+      [makeRawMemory({ content: hugContent })],
+      200,
+    );
+    expect(result.estimatedTokens).toBeLessThanOrEqual(200);
+    expect(result.truncated).toBe(true);
+    expect(result.memoryCount).toBe(1);
+  });
+
+  it('marks truncated=true when not all memories fit', () => {
+    const memories = Array.from({ length: 20 }, (_, i) =>
+      makeRawMemory({ content: `Memory content number ${i} `.repeat(50) }),
+    );
+    const result = MemoryService.buildTokenBudgetedBlock(memories, 500);
+    expect(result.truncated).toBe(true);
+    expect(result.memoryCount).toBeLessThan(20);
+    expect(result.estimatedTokens).toBeLessThanOrEqual(500);
+  });
+
+  it('includes tags in the formatted header', () => {
+    const result = MemoryService.buildTokenBudgetedBlock(
+      [makeRawMemory({ content: 'tagged content', tags: ['foo', 'bar'] })],
+      2000,
+    );
+    expect(result.context).toContain('[foo, bar]');
+  });
+
+  it('echoes tokenBudget and candidatesFound in result', () => {
+    const result = MemoryService.buildTokenBudgetedBlock([], 777, 42);
+    expect(result.tokenBudget).toBe(777);
+    expect(result.candidatesFound).toBe(42);
   });
 });

--- a/apps/mcp-server/src/memory/memory.controller.spec.ts
+++ b/apps/mcp-server/src/memory/memory.controller.spec.ts
@@ -544,6 +544,7 @@ describe('MemoryController', () => {
       expect(mockMemoryService.getMemory).toHaveBeenCalledWith(
         userId,
         memoryId,
+        undefined,
       );
     });
 
@@ -644,6 +645,7 @@ describe('MemoryController', () => {
           tags: undefined,
           ttl: undefined,
         },
+        undefined,
       );
       expect(response.content[0]?.text).toContain(memoryId);
     });
@@ -678,6 +680,7 @@ describe('MemoryController', () => {
       expect(mockMemoryService.deleteMemory).toHaveBeenCalledWith(
         userId,
         memoryId,
+        undefined,
       );
     });
 
@@ -714,6 +717,7 @@ describe('MemoryController', () => {
       expect(mockMemoryService.promoteMemory).toHaveBeenCalledWith(
         userId,
         memoryId,
+        undefined,
       );
       expect(response.content[0]?.text).toContain('Successfully promoted');
       expect(response.content[0]?.text).toContain(memoryId);

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -42,6 +42,8 @@ import {
   CompressContextToolInput,
   loadContextToolSchema,
   LoadContextToolInput,
+  promptContextToolSchema,
+  PromptContextToolInput,
 } from './dto/context.dto';
 import {
   ingestConversationToolSchema,
@@ -53,7 +55,7 @@ import { ConsolidationService } from './consolidation.service';
 /**
  * MCP Memory Tools Controller
  *
- * Implements 19 MCP tools for memory management:
+ * Implements 20 MCP tools for memory management:
  * 1.  create_memory          - Create short-term or long-term memory
  * 2.  get_memory             - Retrieve memory by ID
  * 3.  list_memories          - List memories with pagination
@@ -73,6 +75,7 @@ import { ConsolidationService } from './consolidation.service';
  * 17. compress_context       - Retrieve + format memories as an injectable context block
  * 18. load_context           - Load recent + important memories for session priming
  * 19. ingest_conversation    - Bulk-ingest a conversation as chunked per-turn memories
+ * 20. prompt_context         - Token-budgeted context assembly ranked by query relevance
  */
 @Controller('memory')
 @Injectable()
@@ -959,6 +962,60 @@ export class MemoryController {
   }
 
   /**
+   * MCP Tool: prompt_context
+   * Assemble a token-budgeted, query-ranked context block for prompt injection.
+   */
+  async promptContext(
+    input: unknown,
+  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+    try {
+      this.logger.debug('prompt_context tool called');
+      const validated: PromptContextToolInput =
+        promptContextToolSchema.parse(input);
+
+      const result = await this.memoryService.assemblePromptContext({
+        userId: validated.userId,
+        query: validated.query,
+        tokenBudget: validated.tokenBudget,
+        limit: validated.limit,
+        minScore: validated.minScore,
+        scope: validated.scope,
+        tags: validated.tags,
+        createdFrom: validated.createdFrom,
+        createdTo: validated.createdTo,
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result.context,
+          },
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                memoryCount: result.memoryCount,
+                estimatedTokens: result.estimatedTokens,
+                tokenBudget: result.tokenBudget,
+                truncated: result.truncated,
+                candidatesFound: result.candidatesFound,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (error) {
+      this.logger.error('Error in prompt_context tool:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error occurred';
+      throw new Error(`Failed to assemble prompt context: ${errorMessage}`);
+    }
+  }
+
+  /**
    * Get MCP tools in the format required by the MCP handler
    * This method creates Tool objects that bind controller methods as handlers
    */
@@ -1124,6 +1181,16 @@ export class MemoryController {
           'Bulk-ingest a conversation as per-turn long-term memories. Handles chunking for large turns, controls embedding back-pressure via concurrency, and is idempotent: re-submitting the same conversation returns the existing memory IDs.',
         inputSchema: ingestConversationToolSchema,
         handler: this.ingestConversation.bind(this) as (
+          input: unknown,
+        ) => Promise<unknown>,
+      },
+      // ── C3: Token-Budgeted Prompt Assembly ───────────────────────────────────
+      {
+        name: 'prompt_context',
+        description:
+          'Assemble a token-budgeted context block from memories most relevant to a query. Greedy-packs ranked memories within the token budget (1 token ≈ 4 chars). Returns the formatted block plus token accounting metadata.',
+        inputSchema: promptContextToolSchema,
+        handler: this.promptContext.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
       },

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -160,6 +160,7 @@ export class MemoryController {
       const memory = await this.memoryService.getMemory(
         validatedInput.userId,
         validatedInput.memoryId,
+        validatedInput.scope,
       );
 
       if (!memory) {
@@ -271,6 +272,7 @@ export class MemoryController {
         validatedInput.userId,
         validatedInput.memoryId,
         updateDto,
+        validatedInput.scope,
       );
 
       return {
@@ -307,6 +309,7 @@ export class MemoryController {
       const deleted = await this.memoryService.deleteMemory(
         validatedInput.userId,
         validatedInput.memoryId,
+        validatedInput.scope,
       );
 
       return {
@@ -345,6 +348,7 @@ export class MemoryController {
       const promotedMemory = await this.memoryService.promoteMemory(
         validatedInput.userId,
         validatedInput.memoryId,
+        validatedInput.scope,
       );
 
       return {
@@ -751,6 +755,7 @@ export class MemoryController {
         limit: validated.limit,
         confirm: validated.confirm,
         minScore: validated.minScore,
+        scope: validated.scope,
       });
 
       return {

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -114,6 +114,7 @@ export class MemoryController {
         userId: validatedInput.userId,
         content: validatedInput.content,
         type: validatedInput.type,
+        scope: validatedInput.scope,
         metadata: validatedInput.metadata,
         tags: validatedInput.tags,
         ttl: validatedInput.ttl,
@@ -205,6 +206,7 @@ export class MemoryController {
         {
           limit: validatedInput.limit,
           cursor: validatedInput.cursor,
+          scope: validatedInput.scope,
           tags: validatedInput.tags,
           search: validatedInput.search,
         },
@@ -697,6 +699,7 @@ export class MemoryController {
         userId: validated.userId,
         content: validated.content,
         type: validated.type,
+        scope: validated.scope,
         metadata: validated.metadata,
         tags: validated.tags,
         ttl: validated.ttl,

--- a/apps/mcp-server/src/memory/memory.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.service.spec.ts
@@ -137,7 +137,12 @@ describe('MemoryService', () => {
       const result = await service.getMemory('user-1', 'stm-123');
 
       expect(result).toEqual(mockStmMemory);
-      expect(stmService.findById).toHaveBeenCalledWith('user-1', 'stm-123');
+      expect(stmService.findById).toHaveBeenCalledWith(
+        'user-1',
+        'stm-123',
+        undefined,
+        undefined,
+      );
       expect(ltmService.get).not.toHaveBeenCalled();
     });
 
@@ -150,8 +155,18 @@ describe('MemoryService', () => {
       const result = await service.getMemory('user-1', 'ltm-456');
 
       expect(result).toEqual(mockLtmMemory);
-      expect(stmService.findById).toHaveBeenCalledWith('user-1', 'ltm-456');
-      expect(ltmService.get).toHaveBeenCalledWith('user-1', 'ltm-456');
+      expect(stmService.findById).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        undefined,
+      );
+      expect(ltmService.get).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        undefined,
+      );
     });
 
     it('should return null if memory not found in either store', async () => {
@@ -173,6 +188,28 @@ describe('MemoryService', () => {
         'Redis connection failed',
       );
       expect(ltmService.get).not.toHaveBeenCalled();
+    });
+
+    it('forwards a provided scope to both STM and LTM lookups', async () => {
+      stmService.findById.mockRejectedValue(
+        new StmMemoryNotFoundError('ltm-456'),
+      );
+      ltmService.get.mockResolvedValue(mockLtmMemory);
+
+      await service.getMemory('user-1', 'ltm-456', 'agent:alpha');
+
+      expect(stmService.findById).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        'agent:alpha',
+      );
+      expect(ltmService.get).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        'agent:alpha',
+      );
     });
   });
 
@@ -321,6 +358,34 @@ describe('MemoryService', () => {
       expect(result.startCursor).toBeUndefined();
       expect(result.endCursor).toBeUndefined();
     });
+
+    it('forwards the scope filter to BOTH the STM and LTM list calls', async () => {
+      stmService.list.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+      ltmService.list.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+
+      await service.listMemories('user-1', { limit: 20, scope: 'agent:alpha' });
+
+      // Regression: STM previously dropped the scope filter, leaking other
+      // namespaces' short-term memories into a scoped list.
+      expect(stmService.list).toHaveBeenCalledWith('user-1', {
+        limit: 20,
+        scope: 'agent:alpha',
+      });
+      expect(ltmService.list).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ scope: 'agent:alpha' }),
+      );
+    });
   });
 
   describe('updateMemory', () => {
@@ -336,12 +401,18 @@ describe('MemoryService', () => {
       });
 
       expect(result.content).toBe('Updated content');
-      expect(stmService.update).toHaveBeenCalledWith('user-1', 'stm-123', {
-        content: 'Updated content',
-        metadata: undefined,
-        tags: [],
-        ttl: undefined,
-      });
+      expect(stmService.update).toHaveBeenCalledWith(
+        'user-1',
+        'stm-123',
+        {
+          content: 'Updated content',
+          metadata: undefined,
+          tags: [],
+          ttl: undefined,
+        },
+        undefined,
+        undefined,
+      );
     });
 
     it('should update memory in LTM if not found in STM', async () => {
@@ -359,11 +430,17 @@ describe('MemoryService', () => {
       });
 
       expect(result.content).toBe('Updated content');
-      expect(ltmService.update).toHaveBeenCalledWith('user-1', 'ltm-456', {
-        content: 'Updated content',
-        metadata: undefined,
-        tags: undefined,
-      });
+      expect(ltmService.update).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        {
+          content: 'Updated content',
+          metadata: undefined,
+          tags: undefined,
+        },
+        undefined,
+        undefined,
+      );
     });
 
     it('should throw NotFoundException if memory not found in either store', async () => {
@@ -398,7 +475,12 @@ describe('MemoryService', () => {
       const result = await service.deleteMemory('user-1', 'stm-123');
 
       expect(result).toBe(true);
-      expect(stmService.delete).toHaveBeenCalledWith('user-1', 'stm-123');
+      expect(stmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'stm-123',
+        undefined,
+        undefined,
+      );
     });
 
     it('should delete from LTM successfully', async () => {
@@ -410,7 +492,12 @@ describe('MemoryService', () => {
       const result = await service.deleteMemory('user-1', 'ltm-456');
 
       expect(result).toBe(true);
-      expect(ltmService.delete).toHaveBeenCalledWith('user-1', 'ltm-456');
+      expect(ltmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        undefined,
+      );
     });
 
     it('should return false if not found in either store', async () => {
@@ -430,8 +517,18 @@ describe('MemoryService', () => {
 
       const result = await service.deleteMemory('user-1', 'dual-store-id');
 
-      expect(stmService.delete).toHaveBeenCalledWith('user-1', 'dual-store-id');
-      expect(ltmService.delete).toHaveBeenCalledWith('user-1', 'dual-store-id');
+      expect(stmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'dual-store-id',
+        undefined,
+        undefined,
+      );
+      expect(ltmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'dual-store-id',
+        undefined,
+        undefined,
+      );
       expect(result).toBe(true);
     });
 
@@ -456,6 +553,26 @@ describe('MemoryService', () => {
         'Database connection failed',
       );
     });
+
+    it('forwards a provided scope to both STM and LTM deletes', async () => {
+      stmService.delete.mockResolvedValue(undefined);
+      ltmService.delete.mockResolvedValue(true);
+
+      await service.deleteMemory('user-1', 'mem-1', 'agent:alpha');
+
+      expect(stmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'mem-1',
+        undefined,
+        'agent:alpha',
+      );
+      expect(ltmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'mem-1',
+        undefined,
+        'agent:alpha',
+      );
+    });
   });
 
   describe('promoteMemory', () => {
@@ -465,7 +582,12 @@ describe('MemoryService', () => {
       const result = await service.promoteMemory('user-1', 'stm-123');
 
       expect(result).toEqual(mockLtmMemory);
-      expect(ltmService.promote).toHaveBeenCalledWith('user-1', 'stm-123');
+      expect(ltmService.promote).toHaveBeenCalledWith(
+        'user-1',
+        'stm-123',
+        undefined,
+        undefined,
+      );
     });
   });
 

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -25,6 +25,7 @@ type StmServiceContract = {
   create: (input: {
     userId: string;
     content: string;
+    scope?: string;
     metadata?: Record<string, unknown>;
     tags?: string[];
     ttl?: number;
@@ -51,6 +52,7 @@ type LtmServiceContract = {
   create: (input: {
     userId: string;
     content: string;
+    scope?: string;
     metadata?: Record<string, unknown>;
     tags?: string[];
     skipDuplicateCheck?: boolean;
@@ -71,6 +73,7 @@ type LtmServiceContract = {
     options: {
       limit: number;
       cursor?: string;
+      scope?: string;
       tags?: string[];
       search?: string;
       sortBy?: 'createdAt' | 'updatedAt';
@@ -118,6 +121,7 @@ export interface CreateMemoryDto {
   userId: string;
   content: string;
   type: 'short-term' | 'long-term';
+  scope?: string;
   metadata?: Record<string, unknown>;
   tags?: string[];
   ttl?: number;
@@ -134,6 +138,7 @@ export interface UpdateMemoryDto {
 export interface ListMemoryOptions {
   limit?: number;
   cursor?: string;
+  scope?: string;
   tags?: string[];
   search?: string;
 }
@@ -242,6 +247,7 @@ export class MemoryService {
       return await this.stm.create({
         userId: dto.userId,
         content: dto.content,
+        scope: dto.scope,
         metadata: dto.metadata,
         tags: dto.tags,
         ttl: dto.ttl,
@@ -251,6 +257,7 @@ export class MemoryService {
       return await this.ltm.create({
         userId: dto.userId,
         content: dto.content,
+        scope: dto.scope,
         metadata: dto.metadata,
         tags: dto.tags,
         skipDuplicateCheck: dto.skipDuplicateCheck,
@@ -310,6 +317,7 @@ export class MemoryService {
       this.ltm.list(userId, {
         limit,
         cursor: options.cursor,
+        scope: options.scope,
         tags: options.tags,
         search: options.search,
       }),
@@ -479,6 +487,7 @@ export class MemoryService {
     userId: string;
     content: string;
     type: 'auto' | 'short-term' | 'long-term';
+    scope?: string;
     metadata?: Record<string, unknown>;
     tags?: string[];
     ttl?: number;
@@ -493,6 +502,7 @@ export class MemoryService {
       userId: input.userId,
       content: input.content,
       type: resolvedType,
+      scope: input.scope,
       metadata: input.metadata,
       tags: input.tags,
       ttl: input.ttl,
@@ -635,6 +645,7 @@ export class MemoryService {
             limit: input.recentLimit,
             sortBy: 'createdAt',
             sortOrder: 'desc',
+            scope: input.scope,
             tags: input.tags,
           })
         : Promise.resolve({ items: [] as Memory[] }),
@@ -643,6 +654,7 @@ export class MemoryService {
             limit: input.importantLimit * 3, // fetch extra, sort by importance, take top N
             sortBy: 'updatedAt',
             sortOrder: 'desc',
+            scope: input.scope,
             tags: input.tags,
           })
         : Promise.resolve({ items: [] as Memory[] }),

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -205,6 +205,19 @@ export interface ContextBlock {
   charCount: number;
 }
 
+export interface PromptContextBlock {
+  /** Formatted text ready for prompt injection, ranked by relevance */
+  context: string;
+  memoryCount: number;
+  truncated: boolean;
+  /** Token estimate of the assembled block (~4 chars/token; may under-count for CJK/emoji) */
+  estimatedTokens: number;
+  /** The token budget that was requested */
+  tokenBudget: number;
+  /** Total candidates returned by semantic search before minScore filtering */
+  candidatesFound: number;
+}
+
 export interface IngestConversationResult {
   /** Number of chunks successfully stored as new memories */
   ingested: number;
@@ -627,6 +640,39 @@ export class MemoryService {
   }
 
   /**
+   * Assemble a token-budgeted context block ranked by query relevance.
+   * Uses a conservative ~4 chars/token estimate so the assembled block stays
+   * within the requested budget. Memories are greedy-packed in relevance order;
+   * content is truncated when a single memory exceeds the remaining budget.
+   */
+  async assemblePromptContext(input: {
+    userId: string;
+    query: string;
+    tokenBudget: number;
+    limit: number;
+    minScore: number;
+    scope?: string;
+    tags?: string[];
+    createdFrom?: Date;
+    createdTo?: Date;
+  }): Promise<PromptContextBlock> {
+    const hits = await this.ltm.semanticSearch(input.userId, input.query, {
+      limit: input.limit,
+      scope: input.scope,
+      tags: input.tags,
+      createdFrom: input.createdFrom,
+      createdTo: input.createdTo,
+    });
+
+    const relevant = hits.filter((h) => h.score >= input.minScore);
+    return MemoryService.buildTokenBudgetedBlock(
+      relevant.map((h) => h.memory),
+      input.tokenBudget,
+      hits.length,
+    );
+  }
+
+  /**
    * Load the most relevant memories for a session opening.
    * Blends recency with importance so the agent is primed with both
    * fresh context and durable knowledge.
@@ -861,6 +907,85 @@ export class MemoryService {
       memoryCount: included,
       truncated,
       charCount: context.length,
+    };
+  }
+
+  /**
+   * Token estimate: ceil(chars / 4). Conservative for ASCII/English text; may
+   * severely under-count for CJK, emoji, or other multi-byte content where BPE
+   * models produce 4–6× more tokens per character. The budget guarantee only
+   * holds for predominantly ASCII input.
+   */
+  static estimateTokens(text: string): number {
+    return Math.ceil(text.length / 4);
+  }
+
+  /**
+   * Greedy-pack memories into a token-budgeted block, ranked by relevance order.
+   * Content is truncated when a single memory would otherwise overflow the budget.
+   * The assembled block is guaranteed to satisfy estimatedTokens ≤ tokenBudget.
+   */
+  static buildTokenBudgetedBlock(
+    memories: Memory[],
+    tokenBudget: number,
+    candidatesFound = 0,
+  ): PromptContextBlock {
+    if (memories.length === 0) {
+      const ctx = '(no memories)';
+      return {
+        context: ctx,
+        memoryCount: 0,
+        truncated: false,
+        estimatedTokens: MemoryService.estimateTokens(ctx),
+        tokenBudget,
+        candidatesFound,
+      };
+    }
+
+    const preamble = '## Memory Context\n\n';
+    let assembled = preamble;
+    let included = 0;
+    let truncated = false;
+
+    for (const m of memories) {
+      const date = m.createdAt.toISOString().slice(0, 10);
+      const tagPart = m.tags.length > 0 ? ` [${m.tags.join(', ')}]` : '';
+      const entryHeader = `### [${date}]${tagPart}\n`;
+
+      const currentTokens = MemoryService.estimateTokens(assembled);
+      const headerTokens = MemoryService.estimateTokens(entryHeader);
+      // -4: safety margin so ceil() rounding can't push us over budget.
+      // -3 below (in slice) matches the 3-char '...' suffix — keep both in sync.
+      const maxContentChars =
+        (tokenBudget - currentTokens - headerTokens) * 4 - 4;
+
+      if (maxContentChars <= 0) {
+        truncated = true;
+        break;
+      }
+
+      const contentTruncated = m.content.length > maxContentChars;
+      const content = contentTruncated
+        ? m.content.slice(0, maxContentChars - 3) + '...'
+        : m.content;
+      if (contentTruncated) truncated = true;
+
+      assembled += `${entryHeader}${content}\n`;
+      included++;
+
+      if (MemoryService.estimateTokens(assembled) >= tokenBudget) {
+        if (included < memories.length) truncated = true;
+        break;
+      }
+    }
+
+    return {
+      context: assembled,
+      memoryCount: included,
+      truncated,
+      estimatedTokens: MemoryService.estimateTokens(assembled),
+      tokenBudget,
+      candidatesFound,
     };
   }
 

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -30,7 +30,12 @@ type StmServiceContract = {
     tags?: string[];
     ttl?: number;
   }) => Promise<Memory>;
-  findById: (userId: string, memoryId: string) => Promise<Memory>;
+  findById: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<Memory>;
   update: (
     userId: string,
     memoryId: string,
@@ -40,11 +45,18 @@ type StmServiceContract = {
       tags?: string[];
       ttl?: number;
     },
+    organizationId?: string,
+    scope?: string,
   ) => Promise<Memory>;
-  delete: (userId: string, memoryId: string) => Promise<void>;
+  delete: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<void>;
   list: (
     userId: string,
-    options: { limit: number },
+    options: { limit: number; scope?: string },
   ) => Promise<MemoryListResult>;
 };
 
@@ -57,7 +69,12 @@ type LtmServiceContract = {
     tags?: string[];
     skipDuplicateCheck?: boolean;
   }) => Promise<Memory>;
-  get: (userId: string, memoryId: string) => Promise<Memory | null>;
+  get: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<Memory | null>;
   update: (
     userId: string,
     memoryId: string,
@@ -66,8 +83,15 @@ type LtmServiceContract = {
       metadata?: Record<string, unknown>;
       tags?: string[];
     },
+    organizationId?: string,
+    scope?: string,
   ) => Promise<Memory>;
-  delete: (userId: string, memoryId: string) => Promise<boolean>;
+  delete: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<boolean>;
   list: (
     userId: string,
     options: {
@@ -80,7 +104,12 @@ type LtmServiceContract = {
       sortOrder?: 'asc' | 'desc';
     },
   ) => Promise<MemoryListResult>;
-  promote: (userId: string, memoryId: string) => Promise<Memory>;
+  promote: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<Memory>;
   semanticSearch: (
     userId: string,
     query: string,
@@ -281,19 +310,34 @@ export class MemoryService {
   /**
    * Get a memory - tries STM first, then falls back to LTM
    */
-  async getMemory(userId: string, memoryId: string): Promise<Memory | null> {
+  async getMemory(
+    userId: string,
+    memoryId: string,
+    scope?: string,
+  ): Promise<Memory | null> {
     this.logger.debug(`Getting memory ${memoryId} for user: ${userId}`);
 
     try {
-      // Try STM first (faster access)
-      const stmMemory = await this.stm.findById(userId, memoryId);
+      // Try STM first (faster access). Scope is forwarded so a namespaced
+      // caller cannot read another scope's memory by id.
+      const stmMemory = await this.stm.findById(
+        userId,
+        memoryId,
+        undefined,
+        scope,
+      );
       return stmMemory;
     } catch (error) {
       if (error instanceof StmMemoryNotFoundError) {
         // Not in STM, try LTM
         this.logger.debug(`Memory ${memoryId} not found in STM, checking LTM`);
         try {
-          const ltmMemory = await this.ltm.get(userId, memoryId);
+          const ltmMemory = await this.ltm.get(
+            userId,
+            memoryId,
+            undefined,
+            scope,
+          );
           return ltmMemory;
         } catch (ltmError) {
           if (ltmError instanceof LtmMemoryNotFoundError) {
@@ -325,7 +369,7 @@ export class MemoryService {
     // Note: STM list is not fully implemented yet, but we'll call it anyway
     const [stmResult, ltmResult] = await Promise.all([
       this.stm
-        .list(userId, { limit })
+        .list(userId, { limit, scope: options.scope })
         .catch(() => ({ items: [] as Memory[], totalCount: 0 })),
       this.ltm.list(userId, {
         limit,
@@ -371,40 +415,59 @@ export class MemoryService {
     userId: string,
     memoryId: string,
     updates: UpdateMemoryDto,
+    scope?: string,
   ): Promise<Memory> {
     this.logger.debug(
       `Updating memory ${memoryId} for user: ${userId} with updates:`,
       updates,
     );
 
-    // Try to find the memory first to determine which service to use
+    // Try to find the memory first to determine which service to use. Scope is
+    // forwarded so a namespaced caller cannot locate or modify a foreign memory.
     try {
       // Try STM first
-      await this.stm.findById(userId, memoryId);
+      await this.stm.findById(userId, memoryId, undefined, scope);
 
       // Found in STM, update it
-      return await this.stm.update(userId, memoryId, {
-        content: updates.content,
-        metadata: updates.metadata,
-        tags: updates.tags ?? ([] as string[]),
-        ttl: updates.ttl,
-      });
+      return await this.stm.update(
+        userId,
+        memoryId,
+        {
+          content: updates.content,
+          metadata: updates.metadata,
+          tags: updates.tags ?? ([] as string[]),
+          ttl: updates.ttl,
+        },
+        undefined,
+        scope,
+      );
     } catch (error) {
       if (error instanceof StmMemoryNotFoundError) {
         // Not in STM, try LTM
         this.logger.debug(`Memory ${memoryId} not in STM, trying LTM`);
 
-        const ltmMemory = await this.ltm.get(userId, memoryId);
+        const ltmMemory = await this.ltm.get(
+          userId,
+          memoryId,
+          undefined,
+          scope,
+        );
         if (!ltmMemory) {
           throw new NotFoundException(`Memory ${memoryId} not found`);
         }
 
         // Update in LTM (TTL is ignored for LTM)
-        return await this.ltm.update(userId, memoryId, {
-          content: updates.content,
-          metadata: updates.metadata,
-          tags: updates.tags,
-        });
+        return await this.ltm.update(
+          userId,
+          memoryId,
+          {
+            content: updates.content,
+            metadata: updates.metadata,
+            tags: updates.tags,
+          },
+          undefined,
+          scope,
+        );
       }
       throw error;
     }
@@ -413,15 +476,20 @@ export class MemoryService {
   /**
    * Delete a memory - tries both STM and LTM
    */
-  async deleteMemory(userId: string, memoryId: string): Promise<boolean> {
+  async deleteMemory(
+    userId: string,
+    memoryId: string,
+    scope?: string,
+  ): Promise<boolean> {
     this.logger.debug(`Deleting memory ${memoryId} for user: ${userId}`);
 
     let deletedFromStm = false;
     let deletedFromLtm = false;
 
-    // Try to delete from STM
+    // Try to delete from STM. Scope is forwarded so a namespaced caller cannot
+    // delete a memory that lives in a different scope.
     try {
-      await this.stm.delete(userId, memoryId);
+      await this.stm.delete(userId, memoryId, undefined, scope);
       deletedFromStm = true;
       this.logger.debug(`Memory ${memoryId} deleted from STM`);
     } catch (error) {
@@ -432,7 +500,12 @@ export class MemoryService {
 
     // Try to delete from LTM
     try {
-      deletedFromLtm = await this.ltm.delete(userId, memoryId);
+      deletedFromLtm = await this.ltm.delete(
+        userId,
+        memoryId,
+        undefined,
+        scope,
+      );
       if (deletedFromLtm) {
         this.logger.debug(`Memory ${memoryId} deleted from LTM`);
       }
@@ -449,13 +522,18 @@ export class MemoryService {
   /**
    * Promote a memory from STM to LTM
    */
-  async promoteMemory(userId: string, memoryId: string): Promise<Memory> {
+  async promoteMemory(
+    userId: string,
+    memoryId: string,
+    scope?: string,
+  ): Promise<Memory> {
     this.logger.debug(
       `Promoting memory ${memoryId} from STM to LTM for user: ${userId}`,
     );
 
-    // Use LTM service's promote method which handles the transfer
-    return await this.ltm.promote(userId, memoryId);
+    // Use LTM service's promote method which handles the transfer. Scope is
+    // forwarded so a namespaced caller cannot promote a foreign-scope memory.
+    return await this.ltm.promote(userId, memoryId, undefined, scope);
   }
 
   /**
@@ -536,9 +614,13 @@ export class MemoryService {
     limit: number;
     confirm: boolean;
     minScore: number;
+    scope?: string;
   }): Promise<ForgetResult> {
+    // Confine both the search and the deletion to the caller's namespace so a
+    // scoped `forget` cannot surface or remove memories from another scope.
     const hits = await this.ltm.semanticSearch(input.userId, input.query, {
       limit: input.limit,
+      scope: input.scope,
     });
 
     const candidates: ForgetCandidate[] = hits
@@ -552,7 +634,9 @@ export class MemoryService {
     let deleted = 0;
     if (input.confirm && candidates.length > 0) {
       const results = await Promise.allSettled(
-        candidates.map((c) => this.deleteMemory(input.userId, c.memoryId)),
+        candidates.map((c) =>
+          this.deleteMemory(input.userId, c.memoryId, input.scope),
+        ),
       );
       deleted = results.filter(
         (r) => r.status === 'fulfilled' && r.value,

--- a/apps/mcp-server/test/mcp-tools.integration.spec.ts
+++ b/apps/mcp-server/test/mcp-tools.integration.spec.ts
@@ -133,6 +133,7 @@ describe('MCP Tools Integration', () => {
       list: jest.fn(),
       promote: jest.fn(),
       reindex: jest.fn(),
+      semanticSearch: jest.fn().mockResolvedValue([]),
     };
 
     const queueMock: Partial<jest.Mocked<ReindexQueueService>> = {
@@ -168,9 +169,9 @@ describe('MCP Tools Integration', () => {
   // Tool registration
   // -------------------------------------------------------------------------
   describe('getMcpTools() registration', () => {
-    it('should register exactly 19 tools', () => {
+    it('should register exactly 20 tools', () => {
       const tools = controller.getMcpTools();
-      expect(tools).toHaveLength(19);
+      expect(tools).toHaveLength(20);
     });
 
     it('should register all expected tool names', () => {
@@ -196,6 +197,8 @@ describe('MCP Tools Integration', () => {
       expect(names).toContain('load_context');
       // C2 tools
       expect(names).toContain('ingest_conversation');
+      // C3 tools
+      expect(names).toContain('prompt_context');
     });
 
     it('should attach a callable handler to each tool', () => {
@@ -878,6 +881,106 @@ describe('MCP Tools Integration', () => {
       expect(text(createResp)).toContain('Created short-term memory');
       expect(text(getResp)).toContain(MEMORY_ID);
       expect(text(deleteResp)).toBe(`Successfully deleted memory ${MEMORY_ID}`);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // prompt_context
+  // -------------------------------------------------------------------------
+  describe('prompt_context tool', () => {
+    it('should return a context block and token metadata', async () => {
+      ltmService.semanticSearch.mockResolvedValue([
+        {
+          memory: makeLtmMemory({ content: 'NestJS uses DI throughout' }),
+          score: 0.9,
+        },
+      ]);
+
+      const response = await controller.promptContext({
+        userId: USER_ID,
+        query: 'dependency injection',
+        tokenBudget: 2000,
+      });
+
+      const contextText = response.content[0]!.text;
+      expect(contextText).toContain('NestJS uses DI throughout');
+
+      const meta = JSON.parse(response.content[1]!.text) as {
+        memoryCount: number;
+        estimatedTokens: number;
+        tokenBudget: number;
+        truncated: boolean;
+        candidatesFound: number;
+      };
+      expect(meta.memoryCount).toBe(1);
+      expect(meta.tokenBudget).toBe(2000);
+      expect(meta.estimatedTokens).toBeLessThanOrEqual(2000);
+      expect(meta.truncated).toBe(false);
+      expect(meta.candidatesFound).toBe(1);
+    });
+
+    it('should return (no memories) when no hits pass minScore', async () => {
+      ltmService.semanticSearch.mockResolvedValue([
+        { memory: makeLtmMemory(), score: 0.2 },
+      ]);
+
+      const response = await controller.promptContext({
+        userId: USER_ID,
+        query: 'very specific niche topic',
+        tokenBudget: 500,
+        minScore: 0.8,
+      });
+
+      expect(response.content[0]!.text).toBe('(no memories)');
+    });
+
+    it('should respect token budget when multiple memories are returned', async () => {
+      const bigContent = 'a'.repeat(4000); // ~1000 tokens each
+      ltmService.semanticSearch.mockResolvedValue(
+        Array.from({ length: 5 }, () => ({
+          memory: makeLtmMemory({ content: bigContent }),
+          score: 0.85,
+        })),
+      );
+
+      const response = await controller.promptContext({
+        userId: USER_ID,
+        query: 'large context',
+        tokenBudget: 500,
+      });
+
+      const meta = JSON.parse(response.content[1]!.text) as {
+        estimatedTokens: number;
+        tokenBudget: number;
+        truncated: boolean;
+      };
+      expect(meta.estimatedTokens).toBeLessThanOrEqual(meta.tokenBudget);
+      expect(meta.truncated).toBe(true);
+    });
+
+    it('should throw wrapped error for invalid userId', async () => {
+      await expect(
+        controller.promptContext({
+          userId: 'bad-user',
+          query: 'some query',
+        }),
+      ).rejects.toThrow('Failed to assemble prompt context');
+    });
+
+    it('handler registered via getMcpTools() should be callable', async () => {
+      ltmService.semanticSearch.mockResolvedValue([]);
+
+      const tools = controller.getMcpTools();
+      const tool = tools.find((t) => t.name === 'prompt_context')!;
+      expect(tool).toBeDefined();
+      expect(typeof tool.handler).toBe('function');
+
+      const response = (await tool.handler({
+        userId: USER_ID,
+        query: 'test via handler',
+      })) as { content: Array<{ type: string; text: string }> };
+
+      expect(response.content[0]!.text).toBe('(no memories)');
     });
   });
 });

--- a/apps/mcp-server/test/memory-promotion.integration.spec.ts
+++ b/apps/mcp-server/test/memory-promotion.integration.spec.ts
@@ -85,7 +85,12 @@ describe('MemoryService Promotion Integration', () => {
       const result = await service.promoteMemory(TEST_USER_ID, STM_ID);
 
       expect(result).toEqual(promoted);
-      expect(ltmService.promote).toHaveBeenCalledWith(TEST_USER_ID, STM_ID);
+      expect(ltmService.promote).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        STM_ID,
+        undefined,
+        undefined,
+      );
       expect(ltmService.promote).toHaveBeenCalledTimes(1);
     });
 
@@ -202,10 +207,14 @@ describe('MemoryService Promotion Integration', () => {
       expect(stmService.findById).toHaveBeenCalledWith(
         TEST_USER_ID,
         promotedResult.id,
+        undefined,
+        undefined,
       );
       expect(ltmService.get).toHaveBeenCalledWith(
         TEST_USER_ID,
         promotedResult.id,
+        undefined,
+        undefined,
       );
     });
   });

--- a/apps/mcp-server/test/memory.integration.spec.ts
+++ b/apps/mcp-server/test/memory.integration.spec.ts
@@ -142,7 +142,12 @@ describe('MemoryService Integration', () => {
       const result = await service.getMemory(TEST_USER_ID, STM_ID);
 
       expect(result).toEqual(memory);
-      expect(stmService.findById).toHaveBeenCalledWith(TEST_USER_ID, STM_ID);
+      expect(stmService.findById).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        STM_ID,
+        undefined,
+        undefined,
+      );
       expect(ltmService.get).not.toHaveBeenCalled();
     });
 
@@ -168,7 +173,12 @@ describe('MemoryService Integration', () => {
       const result = await service.deleteMemory(TEST_USER_ID, STM_ID);
 
       expect(result).toBe(true);
-      expect(stmService.delete).toHaveBeenCalledWith(TEST_USER_ID, STM_ID);
+      expect(stmService.delete).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        STM_ID,
+        undefined,
+        undefined,
+      );
     });
   });
 
@@ -205,8 +215,18 @@ describe('MemoryService Integration', () => {
       const result = await service.getMemory(TEST_USER_ID, LTM_ID);
 
       expect(result).toEqual(memory);
-      expect(stmService.findById).toHaveBeenCalledWith(TEST_USER_ID, LTM_ID);
-      expect(ltmService.get).toHaveBeenCalledWith(TEST_USER_ID, LTM_ID);
+      expect(stmService.findById).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        LTM_ID,
+        undefined,
+        undefined,
+      );
+      expect(ltmService.get).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        LTM_ID,
+        undefined,
+        undefined,
+      );
     });
 
     it('should update LTM memory when not found in STM', async () => {
@@ -231,7 +251,12 @@ describe('MemoryService Integration', () => {
       const result = await service.deleteMemory(TEST_USER_ID, LTM_ID);
 
       expect(result).toBe(true);
-      expect(ltmService.delete).toHaveBeenCalledWith(TEST_USER_ID, LTM_ID);
+      expect(ltmService.delete).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        LTM_ID,
+        undefined,
+        undefined,
+      );
     });
   });
 

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -78,6 +78,8 @@ export interface Memory {
   id: string;
   userId: string;
   organizationId?: string | null;
+  /** Optional namespace for agent/session/project isolation. */
+  scope?: string | null;
   content: string;
   metadata?: Record<string, unknown> | null;
   tags: string[];

--- a/packages/memory-ltm/src/memory-ltm.reindex.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.reindex.spec.ts
@@ -10,7 +10,9 @@ function buildMemory(id: string, overrides: Record<string, unknown> = {}) {
     id,
     userId: mockUserId,
     content: `content-${id}`,
-    metadata: { scope: 'session-1' },
+    // Scope is a first-class column; the vector payload is derived from it.
+    scope: 'session-1',
+    metadata: null,
     tags: ['test'],
     type: MemoryType.LONG_TERM,
     createdAt: new Date('2025-01-01T00:00:00Z'),

--- a/packages/memory-ltm/src/memory-ltm.scope-isolation.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.scope-isolation.spec.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryLtmService } from './memory-ltm.service';
+import { DuplicateDetectionService } from './duplicate-detection.service';
+import { ContradictionDetectionService } from './contradiction-detection.service';
+import { MemoryType } from '@engram/database';
+import type { VectorStore } from '@engram/vector-store';
+
+/**
+ * Regression coverage for cross-scope leaks in the LTM create/promote paths:
+ *  - exact-content dedup ({@link MemoryLtmService} findExactDuplicate)
+ *  - semantic dedup (findDuplicate)
+ *  - contradiction / supersession (findContradictionCandidate)
+ *
+ * An unscoped write must never collapse into — or supersede — a scoped memory,
+ * and a scoped write must stay inside its own namespace.
+ */
+
+const USER = 'cldx4k8xp000108l83h4y8v2q';
+const SCOPE_A = 'agent:alpha';
+
+type Row = {
+  id: string;
+  userId: string;
+  organizationId: string | null;
+  scope: string | null;
+  content: string;
+  metadata: Record<string, unknown> | null;
+  tags: string[];
+  type: string;
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: null;
+  embedding: number[];
+};
+
+function makeRow(overrides: Partial<Row>): Row {
+  return {
+    id: 'row-1',
+    userId: USER,
+    organizationId: null,
+    scope: null,
+    content: 'content',
+    metadata: null,
+    tags: [],
+    type: MemoryType.LONG_TERM,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    expiresAt: null,
+    embedding: [0.1, 0.2, 0.3],
+    ...overrides,
+  };
+}
+
+/**
+ * Faithful Prisma `where` matcher: a `scope` key set to `null` means "scope IS
+ * NULL" (only unscoped rows), a string means that exact scope, and an absent
+ * key means no scope constraint — exactly how Prisma treats it.
+ */
+function whereMatches(row: Row, where: Record<string, unknown>): boolean {
+  if (where.userId && row.userId !== where.userId) return false;
+  if (where.type && row.type !== where.type) return false;
+  if (where.content !== undefined && row.content !== where.content) return false;
+  if ('scope' in where && row.scope !== (where.scope ?? null)) return false;
+  if (where.id) {
+    if (typeof where.id === 'object' && where.id !== null && 'in' in where.id) {
+      if (!(where.id as { in: string[] }).in.includes(row.id)) return false;
+    } else if (row.id !== where.id) {
+      return false;
+    }
+  }
+  return true;
+}
+
+describe('MemoryLtmService — create/promote scope isolation', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let db: Row[];
+
+  function buildPrisma(rows: Row[]) {
+    db = rows;
+    return {
+      memory: {
+        findFirst: vi.fn(({ where }) => Promise.resolve(db.find((r) => whereMatches(r, where)) ?? null)),
+        findMany: vi.fn(({ where }) => Promise.resolve(db.filter((r) => whereMatches(r, where)))),
+        create: vi.fn(({ data }: { data: Partial<Row> }) =>
+          Promise.resolve(makeRow({ ...data, id: 'row-new' }))
+        ),
+        update: vi.fn(({ data }: { data: Record<string, unknown> }) =>
+          Promise.resolve(makeRow({ id: 'row-existing', ...data }))
+        ),
+        count: vi.fn().mockResolvedValue(0),
+      },
+      $transaction: vi.fn(),
+    };
+  }
+
+  const embeddings = {
+    generate: vi.fn().mockResolvedValue({ embedding: [0.1, 0.2, 0.3] }),
+  };
+
+  function makeVectorStore(hits: Array<{ id: string; score: number; payload?: Record<string, unknown> }>) {
+    return {
+      backend: 'qdrant',
+      ensureReady: vi.fn().mockResolvedValue(undefined),
+      upsert: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      search: vi.fn().mockResolvedValue(hits),
+    } as unknown as VectorStore & { search: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    embeddings.generate.mockResolvedValue({ embedding: [0.1, 0.2, 0.3] });
+  });
+
+  // ── #4 exact-content dedup ────────────────────────────────────────────────
+  describe('exact-content dedup (findExactDuplicate)', () => {
+    it('an unscoped create does NOT dedup against a scoped memory with identical content', async () => {
+      prisma = buildPrisma([makeRow({ id: 'scoped', scope: SCOPE_A, content: 'shared text' })]);
+      const service = new MemoryLtmService(prisma);
+
+      const result = await service.create({ userId: USER, content: 'shared text' });
+
+      // A brand-new unscoped row is written rather than returning the scoped one.
+      expect(prisma.memory.create).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe('row-new');
+      // The dedup probe constrained scope to NULL (unscoped only).
+      expect(prisma.memory.findFirst).toHaveBeenCalledWith({
+        where: expect.objectContaining({ content: 'shared text', scope: null }),
+      });
+    });
+
+    it('a scoped create does NOT dedup against an unscoped memory with identical content', async () => {
+      prisma = buildPrisma([makeRow({ id: 'unscoped', scope: null, content: 'shared text' })]);
+      const service = new MemoryLtmService(prisma);
+
+      const result = await service.create({ userId: USER, scope: SCOPE_A, content: 'shared text' });
+
+      expect(prisma.memory.create).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe('row-new');
+      expect(prisma.memory.findFirst).toHaveBeenCalledWith({
+        where: expect.objectContaining({ content: 'shared text', scope: SCOPE_A }),
+      });
+    });
+
+    it('a scoped create DOES dedup against a same-scope memory with identical content', async () => {
+      prisma = buildPrisma([makeRow({ id: 'same-scope', scope: SCOPE_A, content: 'shared text' })]);
+      const service = new MemoryLtmService(prisma);
+
+      const result = await service.create({ userId: USER, scope: SCOPE_A, content: 'shared text' });
+
+      // Existing row returned; no new write.
+      expect(prisma.memory.create).not.toHaveBeenCalled();
+      expect(result.id).toBe('same-scope');
+    });
+
+    it('an unscoped create DOES dedup against an unscoped memory with identical content', async () => {
+      prisma = buildPrisma([makeRow({ id: 'unscoped', scope: null, content: 'shared text' })]);
+      const service = new MemoryLtmService(prisma);
+
+      const result = await service.create({ userId: USER, content: 'shared text' });
+
+      expect(prisma.memory.create).not.toHaveBeenCalled();
+      expect(result.id).toBe('unscoped');
+    });
+  });
+
+  // ── #6 semantic dedup ─────────────────────────────────────────────────────
+  describe('semantic dedup (findDuplicate)', () => {
+    it('passes the create scope into the vector-store search filter', async () => {
+      prisma = buildPrisma([]);
+      const vectorStore = makeVectorStore([]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService()
+      );
+
+      await service.create({ userId: USER, scope: SCOPE_A, content: 'new fact' });
+
+      expect(vectorStore.search).toHaveBeenCalledWith(
+        [0.1, 0.2, 0.3],
+        expect.objectContaining({ scope: SCOPE_A, type: MemoryType.LONG_TERM }),
+        expect.any(Number)
+      );
+    });
+
+    it('drops a cross-scope vector hit so an unscoped create is not deduped against a scoped memory', async () => {
+      prisma = buildPrisma([makeRow({ id: 'scoped', scope: SCOPE_A, content: 'similar' })]);
+      // A near-identical hit, but it belongs to SCOPE_A.
+      const vectorStore = makeVectorStore([{ id: 'scoped', score: 0.999, payload: { userId: USER, scope: SCOPE_A } }]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService()
+      );
+
+      const result = await service.create({ userId: USER, content: 'similar' });
+
+      // Not deduped: a fresh unscoped row is written, the scoped one is untouched.
+      expect(prisma.memory.create).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe('row-new');
+    });
+
+    it('dedups against a same-scope vector hit', async () => {
+      prisma = buildPrisma([makeRow({ id: 'row-existing', scope: SCOPE_A, content: 'similar' })]);
+      const vectorStore = makeVectorStore([{ id: 'row-existing', score: 0.999, payload: { userId: USER, scope: SCOPE_A } }]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService()
+      );
+
+      const result = await service.create({ userId: USER, scope: SCOPE_A, content: 'similar' });
+
+      // Linked to the existing row (annotated via update), no new row created.
+      expect(prisma.memory.create).not.toHaveBeenCalled();
+      expect(result.id).toBe('row-existing');
+    });
+  });
+
+  // ── #7 contradiction / supersession ───────────────────────────────────────
+  describe('contradiction detection (findContradictionCandidate)', () => {
+    it('confines the candidate content query to the create scope', async () => {
+      prisma = buildPrisma([]);
+      const vectorStore = makeVectorStore([{ id: 'other', score: 0.5, payload: { userId: USER } }]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService(),
+        undefined,
+        new ContradictionDetectionService()
+      );
+
+      await service.create({ userId: USER, scope: SCOPE_A, content: 'the sky is green' });
+
+      // The content-hydration query for contradiction candidates is scoped.
+      const scopedFindMany = prisma.memory.findMany.mock.calls.find(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (call: any) => call[0]?.where && 'id' in call[0].where && call[0].where.id?.in
+      );
+      expect(scopedFindMany).toBeDefined();
+      expect(scopedFindMany![0].where.scope).toBe(SCOPE_A);
+    });
+
+    it('uses scope IS NULL for the candidate content query on an unscoped create', async () => {
+      prisma = buildPrisma([]);
+      const vectorStore = makeVectorStore([{ id: 'other', score: 0.5, payload: { userId: USER } }]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService(),
+        undefined,
+        new ContradictionDetectionService()
+      );
+
+      await service.create({ userId: USER, content: 'the sky is green' });
+
+      const scopedFindMany = prisma.memory.findMany.mock.calls.find(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (call: any) => call[0]?.where && 'id' in call[0].where && call[0].where.id?.in
+      );
+      expect(scopedFindMany).toBeDefined();
+      expect(scopedFindMany![0].where.scope).toBeNull();
+    });
+  });
+});

--- a/packages/memory-ltm/src/memory-ltm.scope.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.scope.spec.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryLtmService } from './memory-ltm.service';
+import { MemoryType } from '@engram/database';
+
+const SCOPE_A = 'agent:agent-alpha';
+const SCOPE_B = 'session:session-beta';
+const USER_A = 'cldx4k8xp000108l83h4y8v2q';
+
+type MockMemory = {
+  id: string;
+  userId: string;
+  organizationId: string | null;
+  scope: string | null;
+  content: string;
+  metadata: null;
+  tags: string[];
+  type: string;
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: null;
+  embedding: number[];
+};
+
+const makeMemory = (overrides: Partial<MockMemory>): MockMemory => ({
+  id: 'mem-1',
+  userId: USER_A,
+  organizationId: null,
+  scope: null,
+  content: 'test content',
+  metadata: null,
+  tags: [],
+  type: MemoryType.LONG_TERM,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  expiresAt: null,
+  embedding: [],
+  ...overrides,
+});
+
+describe('MemoryLtmService — scope isolation', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let service: MemoryLtmService;
+
+  const memScopeA = makeMemory({ id: 'mem-a1', scope: SCOPE_A, content: 'agent A fact' });
+  const memScopeB = makeMemory({ id: 'mem-b1', scope: SCOPE_B, content: 'session B fact' });
+  const memUnscoped = makeMemory({ id: 'mem-u1', scope: null, content: 'global fact' });
+
+  beforeEach(() => {
+    const db = [memScopeA, memScopeB, memUnscoped];
+
+    prisma = {
+      memory: {
+        count: vi
+          .fn()
+          .mockImplementation(({ where }) =>
+            Promise.resolve(
+              db.filter(
+                (m) =>
+                  (!where.userId || m.userId === where.userId) &&
+                  (!where.scope || m.scope === where.scope) &&
+                  m.type === where.type
+              ).length
+            )
+          ),
+        create: vi
+          .fn()
+          .mockImplementation(({ data }: { data: Partial<MockMemory> }) =>
+            Promise.resolve({ ...makeMemory({}), ...data, id: 'mem-new' })
+          ),
+        findFirst: vi
+          .fn()
+          .mockImplementation(({ where }) =>
+            Promise.resolve(
+              db.find(
+                (m) =>
+                  (!where.id || m.id === where.id) &&
+                  (!where.userId || m.userId === where.userId) &&
+                  (!where.scope || m.scope === where.scope) &&
+                  m.type === where.type &&
+                  (!where.content || m.content === where.content)
+              ) ?? null
+            )
+          ),
+        findMany: vi
+          .fn()
+          .mockImplementation(({ where }) =>
+            Promise.resolve(
+              db.filter(
+                (m) =>
+                  (!where.userId || m.userId === where.userId) &&
+                  (!where.scope || m.scope === where.scope) &&
+                  m.type === where.type
+              )
+            )
+          ),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        update: vi.fn(),
+      },
+      $transaction: vi.fn(),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    service = new MemoryLtmService(prisma as any);
+  });
+
+  describe('create — scope persisted', () => {
+    it('stores the scope on the created memory', async () => {
+      await service.create({ userId: USER_A, scope: SCOPE_A, content: 'new scoped memory' });
+
+      expect(prisma.memory.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ scope: SCOPE_A }),
+      });
+    });
+
+    it('stores null scope when no scope is provided', async () => {
+      await service.create({ userId: USER_A, content: 'unscoped memory' });
+
+      expect(prisma.memory.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ scope: null }),
+      });
+    });
+  });
+
+  describe('list — scope filter', () => {
+    it('returns only scope A memories when scope=SCOPE_A', async () => {
+      const result = await service.list(USER_A, { scope: SCOPE_A });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.scope).toBe(SCOPE_A);
+    });
+
+    it('returns only scope B memories when scope=SCOPE_B', async () => {
+      const result = await service.list(USER_A, { scope: SCOPE_B });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.scope).toBe(SCOPE_B);
+    });
+
+    it('returns all memories when no scope is provided', async () => {
+      const result = await service.list(USER_A);
+      expect(result.items).toHaveLength(3);
+    });
+
+    it('passes scope to prisma.memory.findMany when provided', async () => {
+      await service.list(USER_A, { scope: SCOPE_A });
+
+      expect(prisma.memory.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ scope: SCOPE_A }),
+        })
+      );
+    });
+
+    it('omits scope from findMany when not provided', async () => {
+      await service.list(USER_A);
+
+      const call = prisma.memory.findMany.mock.calls[0]![0];
+      expect(call.where).not.toHaveProperty('scope');
+    });
+  });
+
+  describe('count — scope filter', () => {
+    it('counts only memories in scope A', async () => {
+      const count = await service.count(USER_A, { scope: SCOPE_A });
+      expect(count).toBe(1);
+    });
+
+    it('counts only memories in scope B', async () => {
+      const count = await service.count(USER_A, { scope: SCOPE_B });
+      expect(count).toBe(1);
+    });
+
+    it('passes scope to prisma.memory.count when provided', async () => {
+      await service.count(USER_A, { scope: SCOPE_A });
+
+      expect(prisma.memory.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ scope: SCOPE_A }),
+        })
+      );
+    });
+  });
+
+  describe('get — scope filter', () => {
+    it('returns memory when scope matches', async () => {
+      const result = await service.get(USER_A, 'mem-a1', undefined, SCOPE_A);
+      expect(result).not.toBeNull();
+      expect(result!.scope).toBe(SCOPE_A);
+    });
+
+    it('returns null when scope does not match', async () => {
+      const result = await service.get(USER_A, 'mem-a1', undefined, SCOPE_B);
+      expect(result).toBeNull();
+    });
+
+    it('passes scope to prisma.memory.findFirst when provided', async () => {
+      await service.get(USER_A, 'mem-a1', undefined, SCOPE_A);
+
+      expect(prisma.memory.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ scope: SCOPE_A }),
+        })
+      );
+    });
+
+    it('omits scope from findFirst when not provided', async () => {
+      await service.get(USER_A, 'mem-a1');
+
+      const call = prisma.memory.findFirst.mock.calls[0]![0];
+      expect(call.where).not.toHaveProperty('scope');
+    });
+  });
+
+  describe('scope returned on mapped memory', () => {
+    it('scope field is present on retrieved memory', async () => {
+      const result = await service.get(USER_A, 'mem-a1', undefined, SCOPE_A);
+      expect(result?.scope).toBe(SCOPE_A);
+    });
+
+    it('scope is undefined (not null) when memory has no scope', async () => {
+      const result = await service.get(USER_A, 'mem-u1');
+      expect(result?.scope).toBeUndefined();
+    });
+  });
+});

--- a/packages/memory-ltm/src/memory-ltm.semantic.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.semantic.spec.ts
@@ -11,7 +11,10 @@ function buildMemory(overrides: Record<string, unknown> = {}): Record<string, un
     id: mockMemoryId,
     userId: mockUserId,
     content: 'Test memory content',
-    metadata: { scope: 'session-1' },
+    // Scope is a first-class column (not metadata) — the vector payload reads it
+    // from here, so the mock row must carry it as a top-level field.
+    scope: 'session-1',
+    metadata: null,
     tags: ['test'],
     type: MemoryType.LONG_TERM,
     createdAt: new Date('2025-01-01T00:00:00Z'),
@@ -68,7 +71,7 @@ describe('MemoryLtmService — vector lifecycle & semantic search', () => {
       await service.create({
         userId: mockUserId,
         content: 'Test memory content',
-        metadata: { scope: 'session-1' },
+        scope: 'session-1',
         tags: ['test'],
       });
 

--- a/packages/memory-ltm/src/memory-ltm.service.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.spec.ts
@@ -569,7 +569,12 @@ describe('MemoryLtmService', () => {
 
       const result = await service.promote(mockUserId, mockMemoryId);
 
-      expect(stmService.findById).toHaveBeenCalledWith(mockUserId, mockMemoryId, undefined);
+      expect(stmService.findById).toHaveBeenCalledWith(
+        mockUserId,
+        mockMemoryId,
+        undefined,
+        undefined,
+      );
       expect(stmService.delete).toHaveBeenCalledWith(mockUserId, mockMemoryId, undefined);
       expect(result).toEqual(
         expect.objectContaining({

--- a/packages/memory-ltm/src/memory-ltm.service.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.ts
@@ -3,7 +3,12 @@ import { PrismaService } from '@engram/database';
 import { MemoryType, PaginatedResult } from '@engram/database';
 import { MemoryStmService } from '@engram/memory-stm';
 import { EmbeddingsService } from '@engram/embeddings';
-import { VECTOR_STORE_TOKEN, type VectorStore, type VectorPayload } from '@engram/vector-store';
+import {
+  VECTOR_STORE_TOKEN,
+  type VectorStore,
+  type VectorPayload,
+  type VectorSearchResult,
+} from '@engram/vector-store';
 import { rankResults, DEFAULT_RANKING_WEIGHTS, type RankingWeights } from './rank';
 import { ImportanceScoringService } from './importance.service';
 import { DuplicateDetectionService } from './duplicate-detection.service';
@@ -133,9 +138,16 @@ export class MemoryLtmService {
       }
 
       // ── Step 2 (vector): semantic duplicate detection ──────────────────
+      // Scope is passed so dedup stays within the create's namespace — an
+      // unscoped write must never collapse into a scoped memory, or vice-versa.
       const duplicate =
         !input.skipDuplicateCheck &&
-        (await this.findDuplicate(validatedInput.userId, validatedInput.organizationId, embedding));
+        (await this.findDuplicate(
+          validatedInput.userId,
+          validatedInput.organizationId,
+          validatedInput.scope,
+          embedding
+        ));
       if (duplicate) {
         return await this.linkDuplicateAndReturn(
           duplicate.memoryId,
@@ -147,9 +159,11 @@ export class MemoryLtmService {
       }
 
       // ── Step B1: contradiction detection ──────────────────────────────
+      // Scope-bound so a write can only supersede memories in its own namespace.
       const contradiction = await this.findContradictionCandidate(
         validatedInput.userId,
         validatedInput.organizationId,
+        validatedInput.scope,
         processedContent,
         embedding
       );
@@ -283,7 +297,8 @@ export class MemoryLtmService {
     userId: string,
     memoryId: string,
     input: UpdateLtmMemoryData,
-    organizationId?: string
+    organizationId?: string,
+    scope?: string
   ): Promise<LtmMemory> {
     this.logger.debug(`Updating LTM memory: ${memoryId} for user: ${userId}`);
 
@@ -291,7 +306,9 @@ export class MemoryLtmService {
     const validatedInput = validateUpdateLtmMemory(input);
 
     try {
-      const existingRow = await this.findRawMemory(userId, memoryId, organizationId);
+      // Pass scope so a caller bound to a namespace cannot update memories
+      // outside it — a mismatch resolves to not-found.
+      const existingRow = await this.findRawMemory(userId, memoryId, organizationId, scope);
       if (!existingRow) {
         throw new LtmMemoryNotFoundError(memoryId);
       }
@@ -387,7 +404,12 @@ export class MemoryLtmService {
    * Pass `organizationId` in user-facing paths to prevent cross-tenant deletes.
    * See `get()` for the full isolation contract.
    */
-  async delete(userId: string, memoryId: string, organizationId?: string): Promise<boolean> {
+  async delete(
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string
+  ): Promise<boolean> {
     this.logger.debug(`Deleting LTM memory: ${memoryId} for user: ${userId}`);
 
     try {
@@ -398,6 +420,10 @@ export class MemoryLtmService {
       };
       if (organizationId !== undefined) {
         deleteWhere.organizationId = organizationId;
+      }
+      // Namespace isolation: a scoped caller can only delete within its scope.
+      if (scope !== undefined) {
+        deleteWhere.scope = scope;
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (this.prisma as any).memory.deleteMany({ where: deleteWhere });
@@ -614,8 +640,9 @@ export class MemoryLtmService {
     }
 
     try {
-      // Step 1: Get memory from STM service (org-scoped so we find the right key)
-      const stmMemory = await this.stmService.findById(userId, memoryId, organizationId);
+      // Step 1: Get memory from STM service (org- and scope-scoped so we find
+      // the right key and refuse to promote a memory from another namespace).
+      const stmMemory = await this.stmService.findById(userId, memoryId, organizationId, scope);
       if (!stmMemory) {
         throw new LtmPromotionError(memoryId, 'Memory not found in short-term storage');
       }
@@ -663,7 +690,12 @@ export class MemoryLtmService {
         embedding = result?.embedding ?? [];
       }
 
-      const duplicate = await this.findDuplicate(userId, resolvedOrgId ?? undefined, embedding);
+      const duplicate = await this.findDuplicate(
+        userId,
+        resolvedOrgId ?? undefined,
+        resolvedScope ?? undefined,
+        embedding
+      );
       if (duplicate) {
         const existing = await this.linkDuplicateAndReturn(
           duplicate.memoryId,
@@ -1173,7 +1205,8 @@ export class MemoryLtmService {
   private async findRawMemory(
     userId: string,
     memoryId: string,
-    organizationId?: string
+    organizationId?: string,
+    scope?: string
   ): Promise<PrismaMemory | null> {
     const where: Record<string, unknown> = {
       id: memoryId,
@@ -1182,6 +1215,9 @@ export class MemoryLtmService {
     };
     if (organizationId !== undefined) {
       where.organizationId = organizationId;
+    }
+    if (scope !== undefined) {
+      where.scope = scope;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.prisma as any).memory.findFirst({ where }) as Promise<PrismaMemory | null>;
@@ -1256,16 +1292,32 @@ export class MemoryLtmService {
     if (organizationId !== undefined) {
       where.organizationId = organizationId;
     }
-    if (scope !== undefined) {
-      where.scope = scope;
-    }
+    // Always constrain by namespace for dedup. Note that `scope` is treated differently
+    // here than in read/update/delete paths: `undefined` means "unscoped only"
+    // (scope IS NULL), not "no scope filter".
+    where.scope = scope ?? null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.prisma as any).memory.findFirst({ where }) as Promise<PrismaMemory | null>;
+  }
+
+  /**
+   * Keep only candidates that share the create's namespace. The vector store
+   * filter cannot express "scope IS NULL", so for an unscoped create we drop any
+   * hit that carries a scope in its payload; for a scoped create the store has
+   * already filtered, and this simply re-asserts the invariant.
+   */
+  private hitMatchesScope(hit: VectorSearchResult, scope: string | undefined): boolean {
+    const hitScope =
+      typeof hit.payload?.scope === 'string' && hit.payload.scope.length > 0
+        ? hit.payload.scope
+        : undefined;
+    return hitScope === scope;
   }
 
   private async findDuplicate(
     userId: string,
     organizationId: string | undefined,
+    scope: string | undefined,
     embedding: number[]
   ): Promise<DuplicateDetectionMatch | null> {
     if (!this.vectorStore || !this.duplicateDetectionService || embedding.length === 0) {
@@ -1273,15 +1325,17 @@ export class MemoryLtmService {
     }
     const hits = await this.vectorStore.search(
       embedding,
-      { userId, organizationId, type: MemoryType.LONG_TERM },
+      { userId, organizationId, scope, type: MemoryType.LONG_TERM },
       3
     );
-    return this.duplicateDetectionService.findMatch(hits);
+    const scopedHits = hits.filter((hit) => this.hitMatchesScope(hit, scope));
+    return this.duplicateDetectionService.findMatch(scopedHits);
   }
 
   private async findContradictionCandidate(
     userId: string,
     organizationId: string | undefined,
+    scope: string | undefined,
     content: string,
     embedding: number[]
   ): Promise<ContradictionMatch | null> {
@@ -1290,18 +1344,21 @@ export class MemoryLtmService {
     }
     const hits = await this.vectorStore.search(
       embedding,
-      { userId, organizationId, type: MemoryType.LONG_TERM },
+      { userId, organizationId, scope, type: MemoryType.LONG_TERM },
       5
     );
     if (hits.length === 0) return null;
 
     // Fetch content for all hit candidates in one query, scoped to the same
-    // tenant so a vector-store misconfiguration cannot surface foreign rows.
+    // tenant *and namespace* so neither a vector-store misconfiguration nor an
+    // unscoped search can surface foreign rows. `scope ?? null` confines the
+    // match to the create's own namespace (NULL = unscoped).
     const hitIds = hits.map((h) => h.id);
     const contentWhere: Record<string, unknown> = {
       id: { in: hitIds },
       userId,
       type: MemoryType.LONG_TERM,
+      scope: scope ?? null,
     };
     if (organizationId !== undefined) {
       contentWhere.organizationId = organizationId;

--- a/packages/memory-ltm/src/memory-ltm.service.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.ts
@@ -40,6 +40,7 @@ type PrismaMemory = {
   id: string;
   userId: string;
   organizationId: string | null;
+  scope: string | null;
   content: string;
   metadata: unknown; // Using unknown for type safety; must be type-checked before use
   tags: string[];
@@ -114,7 +115,8 @@ export class MemoryLtmService {
       const exactDup = await this.findExactDuplicate(
         validatedInput.userId,
         processedContent,
-        validatedInput.organizationId
+        validatedInput.organizationId,
+        validatedInput.scope
       );
       if (exactDup) {
         this.logger.debug(`Exact content duplicate; returning existing memory ${exactDup.id}`);
@@ -182,6 +184,7 @@ export class MemoryLtmService {
         data: {
           userId: validatedInput.userId,
           organizationId: validatedInput.organizationId ?? null,
+          scope: validatedInput.scope ?? null,
           content: processedContent,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           metadata: metadata as any,
@@ -236,7 +239,12 @@ export class MemoryLtmService {
    * callers (e.g. reindex) but must NOT be used in user-facing paths — the auth
    * layer (#128, #130) must always supply the caller's org context.
    */
-  async get(userId: string, memoryId: string, organizationId?: string): Promise<LtmMemory | null> {
+  async get(
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string
+  ): Promise<LtmMemory | null> {
     this.logger.debug(`Getting LTM memory: ${memoryId} for user: ${userId}`);
 
     try {
@@ -247,6 +255,9 @@ export class MemoryLtmService {
       };
       if (organizationId !== undefined) {
         where.organizationId = organizationId;
+      }
+      if (scope !== undefined) {
+        where.scope = scope;
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const memory = await (this.prisma as any).memory.findFirst({ where });
@@ -351,17 +362,12 @@ export class MemoryLtmService {
       this.logger.debug(`LTM memory updated: ${memoryId}`);
       const ltmMemory = this.mapToLtmMemory(memory);
 
-      // Re-index on new embedding, tag changes, or metadata changes that alter the
-      // scope field (the only metadata value persisted in the vector payload).
-      const oldScope = this.extractScope(existing.metadata);
-      const newScope = this.extractScope(nextMetadata);
-      const metadataAffectsPayload =
-        (validatedInput.metadata !== undefined || validatedInput.metadataMerge !== undefined) &&
-        oldScope !== newScope;
+      // Re-index when the embedding or tags change (both affect the stored vector payload).
+      // Scope is immutable via update(), so it never triggers a re-index here.
       const embeddingToIndex = newEmbedding ?? ltmMemory.embedding;
       if (
         embeddingToIndex.length > 0 &&
-        (newEmbedding !== undefined || validatedInput.tags !== undefined || metadataAffectsPayload)
+        (newEmbedding !== undefined || validatedInput.tags !== undefined)
       ) {
         await this.indexVector(ltmMemory, embeddingToIndex);
       }
@@ -431,6 +437,9 @@ export class MemoryLtmService {
 
       if (validatedOptions.organizationId) {
         whereClause.organizationId = validatedOptions.organizationId;
+      }
+      if (validatedOptions.scope) {
+        whereClause.scope = validatedOptions.scope;
       }
 
       // Add filters
@@ -526,6 +535,9 @@ export class MemoryLtmService {
       if (filters?.organizationId) {
         whereClause.organizationId = filters.organizationId;
       }
+      if (filters?.scope) {
+        whereClause.scope = filters.scope;
+      }
 
       // Add filters if provided
       if (filters?.tags && filters.tags.length > 0) {
@@ -587,9 +599,14 @@ export class MemoryLtmService {
 
   /**
    * Promote a memory from short-term to long-term storage.
-   * Pass `organizationId` to preserve the org scope through the STM→LTM transfer.
+   * Pass `organizationId` and `scope` to preserve both namespaces through the STM→LTM transfer.
    */
-  async promote(userId: string, memoryId: string, organizationId?: string): Promise<LtmMemory> {
+  async promote(
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string
+  ): Promise<LtmMemory> {
     this.logger.debug(`Promoting memory ${memoryId} to LTM for user: ${userId}`);
 
     if (!this.stmService) {
@@ -608,10 +625,17 @@ export class MemoryLtmService {
 
       // Org scope: prefer the explicit param, fall back to what's stored in the STM payload.
       const resolvedOrgId = organizationId ?? stmMemory.organizationId ?? null;
+      // Namespace scope: prefer the explicit param, fall back to the STM payload scope.
+      const resolvedScope = scope ?? stmMemory.scope ?? null;
 
       // Exact content dedup: if the STM content already exists verbatim in LTM,
       // skip promotion and return the existing memory without generating an embedding.
-      const exactDup = await this.findExactDuplicate(userId, stmMemory.content, resolvedOrgId);
+      const exactDup = await this.findExactDuplicate(
+        userId,
+        stmMemory.content,
+        resolvedOrgId,
+        resolvedScope ?? undefined
+      );
       if (exactDup) {
         this.logger.debug(
           `Exact content duplicate on promote; returning existing LTM memory ${exactDup.id}`
@@ -683,6 +707,7 @@ export class MemoryLtmService {
             id: stmMemory.id,
             userId: stmMemory.userId,
             organizationId: resolvedOrgId,
+            scope: resolvedScope,
             content: stmMemory.content,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             metadata: metadata as any,
@@ -1220,7 +1245,8 @@ export class MemoryLtmService {
   private async findExactDuplicate(
     userId: string,
     content: string,
-    organizationId: string | null | undefined
+    organizationId: string | null | undefined,
+    scope?: string
   ): Promise<PrismaMemory | null> {
     const where: Record<string, unknown> = {
       userId,
@@ -1229,6 +1255,9 @@ export class MemoryLtmService {
     };
     if (organizationId !== undefined) {
       where.organizationId = organizationId;
+    }
+    if (scope !== undefined) {
+      where.scope = scope;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.prisma as any).memory.findFirst({ where }) as Promise<PrismaMemory | null>;
@@ -1401,19 +1430,10 @@ export class MemoryLtmService {
     if (memory.organizationId) {
       payload.organizationId = memory.organizationId;
     }
-    const scope = this.extractScope(memory.metadata);
-    if (scope) {
-      payload.scope = scope;
+    if (memory.scope) {
+      payload.scope = memory.scope;
     }
     return payload;
-  }
-
-  /**
-   * Derive an optional `scope` namespace from a memory's metadata.
-   */
-  private extractScope(metadata: Record<string, unknown> | null | undefined): string | undefined {
-    const scope = metadata?.scope;
-    return typeof scope === 'string' && scope.length > 0 ? scope : undefined;
   }
 
   /**
@@ -1423,6 +1443,7 @@ export class MemoryLtmService {
     return {
       ...memory,
       organizationId: memory.organizationId ?? undefined,
+      scope: memory.scope ?? undefined,
       type: 'long-term' as const,
       expiresAt: null,
       metadata: memory.metadata as Record<string, unknown> | null,

--- a/packages/memory-ltm/src/types.ts
+++ b/packages/memory-ltm/src/types.ts
@@ -24,6 +24,8 @@ export interface LtmMemory extends Memory {
 export interface CreateLtmMemoryData {
   userId: string;
   organizationId?: string;
+  /** Optional namespace for agent/session/project isolation. */
+  scope?: string;
   content: string;
   metadata?: Record<string, unknown>;
   tags?: string[];
@@ -48,6 +50,8 @@ export interface LtmQueryOptions {
   limit?: number;
   cursor?: string;
   organizationId?: string;
+  /** Optional namespace filter; omit to return all scopes. */
+  scope?: string;
   tags?: string[];
   dateFrom?: Date;
   dateTo?: Date;
@@ -199,6 +203,7 @@ export interface DecayPolicyResult {
 export const createLtmMemorySchema = z.object({
   userId: userIdSchema,
   organizationId: z.string().cuid2().optional(),
+  scope: z.string().min(1).max(256).optional(),
   content: z.string().min(1, 'Content cannot be empty').max(10240, 'Content cannot exceed 10KB'),
   metadata: z.record(z.string(), z.unknown()).optional().nullable(),
   tags: z.array(z.string()).optional().default([]),
@@ -221,6 +226,7 @@ export const ltmQueryOptionsSchema = z.object({
   limit: z.number().int().min(1).max(100).optional().default(20),
   cursor: cursorIdSchema.optional(),
   organizationId: z.string().cuid2().optional(),
+  scope: z.string().min(1).max(256).optional(),
   tags: z.array(z.string()).optional(),
   dateFrom: z.date().optional(),
   dateTo: z.date().optional(),

--- a/packages/memory-stm/src/memory-stm.scope.spec.ts
+++ b/packages/memory-stm/src/memory-stm.scope.spec.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryStmService } from './memory-stm.service';
+import { StmMemoryNotFoundError } from './types';
+
+const SCOPE_A = 'agent:agent-alpha';
+const SCOPE_B = 'session:session-beta';
+const USER_A = 'cldx4k8xp000108l83h4y8v2q';
+const TTL = 3600;
+
+interface FakeRedis {
+  store: Map<string, { value: string; ttl: number }>;
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  del: ReturnType<typeof vi.fn>;
+  delMany: ReturnType<typeof vi.fn>;
+  ttl: ReturnType<typeof vi.fn>;
+  scan: ReturnType<typeof vi.fn>;
+  pipeline: ReturnType<typeof vi.fn>;
+}
+
+function makeRedis(): FakeRedis {
+  const store = new Map<string, { value: string; ttl: number }>();
+  return {
+    store,
+    get: vi.fn(async (key: string): Promise<string | null> => store.get(key)?.value ?? null),
+    set: vi.fn(async (key: string, value: string, ttl: number): Promise<string> => {
+      store.set(key, { value, ttl });
+      return 'OK';
+    }),
+    del: vi.fn(async (key: string): Promise<number> => {
+      const existed = store.has(key);
+      store.delete(key);
+      return existed ? 1 : 0;
+    }),
+    delMany: vi.fn(async (keys: string[]): Promise<number> => {
+      let count = 0;
+      for (const key of keys) {
+        if (store.has(key)) {
+          store.delete(key);
+          count++;
+        }
+      }
+      return count;
+    }),
+    ttl: vi.fn(async (key: string): Promise<number> => {
+      return store.has(key) ? TTL : -2;
+    }),
+    scan: vi.fn(
+      async (
+        _cursor: string,
+        opts: { match: string }
+      ): Promise<{ cursor: string; keys: string[] }> => {
+        const pattern = opts.match.replace(/\*/g, '.*').replace(/\?/g, '.');
+        const re = new RegExp(`^${pattern}$`);
+        const keys = [...store.keys()].filter((k) => re.test(k));
+        return { cursor: '0', keys };
+      }
+    ),
+    pipeline: vi.fn((): { get: (key: string) => unknown; exec: () => Promise<unknown> } => {
+      const ops: Array<() => Promise<[null, string | null]>> = [];
+      const pipe: { get: (key: string) => unknown; exec: () => Promise<unknown> } = {
+        get: (key: string): unknown => {
+          ops.push(
+            async (): Promise<[null, string | null]> => [null, store.get(key)?.value ?? null]
+          );
+          return pipe;
+        },
+        exec: async (): Promise<unknown> => Promise.all(ops.map((op) => op())),
+      };
+      return pipe;
+    }),
+  };
+}
+
+describe('MemoryStmService — scope isolation', () => {
+  let redis: ReturnType<typeof makeRedis>;
+  let service: MemoryStmService;
+
+  beforeEach(() => {
+    redis = makeRedis();
+    service = new MemoryStmService(redis as never);
+  });
+
+  describe('create — scope persisted in payload', () => {
+    it('stores scope in the Redis JSON payload', async () => {
+      const mem = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      // Find the stored key and parse the value
+      const allKeys = [...redis.store.keys()];
+      expect(allKeys).toHaveLength(1);
+      const raw = redis.store.get(allKeys[0]!)?.value;
+      const parsed = JSON.parse(raw!);
+      expect(parsed.scope).toBe(SCOPE_A);
+      expect(mem.scope).toBe(SCOPE_A);
+    });
+
+    it('scope is undefined when not provided', async () => {
+      const mem = await service.create({
+        userId: USER_A,
+        content: 'unscoped fact',
+        ttl: TTL,
+      });
+      expect(mem.scope).toBeUndefined();
+    });
+  });
+
+  describe('findById — scope verification', () => {
+    it('returns memory when scope matches', async () => {
+      const created = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      const found = await service.findById(USER_A, created.id, undefined, SCOPE_A);
+      expect(found.scope).toBe(SCOPE_A);
+    });
+
+    it('throws StmMemoryNotFoundError when scope does not match', async () => {
+      const created = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      await expect(service.findById(USER_A, created.id, undefined, SCOPE_B)).rejects.toThrow(
+        StmMemoryNotFoundError
+      );
+    });
+
+    it('returns memory without scope check when scope not provided', async () => {
+      const created = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      const found = await service.findById(USER_A, created.id);
+      expect(found.scope).toBe(SCOPE_A);
+    });
+  });
+
+  describe('list — scope filter', () => {
+    beforeEach(async () => {
+      await Promise.all([
+        service.create({ userId: USER_A, scope: SCOPE_A, content: 'agent A mem', ttl: TTL }),
+        service.create({ userId: USER_A, scope: SCOPE_B, content: 'session B mem', ttl: TTL }),
+        service.create({ userId: USER_A, content: 'unscoped mem', ttl: TTL }),
+      ]);
+    });
+
+    it('returns only scope A memories when scope=SCOPE_A', async () => {
+      const result = await service.list(USER_A, { scope: SCOPE_A });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.scope).toBe(SCOPE_A);
+    });
+
+    it('returns only scope B memories when scope=SCOPE_B', async () => {
+      const result = await service.list(USER_A, { scope: SCOPE_B });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.scope).toBe(SCOPE_B);
+    });
+
+    it('returns all memories when no scope filter provided', async () => {
+      const result = await service.list(USER_A);
+      expect(result.items).toHaveLength(3);
+    });
+  });
+
+  describe('count — scope filter', () => {
+    beforeEach(async () => {
+      await Promise.all([
+        service.create({ userId: USER_A, scope: SCOPE_A, content: 'agent A 1', ttl: TTL }),
+        service.create({ userId: USER_A, scope: SCOPE_A, content: 'agent A 2', ttl: TTL }),
+        service.create({ userId: USER_A, scope: SCOPE_B, content: 'session B 1', ttl: TTL }),
+      ]);
+    });
+
+    it('counts only memories in scope A', async () => {
+      const count = await service.count(USER_A, { scope: SCOPE_A });
+      expect(count).toBe(2);
+    });
+
+    it('counts only memories in scope B', async () => {
+      const count = await service.count(USER_A, { scope: SCOPE_B });
+      expect(count).toBe(1);
+    });
+
+    it('counts all when no scope filter', async () => {
+      const count = await service.count(USER_A);
+      expect(count).toBe(3);
+    });
+  });
+
+  describe('scope A and scope B memories in separate logical namespaces', () => {
+    it('list scope A cannot see scope B memories', async () => {
+      await service.create({ userId: USER_A, scope: SCOPE_A, content: 'secret A', ttl: TTL });
+      await service.create({ userId: USER_A, scope: SCOPE_B, content: 'secret B', ttl: TTL });
+
+      const resultA = await service.list(USER_A, { scope: SCOPE_A });
+      const resultB = await service.list(USER_A, { scope: SCOPE_B });
+
+      expect(resultA.items.map((m) => m.content)).not.toContain('secret B');
+      expect(resultB.items.map((m) => m.content)).not.toContain('secret A');
+    });
+  });
+});

--- a/packages/memory-stm/src/memory-stm.scope.spec.ts
+++ b/packages/memory-stm/src/memory-stm.scope.spec.ts
@@ -148,6 +148,55 @@ describe('MemoryStmService — scope isolation', () => {
     });
   });
 
+  describe('delete — scope verification', () => {
+    it('deletes the memory when the scope matches', async () => {
+      const created = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      await service.delete(USER_A, created.id, undefined, SCOPE_A);
+
+      await expect(service.findById(USER_A, created.id)).rejects.toThrow(
+        StmMemoryNotFoundError
+      );
+    });
+
+    it('does NOT delete and throws when the scope does not match', async () => {
+      const created = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      await expect(
+        service.delete(USER_A, created.id, undefined, SCOPE_B)
+      ).rejects.toThrow(StmMemoryNotFoundError);
+
+      // The memory must still be present — a foreign scope cannot delete it.
+      const stillThere = await service.findById(USER_A, created.id);
+      expect(stillThere.scope).toBe(SCOPE_A);
+    });
+
+    it('deletes without a scope check when scope is not provided', async () => {
+      const created = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      await service.delete(USER_A, created.id);
+
+      await expect(service.findById(USER_A, created.id)).rejects.toThrow(
+        StmMemoryNotFoundError
+      );
+    });
+  });
+
   describe('list — scope filter', () => {
     beforeEach(async () => {
       await Promise.all([

--- a/packages/memory-stm/src/memory-stm.service.ts
+++ b/packages/memory-stm/src/memory-stm.service.ts
@@ -150,15 +150,17 @@ export class MemoryStmService {
     userId: string,
     memoryId: string,
     input: UpdateStmMemoryData,
-    organizationId?: string
+    organizationId?: string,
+    scope?: string
   ): Promise<StmMemory> {
     this.logger.debug(`Updating STM memory: ${memoryId} for user: ${userId}`);
 
     // Validate input
     const validatedInput = updateStmMemorySchema.parse(input);
 
-    // Get existing memory (must use same org scope to find the key)
-    const existing = await this.findById(userId, memoryId, organizationId);
+    // Get existing memory (must use same org scope to find the key). Passing
+    // scope enforces namespace isolation — a mismatch surfaces as not-found.
+    const existing = await this.findById(userId, memoryId, organizationId, scope);
 
     // Validate new TTL if provided
     const newTtl = validatedInput.ttl ?? existing.ttl;
@@ -192,10 +194,36 @@ export class MemoryStmService {
   /**
    * Delete a short-term memory
    */
-  async delete(userId: string, memoryId: string, organizationId?: string): Promise<void> {
+  async delete(
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string
+  ): Promise<void> {
     this.logger.debug(`Deleting STM memory: ${memoryId} for user: ${userId}`);
 
     const redisKey = this.keyBuilder.buildMemoryKey(userId, memoryId, organizationId);
+
+    // Scope isolation: the Redis key does not encode scope, so when a scope is
+    // supplied we must read the record and verify it before deleting. A mismatch
+    // is treated as not-found so a caller bound to one namespace cannot delete
+    // another's memory.
+    if (scope !== undefined) {
+      const raw = await this.redisService.get(redisKey);
+      if (!raw) {
+        throw new StmMemoryNotFoundError(memoryId);
+      }
+      let memory: StmMemory;
+      try {
+        memory = this.deserializeStmMemory(JSON.parse(raw));
+      } catch {
+        throw new StmMemoryNotFoundError(memoryId);
+      }
+      if (memory.scope !== scope) {
+        throw new StmMemoryNotFoundError(memoryId);
+      }
+    }
+
     const deleted = await this.redisService.del(redisKey);
 
     if (deleted === 0) {

--- a/packages/memory-stm/src/memory-stm.service.ts
+++ b/packages/memory-stm/src/memory-stm.service.ts
@@ -64,6 +64,7 @@ export class MemoryStmService {
       id: memoryId,
       userId: validatedInput.userId,
       organizationId: validatedInput.organizationId,
+      scope: validatedInput.scope,
       content: validatedInput.content,
       metadata: validatedInput.metadata || null,
       tags: validatedInput.tags || [],
@@ -93,7 +94,12 @@ export class MemoryStmService {
   /**
    * Retrieve a short-term memory by ID
    */
-  async findById(userId: string, memoryId: string, organizationId?: string): Promise<StmMemory> {
+  async findById(
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string
+  ): Promise<StmMemory> {
     this.logger.debug(`Finding STM memory: ${memoryId} for user: ${userId}`);
 
     const redisKey = this.keyBuilder.buildMemoryKey(userId, memoryId, organizationId);
@@ -117,6 +123,11 @@ export class MemoryStmService {
     if (memory.expiresAt && new Date() > new Date(memory.expiresAt)) {
       await this.redisService.del(redisKey);
       throw new StmMemoryExpiredError(memoryId);
+    }
+
+    // Enforce scope isolation: treat a scope mismatch as not-found.
+    if (scope !== undefined && memory.scope !== scope) {
+      throw new StmMemoryNotFoundError(memoryId);
     }
 
     // Increment access counter and persist back to Redis.
@@ -206,6 +217,7 @@ export class MemoryStmService {
     const limit = options.limit || 20;
     const cursor = options.cursor || '0';
     const tags = options.tags || [];
+    const scope = options.scope;
     const pattern = this.keyBuilder.buildUserPattern(userId, options.organizationId);
 
     // Use Redis SCAN for memory-efficient iteration
@@ -239,6 +251,9 @@ export class MemoryStmService {
                 if (!hasMatchingTag) continue;
               }
 
+              // Apply scope filtering if scope is provided
+              if (scope !== undefined && memory.scope !== scope) continue;
+
               memories.push(memory);
               if (memories.length >= limit) break;
             } catch {
@@ -250,7 +265,11 @@ export class MemoryStmService {
     }
 
     // Get total count for pagination metadata
-    const totalCount = await this.count(userId, { tags, organizationId: options.organizationId });
+    const totalCount = await this.count(userId, {
+      tags,
+      organizationId: options.organizationId,
+      scope,
+    });
 
     return {
       items: memories,
@@ -317,16 +336,18 @@ export class MemoryStmService {
   }
 
   /**
-   * Count total memories for a user with optional tag filtering
+   * Count total memories for a user with optional tag and scope filtering
    */
   async count(
     userId: string,
-    options: { tags?: string[]; organizationId?: string } = {}
+    options: { tags?: string[]; organizationId?: string; scope?: string } = {}
   ): Promise<number> {
     this.logger.debug(`Counting STM memories for user: ${userId}`);
 
     const pattern = this.keyBuilder.buildUserPattern(userId, options.organizationId);
     const tags = options.tags || [];
+    const scope = options.scope;
+    const needsPayloadScan = tags.length > 0 || scope !== undefined;
     let cursor = '0';
     let count = 0;
 
@@ -336,8 +357,8 @@ export class MemoryStmService {
         count: 1000, // Process in batches
       });
 
-      if (tags.length > 0) {
-        // Need to check tag filtering - fetch and count
+      if (needsPayloadScan) {
+        // Need to fetch payloads to apply tag/scope filtering
         const keys = scanResult.keys;
         if (keys.length > 0) {
           const pipeline = this.redisService.pipeline();
@@ -349,8 +370,12 @@ export class MemoryStmService {
               if (!error && data) {
                 try {
                   const memory = this.deserializeStmMemory(JSON.parse(data as string));
-                  const hasMatchingTag = tags.some((tag) => memory.tags.includes(tag));
-                  if (hasMatchingTag) count++;
+                  if (tags.length > 0) {
+                    const hasMatchingTag = tags.some((tag) => memory.tags.includes(tag));
+                    if (!hasMatchingTag) continue;
+                  }
+                  if (scope !== undefined && memory.scope !== scope) continue;
+                  count++;
                 } catch {
                   // Skip invalid entries
                   this.logger.warn(`Failed to parse STM memory during count`);
@@ -360,7 +385,7 @@ export class MemoryStmService {
           }
         }
       } else {
-        // Simple count without tag filtering
+        // Simple count without payload filtering
         count += scanResult.keys.length;
       }
 

--- a/packages/memory-stm/src/types.ts
+++ b/packages/memory-stm/src/types.ts
@@ -56,6 +56,8 @@ export interface StmMemory extends Memory {
   accessCount: number;
   /** Organization scope; absent for personal (non-org) memories. */
   organizationId?: string;
+  /** Optional namespace for agent/session/project isolation. */
+  scope?: string;
 }
 
 // Validation schemas for STM operations
@@ -88,6 +90,7 @@ const ttlSchema = z
 export const createStmMemorySchema = z.object({
   userId: userIdSchema,
   organizationId: z.string().cuid2().optional(),
+  scope: z.string().min(1).max(256).optional(),
   content: contentSchema,
   metadata: metadataSchema,
   tags: tagsSchema.optional(),
@@ -111,6 +114,7 @@ export const listStmOptionsSchema = z.object({
     .default('0'),
   tags: z.array(z.string()).optional(),
   organizationId: z.string().cuid2().optional(),
+  scope: z.string().min(1).max(256).optional(),
 });
 
 // Type exports

--- a/packages/vector-store/src/pgvector.vector-store.ts
+++ b/packages/vector-store/src/pgvector.vector-store.ts
@@ -227,7 +227,7 @@ export class PgVectorStore implements VectorStore {
     }
     if (filter.scope) {
       params.push(filter.scope);
-      clauses.push(`"metadata"->>'scope' = $${params.length}`);
+      clauses.push(`"scope" = $${params.length}`);
     }
     if (filter.tags && filter.tags.length > 0) {
       params.push(filter.tags);
@@ -243,7 +243,7 @@ export class PgVectorStore implements VectorStore {
     }
 
     const sql =
-      `SELECT "id", "userId", "organizationId", "type", "tags", "metadata"->>'scope' AS scope, "createdAt", ` +
+      `SELECT "id", "userId", "organizationId", "type", "tags", "scope", "createdAt", ` +
       `1 - ("${this.column}" <=> $1::vector) AS score ` +
       `FROM "${this.table}" WHERE ${clauses.join(' AND ')} ` +
       `ORDER BY "${this.column}" <=> $1::vector LIMIT ${safeLimit}`;

--- a/prisma/migrations/20260623000000_add_memory_scope/migration.sql
+++ b/prisma/migrations/20260623000000_add_memory_scope/migration.sql
@@ -1,0 +1,4 @@
+-- Add scope column and index to memories table for agent/session/project namespacing
+ALTER TABLE "memories" ADD COLUMN "scope" TEXT;
+
+CREATE INDEX "memories_userId_scope_idx" ON "memories"("userId", "scope");

--- a/prisma/migrations/20260623000000_add_memory_scope/migration.sql
+++ b/prisma/migrations/20260623000000_add_memory_scope/migration.sql
@@ -1,4 +1,16 @@
 -- Add scope column and index to memories table for agent/session/project namespacing
 ALTER TABLE "memories" ADD COLUMN "scope" TEXT;
 
+-- Backfill the new first-class column from the legacy metadata.scope value so
+-- pre-existing memories keep their namespace. Before this column existed, scope
+-- was stored inside the `metadata` JSONB blob (`metadata.scope`); the application
+-- no longer reads it from there, so without this backfill those memories would
+-- silently lose their scope and leak across namespace boundaries.
+-- Only copy non-empty string values; leave everything else NULL (unscoped).
+UPDATE "memories"
+SET "scope" = "metadata"->>'scope'
+WHERE "scope" IS NULL
+  AND jsonb_typeof("metadata"->'scope') = 'string'
+  AND length("metadata"->>'scope') > 0;
+
 CREATE INDEX "memories_userId_scope_idx" ON "memories"("userId", "scope");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,7 @@ model Memory {
   id             String   @id @default(cuid(2))
   userId         String
   organizationId String?
+  scope          String?  // Optional namespace: 'agent:<id>', 'session:<id>', 'project:<id>', etc.
   content        String   @db.Text // Support up to 10KB content
   metadata       Json?
   tags           String[]
@@ -106,6 +107,7 @@ model Memory {
   // Indexes for performance
   @@index([userId])
   @@index([userId, type])
+  @@index([userId, scope])
   @@index([organizationId])
   @@index([organizationId, type])
   @@index([expiresAt])


### PR DESCRIPTION
## Summary

- Adds a first-class `scope` column to the `Memory` Prisma model (e.g. `agent:<id>`, `session:<id>`, `project:<id>`) with a `(userId, scope)` composite index
- All LTM reads (`get`, `list`, `count`) and writes (`create`) pass scope through as a Prisma WHERE filter; STM (`findById`, `list`, `count`) enforce scope by filtering the Redis JSON payload
- Removes the old dual source-of-truth: `extractScope(metadata)` is gone; pgvector SQL now reads the `"scope"` column directly instead of `"metadata"->>'scope'`
- Scope is immutable after creation (`update` does not accept a scope field)
- STM→LTM promotion propagates scope from the STM payload

## Test plan

- [ ] `pnpm --filter @engram/memory-ltm exec vitest run src/memory-ltm.scope.spec.ts` — 16 tests pass (create/list/count/get scope isolation)
- [ ] `pnpm --filter @engram/memory-stm exec vitest run src/memory-stm.scope.spec.ts` — 12 tests pass (create/findById/list/count scope isolation)
- [ ] `pnpm db:migrate` applies `20260623000000_add_memory_scope` cleanly
- [ ] Full suite: `pnpm test` (no regressions)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)