### PR TITLE
feat(api): prompt-context assembly (token-budgeted top-N) (#125)

### DIFF
--- a/apps/mcp-server/src/memory/dto/context.dto.ts
+++ b/apps/mcp-server/src/memory/dto/context.dto.ts
@@ -85,8 +85,8 @@ export type LoadContextToolInput = z.infer<typeof loadContextToolSchema>;
  * Input schema for the `prompt_context` MCP tool.
  *
  * Assembles a token-budgeted, ranked context block from the most relevant
- * long-term memories for a query. Uses a conservative ~4 chars/token heuristic
- * to ensure the assembled block stays within the requested token budget.
+ * long-term memories for a query. Uses ~4 chars/token heuristic (conservative
+ * for ASCII; may under-count for CJK/emoji content).
  */
 export const promptContextToolSchema = z
   .object({
@@ -98,7 +98,7 @@ export const promptContextToolSchema = z
       .max(2048, 'Query cannot exceed 2048 characters'),
     /**
      * Maximum token budget for the assembled context block.
-     * Conservative estimate: 1 token ≈ 4 characters.
+     * ~4 chars/token (conservative for ASCII; may under-count for CJK/emoji).
      * Default 2000 tokens (~8000 chars). Max 32000 tokens.
      */
     tokenBudget: z.coerce
@@ -116,6 +116,10 @@ export const promptContextToolSchema = z
     scope: z.string().max(256).optional(),
     /** Optional tag filter */
     tags: z.array(z.string()).max(20).optional(),
+    /** Only include memories created on or after this date (ISO 8601) */
+    createdFrom: z.coerce.date().optional(),
+    /** Only include memories created on or before this date (ISO 8601) */
+    createdTo: z.coerce.date().optional(),
   })
   .strict();
 

--- a/apps/mcp-server/src/memory/dto/context.dto.ts
+++ b/apps/mcp-server/src/memory/dto/context.dto.ts
@@ -80,3 +80,43 @@ export const loadContextToolSchema = z
   .strict();
 
 export type LoadContextToolInput = z.infer<typeof loadContextToolSchema>;
+
+/**
+ * Input schema for the `prompt_context` MCP tool.
+ *
+ * Assembles a token-budgeted, ranked context block from the most relevant
+ * long-term memories for a query. Uses a conservative ~4 chars/token heuristic
+ * to ensure the assembled block stays within the requested token budget.
+ */
+export const promptContextToolSchema = z
+  .object({
+    userId: userIdSchema,
+    /** Natural-language query used to rank and retrieve relevant memories */
+    query: z
+      .string()
+      .min(1, 'Query cannot be empty')
+      .max(2048, 'Query cannot exceed 2048 characters'),
+    /**
+     * Maximum token budget for the assembled context block.
+     * Conservative estimate: 1 token ≈ 4 characters.
+     * Default 2000 tokens (~8000 chars). Max 32000 tokens.
+     */
+    tokenBudget: z.coerce
+      .number()
+      .int()
+      .min(100)
+      .max(32000)
+      .optional()
+      .default(2000),
+    /** Maximum memories to retrieve before filtering and ranking (default 20, max 50) */
+    limit: z.coerce.number().int().min(1).max(50).optional().default(20),
+    /** Minimum similarity score [0–1] to include a memory (default 0.5) */
+    minScore: z.coerce.number().min(0).max(1).optional().default(0.5),
+    /** Optional scope filter */
+    scope: z.string().max(256).optional(),
+    /** Optional tag filter */
+    tags: z.array(z.string()).max(20).optional(),
+  })
+  .strict();
+
+export type PromptContextToolInput = z.infer<typeof promptContextToolSchema>;

--- a/apps/mcp-server/src/memory/memory.c1.controller.spec.ts
+++ b/apps/mcp-server/src/memory/memory.c1.controller.spec.ts
@@ -62,8 +62,8 @@ describe('MemoryController — C1 High-Level Agent UX Tools', () => {
     controller = module.get<MemoryController>(MemoryController);
   });
 
-  it('should expose 19 MCP tools', () => {
-    expect(controller.getMcpTools()).toHaveLength(19);
+  it('should expose 20 MCP tools', () => {
+    expect(controller.getMcpTools()).toHaveLength(20);
   });
 
   // ─── remember ───────────────────────────────────────────────────────────────

--- a/apps/mcp-server/src/memory/memory.c1.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.c1.service.spec.ts
@@ -453,6 +453,7 @@ describe('MemoryService — C1 High-Level Agent UX Methods', () => {
       expect(result.estimatedTokens).toBeLessThanOrEqual(result.tokenBudget);
       expect(result.tokenBudget).toBe(2000);
       expect(result.truncated).toBe(false);
+      expect(result.candidatesFound).toBe(1);
     });
 
     it('returns empty context block when no memories pass minScore', async () => {
@@ -471,6 +472,7 @@ describe('MemoryService — C1 High-Level Agent UX Methods', () => {
       expect(result.memoryCount).toBe(0);
       expect(result.context).toBe('(no memories)');
       expect(result.truncated).toBe(false);
+      expect(result.candidatesFound).toBe(1);
     });
 
     it('truncates when memories exceed the token budget', async () => {
@@ -533,7 +535,7 @@ describe('MemoryService — C1 High-Level Agent UX Methods', () => {
       );
     });
 
-    it('echoes tokenBudget in result', async () => {
+    it('echoes tokenBudget in result and reports candidatesFound=0 when no hits', async () => {
       ltmService.semanticSearch.mockResolvedValue([]);
 
       const result = await service.assemblePromptContext({
@@ -545,6 +547,29 @@ describe('MemoryService — C1 High-Level Agent UX Methods', () => {
       });
 
       expect(result.tokenBudget).toBe(750);
+      expect(result.candidatesFound).toBe(0);
+    });
+
+    it('passes createdFrom and createdTo through to semanticSearch', async () => {
+      ltmService.semanticSearch.mockResolvedValue([]);
+      const from = new Date('2025-01-01');
+      const to = new Date('2025-06-30');
+
+      await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'date-filtered query',
+        tokenBudget: 500,
+        limit: 10,
+        minScore: 0.5,
+        createdFrom: from,
+        createdTo: to,
+      });
+
+      expect(ltmService.semanticSearch).toHaveBeenCalledWith(
+        USER_ID,
+        'date-filtered query',
+        expect.objectContaining({ createdFrom: from, createdTo: to }),
+      );
     });
   });
 });
@@ -808,7 +833,7 @@ describe('MemoryService.estimateTokens (static)', () => {
     expect(MemoryService.estimateTokens('a'.repeat(100))).toBe(25);
   });
 
-  it('always over-counts (conservative)', () => {
+  it('always rounds up (ceil)', () => {
     // every string of length n → ceil(n/4) ≥ n/4
     for (const len of [1, 3, 5, 7, 99]) {
       const result = MemoryService.estimateTokens('a'.repeat(len));
@@ -824,6 +849,7 @@ describe('MemoryService.buildTokenBudgetedBlock (static)', () => {
     expect(result.memoryCount).toBe(0);
     expect(result.truncated).toBe(false);
     expect(result.tokenBudget).toBe(1000);
+    expect(result.candidatesFound).toBe(0);
   });
 
   it('includes all memories when they fit in the budget', () => {
@@ -876,8 +902,9 @@ describe('MemoryService.buildTokenBudgetedBlock (static)', () => {
     expect(result.context).toContain('[foo, bar]');
   });
 
-  it('echoes tokenBudget in result', () => {
-    const result = MemoryService.buildTokenBudgetedBlock([], 777);
+  it('echoes tokenBudget and candidatesFound in result', () => {
+    const result = MemoryService.buildTokenBudgetedBlock([], 777, 42);
     expect(result.tokenBudget).toBe(777);
+    expect(result.candidatesFound).toBe(42);
   });
 });

--- a/apps/mcp-server/src/memory/memory.c1.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.c1.service.spec.ts
@@ -3,6 +3,7 @@ import { MemoryService } from './memory.service';
 import { MemoryStmService, StmMemoryNotFoundError } from '@engram/memory-stm';
 import { MemoryLtmService, ImportanceScoringService } from '@engram/memory-ltm';
 import type { LtmMemory } from '@engram/memory-ltm';
+import type { Memory } from '@engram/database';
 
 const USER_ID = 'clm0000000000000000000000';
 const MEM_ID = 'clm1111111111111111111111';
@@ -422,6 +423,130 @@ describe('MemoryService — C1 High-Level Agent UX Methods', () => {
       expect(result.context).toBe('(no memories)');
     });
   });
+
+  // ─── assemblePromptContext ───────────────────────────────────────────────────
+
+  describe('assemblePromptContext', () => {
+    it('returns formatted context block within token budget', async () => {
+      ltmService.semanticSearch.mockResolvedValue([
+        {
+          memory: makeMemory({
+            id: MEM_ID,
+            content: 'Use Redis for caching',
+            tags: ['infra'],
+          }),
+          score: 0.85,
+        },
+      ]);
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'caching strategy',
+        tokenBudget: 2000,
+        limit: 20,
+        minScore: 0.5,
+      });
+
+      expect(result.memoryCount).toBe(1);
+      expect(result.context).toContain('Use Redis for caching');
+      expect(result.estimatedTokens).toBeGreaterThan(0);
+      expect(result.estimatedTokens).toBeLessThanOrEqual(result.tokenBudget);
+      expect(result.tokenBudget).toBe(2000);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('returns empty context block when no memories pass minScore', async () => {
+      ltmService.semanticSearch.mockResolvedValue([
+        { memory: makeMemory({ id: MEM_ID }), score: 0.3 },
+      ]);
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'obscure topic',
+        tokenBudget: 2000,
+        limit: 20,
+        minScore: 0.5,
+      });
+
+      expect(result.memoryCount).toBe(0);
+      expect(result.context).toBe('(no memories)');
+      expect(result.truncated).toBe(false);
+    });
+
+    it('truncates when memories exceed the token budget', async () => {
+      const longContent = 'x'.repeat(400); // ~100 tokens per entry
+      ltmService.semanticSearch.mockResolvedValue(
+        Array.from({ length: 10 }, (_, i) => ({
+          memory: makeMemory({ id: MEM_ID, content: longContent + String(i) }),
+          score: 0.9,
+        })),
+      );
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'anything',
+        tokenBudget: 200,
+        limit: 10,
+        minScore: 0.5,
+      });
+
+      expect(result.truncated).toBe(true);
+      expect(result.estimatedTokens).toBeLessThanOrEqual(result.tokenBudget);
+      expect(result.memoryCount).toBeGreaterThan(0);
+    });
+
+    it('enforces budget even for a single oversized memory', async () => {
+      const hugContent = 'y'.repeat(20000); // ~5000 tokens
+      ltmService.semanticSearch.mockResolvedValue([
+        { memory: makeMemory({ id: MEM_ID, content: hugContent }), score: 0.9 },
+      ]);
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'big memory',
+        tokenBudget: 300,
+        limit: 5,
+        minScore: 0.5,
+      });
+
+      expect(result.estimatedTokens).toBeLessThanOrEqual(result.tokenBudget);
+      expect(result.truncated).toBe(true);
+      expect(result.memoryCount).toBe(1);
+    });
+
+    it('passes scope through to semanticSearch', async () => {
+      ltmService.semanticSearch.mockResolvedValue([]);
+
+      await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'scoped query',
+        tokenBudget: 500,
+        limit: 10,
+        minScore: 0.5,
+        scope: 'project-x',
+      });
+
+      expect(ltmService.semanticSearch).toHaveBeenCalledWith(
+        USER_ID,
+        'scoped query',
+        expect.objectContaining({ scope: 'project-x' }),
+      );
+    });
+
+    it('echoes tokenBudget in result', async () => {
+      ltmService.semanticSearch.mockResolvedValue([]);
+
+      const result = await service.assemblePromptContext({
+        userId: USER_ID,
+        query: 'test',
+        tokenBudget: 750,
+        limit: 5,
+        minScore: 0.5,
+      });
+
+      expect(result.tokenBudget).toBe(750);
+    });
+  });
 });
 
 // ─── C2: Bulk Ingestion ──────────────────────────────────────────────────────
@@ -656,5 +781,103 @@ describe('MemoryService — C2 Bulk Conversation Ingestion', () => {
       expect(combined).toContain('Para2');
       expect(combined).toContain('Para3');
     });
+  });
+});
+
+// ─── Static Token Helpers ─────────────────────────────────────────────────────
+
+const makeRawMemory = (overrides: Partial<Memory> = {}): Memory => ({
+  id: 'clm1111111111111111111111',
+  userId: 'clm0000000000000000000000',
+  content: 'Test memory content',
+  metadata: {},
+  tags: [],
+  embedding: [],
+  type: 'long-term',
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  expiresAt: null,
+  ...overrides,
+});
+
+describe('MemoryService.estimateTokens (static)', () => {
+  it('returns ceil(chars / 4) for a simple string', () => {
+    expect(MemoryService.estimateTokens('abcd')).toBe(1); // 4/4 = 1
+    expect(MemoryService.estimateTokens('abcde')).toBe(2); // ceil(5/4) = 2
+    expect(MemoryService.estimateTokens('')).toBe(0);
+    expect(MemoryService.estimateTokens('a'.repeat(100))).toBe(25);
+  });
+
+  it('always over-counts (conservative)', () => {
+    // every string of length n → ceil(n/4) ≥ n/4
+    for (const len of [1, 3, 5, 7, 99]) {
+      const result = MemoryService.estimateTokens('a'.repeat(len));
+      expect(result).toBeGreaterThanOrEqual(len / 4);
+    }
+  });
+});
+
+describe('MemoryService.buildTokenBudgetedBlock (static)', () => {
+  it('returns (no memories) for empty input', () => {
+    const result = MemoryService.buildTokenBudgetedBlock([], 1000);
+    expect(result.context).toBe('(no memories)');
+    expect(result.memoryCount).toBe(0);
+    expect(result.truncated).toBe(false);
+    expect(result.tokenBudget).toBe(1000);
+  });
+
+  it('includes all memories when they fit in the budget', () => {
+    const memories = [
+      makeRawMemory({ content: 'short content A' }),
+      makeRawMemory({ content: 'short content B' }),
+    ];
+    const result = MemoryService.buildTokenBudgetedBlock(memories, 2000);
+    expect(result.memoryCount).toBe(2);
+    expect(result.truncated).toBe(false);
+    expect(result.estimatedTokens).toBeLessThanOrEqual(2000);
+  });
+
+  it('respects token budget: estimatedTokens ≤ tokenBudget', () => {
+    const bigContent = 'w'.repeat(10000);
+    const memories = Array.from({ length: 5 }, () =>
+      makeRawMemory({ content: bigContent }),
+    );
+    const budget = 300;
+    const result = MemoryService.buildTokenBudgetedBlock(memories, budget);
+    expect(result.estimatedTokens).toBeLessThanOrEqual(budget);
+  });
+
+  it('truncates a single memory larger than the budget', () => {
+    const hugContent = 'z'.repeat(50000); // ~12500 tokens
+    const result = MemoryService.buildTokenBudgetedBlock(
+      [makeRawMemory({ content: hugContent })],
+      200,
+    );
+    expect(result.estimatedTokens).toBeLessThanOrEqual(200);
+    expect(result.truncated).toBe(true);
+    expect(result.memoryCount).toBe(1);
+  });
+
+  it('marks truncated=true when not all memories fit', () => {
+    const memories = Array.from({ length: 20 }, (_, i) =>
+      makeRawMemory({ content: `Memory content number ${i} `.repeat(50) }),
+    );
+    const result = MemoryService.buildTokenBudgetedBlock(memories, 500);
+    expect(result.truncated).toBe(true);
+    expect(result.memoryCount).toBeLessThan(20);
+    expect(result.estimatedTokens).toBeLessThanOrEqual(500);
+  });
+
+  it('includes tags in the formatted header', () => {
+    const result = MemoryService.buildTokenBudgetedBlock(
+      [makeRawMemory({ content: 'tagged content', tags: ['foo', 'bar'] })],
+      2000,
+    );
+    expect(result.context).toContain('[foo, bar]');
+  });
+
+  it('echoes tokenBudget in result', () => {
+    const result = MemoryService.buildTokenBudgetedBlock([], 777);
+    expect(result.tokenBudget).toBe(777);
   });
 });

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -981,6 +981,8 @@ export class MemoryController {
         minScore: validated.minScore,
         scope: validated.scope,
         tags: validated.tags,
+        createdFrom: validated.createdFrom,
+        createdTo: validated.createdTo,
       });
 
       return {
@@ -997,6 +999,7 @@ export class MemoryController {
                 estimatedTokens: result.estimatedTokens,
                 tokenBudget: result.tokenBudget,
                 truncated: result.truncated,
+                candidatesFound: result.candidatesFound,
               },
               null,
               2,

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -42,6 +42,8 @@ import {
   CompressContextToolInput,
   loadContextToolSchema,
   LoadContextToolInput,
+  promptContextToolSchema,
+  PromptContextToolInput,
 } from './dto/context.dto';
 import {
   ingestConversationToolSchema,
@@ -53,7 +55,7 @@ import { ConsolidationService } from './consolidation.service';
 /**
  * MCP Memory Tools Controller
  *
- * Implements 19 MCP tools for memory management:
+ * Implements 20 MCP tools for memory management:
  * 1.  create_memory          - Create short-term or long-term memory
  * 2.  get_memory             - Retrieve memory by ID
  * 3.  list_memories          - List memories with pagination
@@ -73,6 +75,7 @@ import { ConsolidationService } from './consolidation.service';
  * 17. compress_context       - Retrieve + format memories as an injectable context block
  * 18. load_context           - Load recent + important memories for session priming
  * 19. ingest_conversation    - Bulk-ingest a conversation as chunked per-turn memories
+ * 20. prompt_context         - Token-budgeted context assembly ranked by query relevance
  */
 @Controller('memory')
 @Injectable()
@@ -959,6 +962,57 @@ export class MemoryController {
   }
 
   /**
+   * MCP Tool: prompt_context
+   * Assemble a token-budgeted, query-ranked context block for prompt injection.
+   */
+  async promptContext(
+    input: unknown,
+  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+    try {
+      this.logger.debug('prompt_context tool called');
+      const validated: PromptContextToolInput =
+        promptContextToolSchema.parse(input);
+
+      const result = await this.memoryService.assemblePromptContext({
+        userId: validated.userId,
+        query: validated.query,
+        tokenBudget: validated.tokenBudget,
+        limit: validated.limit,
+        minScore: validated.minScore,
+        scope: validated.scope,
+        tags: validated.tags,
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result.context,
+          },
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                memoryCount: result.memoryCount,
+                estimatedTokens: result.estimatedTokens,
+                tokenBudget: result.tokenBudget,
+                truncated: result.truncated,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (error) {
+      this.logger.error('Error in prompt_context tool:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error occurred';
+      throw new Error(`Failed to assemble prompt context: ${errorMessage}`);
+    }
+  }
+
+  /**
    * Get MCP tools in the format required by the MCP handler
    * This method creates Tool objects that bind controller methods as handlers
    */
@@ -1124,6 +1178,16 @@ export class MemoryController {
           'Bulk-ingest a conversation as per-turn long-term memories. Handles chunking for large turns, controls embedding back-pressure via concurrency, and is idempotent: re-submitting the same conversation returns the existing memory IDs.',
         inputSchema: ingestConversationToolSchema,
         handler: this.ingestConversation.bind(this) as (
+          input: unknown,
+        ) => Promise<unknown>,
+      },
+      // ── C3: Token-Budgeted Prompt Assembly ───────────────────────────────────
+      {
+        name: 'prompt_context',
+        description:
+          'Assemble a token-budgeted context block from memories most relevant to a query. Greedy-packs ranked memories within the token budget (1 token ≈ 4 chars). Returns the formatted block plus token accounting metadata.',
+        inputSchema: promptContextToolSchema,
+        handler: this.promptContext.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
       },

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -210,10 +210,12 @@ export interface PromptContextBlock {
   context: string;
   memoryCount: number;
   truncated: boolean;
-  /** Conservative token estimate of the assembled block (~4 chars/token) */
+  /** Token estimate of the assembled block (~4 chars/token; may under-count for CJK/emoji) */
   estimatedTokens: number;
   /** The token budget that was requested */
   tokenBudget: number;
+  /** Total candidates returned by semantic search before minScore filtering */
+  candidatesFound: number;
 }
 
 export interface IngestConversationResult {
@@ -651,17 +653,22 @@ export class MemoryService {
     minScore: number;
     scope?: string;
     tags?: string[];
+    createdFrom?: Date;
+    createdTo?: Date;
   }): Promise<PromptContextBlock> {
     const hits = await this.ltm.semanticSearch(input.userId, input.query, {
       limit: input.limit,
       scope: input.scope,
       tags: input.tags,
+      createdFrom: input.createdFrom,
+      createdTo: input.createdTo,
     });
 
     const relevant = hits.filter((h) => h.score >= input.minScore);
     return MemoryService.buildTokenBudgetedBlock(
       relevant.map((h) => h.memory),
       input.tokenBudget,
+      hits.length,
     );
   }
 
@@ -903,7 +910,12 @@ export class MemoryService {
     };
   }
 
-  /** Conservative token estimate: ceil(chars / 4). Over-counts to avoid budget overrun. */
+  /**
+   * Token estimate: ceil(chars / 4). Conservative for ASCII/English text; may
+   * severely under-count for CJK, emoji, or other multi-byte content where BPE
+   * models produce 4–6× more tokens per character. The budget guarantee only
+   * holds for predominantly ASCII input.
+   */
   static estimateTokens(text: string): number {
     return Math.ceil(text.length / 4);
   }
@@ -916,6 +928,7 @@ export class MemoryService {
   static buildTokenBudgetedBlock(
     memories: Memory[],
     tokenBudget: number,
+    candidatesFound = 0,
   ): PromptContextBlock {
     if (memories.length === 0) {
       const ctx = '(no memories)';
@@ -925,6 +938,7 @@ export class MemoryService {
         truncated: false,
         estimatedTokens: MemoryService.estimateTokens(ctx),
         tokenBudget,
+        candidatesFound,
       };
     }
 
@@ -940,7 +954,8 @@ export class MemoryService {
 
       const currentTokens = MemoryService.estimateTokens(assembled);
       const headerTokens = MemoryService.estimateTokens(entryHeader);
-      // Reserve at least 1 token for a trailing newline; use -4 safety margin for ceil rounding.
+      // -4: safety margin so ceil() rounding can't push us over budget.
+      // -3 below (in slice) matches the 3-char '...' suffix — keep both in sync.
       const maxContentChars =
         (tokenBudget - currentTokens - headerTokens) * 4 - 4;
 
@@ -964,16 +979,13 @@ export class MemoryService {
       }
     }
 
-    if (included < memories.length && !truncated) {
-      truncated = true;
-    }
-
     return {
       context: assembled,
       memoryCount: included,
       truncated,
       estimatedTokens: MemoryService.estimateTokens(assembled),
       tokenBudget,
+      candidatesFound,
     };
   }
 

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -205,6 +205,17 @@ export interface ContextBlock {
   charCount: number;
 }
 
+export interface PromptContextBlock {
+  /** Formatted text ready for prompt injection, ranked by relevance */
+  context: string;
+  memoryCount: number;
+  truncated: boolean;
+  /** Conservative token estimate of the assembled block (~4 chars/token) */
+  estimatedTokens: number;
+  /** The token budget that was requested */
+  tokenBudget: number;
+}
+
 export interface IngestConversationResult {
   /** Number of chunks successfully stored as new memories */
   ingested: number;
@@ -627,6 +638,34 @@ export class MemoryService {
   }
 
   /**
+   * Assemble a token-budgeted context block ranked by query relevance.
+   * Uses a conservative ~4 chars/token estimate so the assembled block stays
+   * within the requested budget. Memories are greedy-packed in relevance order;
+   * content is truncated when a single memory exceeds the remaining budget.
+   */
+  async assemblePromptContext(input: {
+    userId: string;
+    query: string;
+    tokenBudget: number;
+    limit: number;
+    minScore: number;
+    scope?: string;
+    tags?: string[];
+  }): Promise<PromptContextBlock> {
+    const hits = await this.ltm.semanticSearch(input.userId, input.query, {
+      limit: input.limit,
+      scope: input.scope,
+      tags: input.tags,
+    });
+
+    const relevant = hits.filter((h) => h.score >= input.minScore);
+    return MemoryService.buildTokenBudgetedBlock(
+      relevant.map((h) => h.memory),
+      input.tokenBudget,
+    );
+  }
+
+  /**
    * Load the most relevant memories for a session opening.
    * Blends recency with importance so the agent is primed with both
    * fresh context and durable knowledge.
@@ -861,6 +900,80 @@ export class MemoryService {
       memoryCount: included,
       truncated,
       charCount: context.length,
+    };
+  }
+
+  /** Conservative token estimate: ceil(chars / 4). Over-counts to avoid budget overrun. */
+  static estimateTokens(text: string): number {
+    return Math.ceil(text.length / 4);
+  }
+
+  /**
+   * Greedy-pack memories into a token-budgeted block, ranked by relevance order.
+   * Content is truncated when a single memory would otherwise overflow the budget.
+   * The assembled block is guaranteed to satisfy estimatedTokens ≤ tokenBudget.
+   */
+  static buildTokenBudgetedBlock(
+    memories: Memory[],
+    tokenBudget: number,
+  ): PromptContextBlock {
+    if (memories.length === 0) {
+      const ctx = '(no memories)';
+      return {
+        context: ctx,
+        memoryCount: 0,
+        truncated: false,
+        estimatedTokens: MemoryService.estimateTokens(ctx),
+        tokenBudget,
+      };
+    }
+
+    const preamble = '## Memory Context\n\n';
+    let assembled = preamble;
+    let included = 0;
+    let truncated = false;
+
+    for (const m of memories) {
+      const date = m.createdAt.toISOString().slice(0, 10);
+      const tagPart = m.tags.length > 0 ? ` [${m.tags.join(', ')}]` : '';
+      const entryHeader = `### [${date}]${tagPart}\n`;
+
+      const currentTokens = MemoryService.estimateTokens(assembled);
+      const headerTokens = MemoryService.estimateTokens(entryHeader);
+      // Reserve at least 1 token for a trailing newline; use -4 safety margin for ceil rounding.
+      const maxContentChars =
+        (tokenBudget - currentTokens - headerTokens) * 4 - 4;
+
+      if (maxContentChars <= 0) {
+        truncated = true;
+        break;
+      }
+
+      const contentTruncated = m.content.length > maxContentChars;
+      const content = contentTruncated
+        ? m.content.slice(0, maxContentChars - 3) + '...'
+        : m.content;
+      if (contentTruncated) truncated = true;
+
+      assembled += `${entryHeader}${content}\n`;
+      included++;
+
+      if (MemoryService.estimateTokens(assembled) >= tokenBudget) {
+        if (included < memories.length) truncated = true;
+        break;
+      }
+    }
+
+    if (included < memories.length && !truncated) {
+      truncated = true;
+    }
+
+    return {
+      context: assembled,
+      memoryCount: included,
+      truncated,
+      estimatedTokens: MemoryService.estimateTokens(assembled),
+      tokenBudget,
     };
   }
 

--- a/apps/mcp-server/test/mcp-tools.integration.spec.ts
+++ b/apps/mcp-server/test/mcp-tools.integration.spec.ts
@@ -133,7 +133,7 @@ describe('MCP Tools Integration', () => {
       list: jest.fn(),
       promote: jest.fn(),
       reindex: jest.fn(),
-      semanticSearch: jest.fn(),
+      semanticSearch: jest.fn().mockResolvedValue([]),
     };
 
     const queueMock: Partial<jest.Mocked<ReindexQueueService>> = {
@@ -910,11 +910,13 @@ describe('MCP Tools Integration', () => {
         estimatedTokens: number;
         tokenBudget: number;
         truncated: boolean;
+        candidatesFound: number;
       };
       expect(meta.memoryCount).toBe(1);
       expect(meta.tokenBudget).toBe(2000);
       expect(meta.estimatedTokens).toBeLessThanOrEqual(2000);
       expect(meta.truncated).toBe(false);
+      expect(meta.candidatesFound).toBe(1);
     });
 
     it('should return (no memories) when no hits pass minScore', async () => {

--- a/apps/mcp-server/test/mcp-tools.integration.spec.ts
+++ b/apps/mcp-server/test/mcp-tools.integration.spec.ts
@@ -133,6 +133,7 @@ describe('MCP Tools Integration', () => {
       list: jest.fn(),
       promote: jest.fn(),
       reindex: jest.fn(),
+      semanticSearch: jest.fn(),
     };
 
     const queueMock: Partial<jest.Mocked<ReindexQueueService>> = {
@@ -168,9 +169,9 @@ describe('MCP Tools Integration', () => {
   // Tool registration
   // -------------------------------------------------------------------------
   describe('getMcpTools() registration', () => {
-    it('should register exactly 19 tools', () => {
+    it('should register exactly 20 tools', () => {
       const tools = controller.getMcpTools();
-      expect(tools).toHaveLength(19);
+      expect(tools).toHaveLength(20);
     });
 
     it('should register all expected tool names', () => {
@@ -196,6 +197,8 @@ describe('MCP Tools Integration', () => {
       expect(names).toContain('load_context');
       // C2 tools
       expect(names).toContain('ingest_conversation');
+      // C3 tools
+      expect(names).toContain('prompt_context');
     });
 
     it('should attach a callable handler to each tool', () => {
@@ -878,6 +881,104 @@ describe('MCP Tools Integration', () => {
       expect(text(createResp)).toContain('Created short-term memory');
       expect(text(getResp)).toContain(MEMORY_ID);
       expect(text(deleteResp)).toBe(`Successfully deleted memory ${MEMORY_ID}`);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // prompt_context
+  // -------------------------------------------------------------------------
+  describe('prompt_context tool', () => {
+    it('should return a context block and token metadata', async () => {
+      ltmService.semanticSearch.mockResolvedValue([
+        {
+          memory: makeLtmMemory({ content: 'NestJS uses DI throughout' }),
+          score: 0.9,
+        },
+      ]);
+
+      const response = await controller.promptContext({
+        userId: USER_ID,
+        query: 'dependency injection',
+        tokenBudget: 2000,
+      });
+
+      const contextText = response.content[0]!.text;
+      expect(contextText).toContain('NestJS uses DI throughout');
+
+      const meta = JSON.parse(response.content[1]!.text) as {
+        memoryCount: number;
+        estimatedTokens: number;
+        tokenBudget: number;
+        truncated: boolean;
+      };
+      expect(meta.memoryCount).toBe(1);
+      expect(meta.tokenBudget).toBe(2000);
+      expect(meta.estimatedTokens).toBeLessThanOrEqual(2000);
+      expect(meta.truncated).toBe(false);
+    });
+
+    it('should return (no memories) when no hits pass minScore', async () => {
+      ltmService.semanticSearch.mockResolvedValue([
+        { memory: makeLtmMemory(), score: 0.2 },
+      ]);
+
+      const response = await controller.promptContext({
+        userId: USER_ID,
+        query: 'very specific niche topic',
+        tokenBudget: 500,
+        minScore: 0.8,
+      });
+
+      expect(response.content[0]!.text).toBe('(no memories)');
+    });
+
+    it('should respect token budget when multiple memories are returned', async () => {
+      const bigContent = 'a'.repeat(4000); // ~1000 tokens each
+      ltmService.semanticSearch.mockResolvedValue(
+        Array.from({ length: 5 }, () => ({
+          memory: makeLtmMemory({ content: bigContent }),
+          score: 0.85,
+        })),
+      );
+
+      const response = await controller.promptContext({
+        userId: USER_ID,
+        query: 'large context',
+        tokenBudget: 500,
+      });
+
+      const meta = JSON.parse(response.content[1]!.text) as {
+        estimatedTokens: number;
+        tokenBudget: number;
+        truncated: boolean;
+      };
+      expect(meta.estimatedTokens).toBeLessThanOrEqual(meta.tokenBudget);
+      expect(meta.truncated).toBe(true);
+    });
+
+    it('should throw wrapped error for invalid userId', async () => {
+      await expect(
+        controller.promptContext({
+          userId: 'bad-user',
+          query: 'some query',
+        }),
+      ).rejects.toThrow('Failed to assemble prompt context');
+    });
+
+    it('handler registered via getMcpTools() should be callable', async () => {
+      ltmService.semanticSearch.mockResolvedValue([]);
+
+      const tools = controller.getMcpTools();
+      const tool = tools.find((t) => t.name === 'prompt_context')!;
+      expect(tool).toBeDefined();
+      expect(typeof tool.handler).toBe('function');
+
+      const response = (await tool.handler({
+        userId: USER_ID,
+        query: 'test via handler',
+      })) as { content: Array<{ type: string; text: string }> };
+
+      expect(response.content[0]!.text).toBe('(no memories)');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a new `prompt_context` MCP tool (tool #20) that assembles a relevance-ranked, token-budgeted context block from long-term memories
- Uses a conservative `ceil(chars / 4)` token estimator — over-counts to ensure `estimatedTokens ≤ tokenBudget` is always satisfied, even for single oversized memories
- Greedy-packs memories in semantic-search rank order, truncating individual memory content when it would overflow the remaining budget
- Returns the formatted context block plus accounting metadata: `estimatedTokens`, `tokenBudget`, `memoryCount`, `truncated`

## Acceptance criteria

- [x] Accepts `query` + `tokenBudget` + optional `scope`, `tags`, `minScore`, `limit`
- [x] Returns memories ranked by relevance within budget
- [x] Token estimation accounted for (conservative ceil heuristic)
- [x] Tests verify budget adherence, including single-memory overflow edge case

## Test plan

- [x] Service unit tests: happy path, minScore filtering, budget truncation, single oversized memory, scope pass-through, tokenBudget echo
- [x] Static helper tests: `estimateTokens` (ceil invariant, over-count), `buildTokenBudgetedBlock` (empty, fits, budget limit, single oversized, truncation flag, tag header)
- [x] Integration wiring tests: formatted response, `(no memories)` path, budget respected across multiple memories, invalid userId rejection, handler callable via `getMcpTools()`
- [x] Tool count updated from 19 → 20 in both controller JSDoc and integration spec

Depends on: #178 (scoping/namespaces for `scope` parameter support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)