### PR TITLE
Add scope isolation to memory create/promote/delete paths

### DIFF
--- a/apps/mcp-server/src/memory/dto/forget.dto.ts
+++ b/apps/mcp-server/src/memory/dto/forget.dto.ts
@@ -28,6 +28,11 @@ export const forgetToolSchema = z
     confirm: z.boolean().optional().default(false),
     /** Minimum similarity score [0–1] for a memory to be considered a match */
     minScore: z.coerce.number().min(0).max(1).optional().default(0.6),
+    /**
+     * Optional namespace; when set, only memories in this scope are searched
+     * and deleted, so a scoped caller cannot forget another scope's memories.
+     */
+    scope: z.string().min(1).max(256).optional(),
   })
   .strict();
 

--- a/apps/mcp-server/src/memory/dto/get-memory.dto.ts
+++ b/apps/mcp-server/src/memory/dto/get-memory.dto.ts
@@ -1,9 +1,13 @@
 import { memoryIdSchema, userIdSchema } from '@engram/database';
 import { z } from 'zod';
 
-export const getMemoryToolSchema = z.object({
-  userId: userIdSchema,
-  memoryId: memoryIdSchema,
-});
+export const getMemoryToolSchema = z
+  .object({
+    userId: userIdSchema,
+    memoryId: memoryIdSchema,
+    /** Optional namespace; when set, the memory is only returned if it lives in this scope. */
+    scope: z.string().min(1).max(256).optional(),
+  })
+  .strict();
 
 export type GetMemoryToolInput = z.infer<typeof getMemoryToolSchema>;

--- a/apps/mcp-server/src/memory/dto/update-memory.dto.ts
+++ b/apps/mcp-server/src/memory/dto/update-memory.dto.ts
@@ -1,17 +1,24 @@
 import { memoryIdSchema, userIdSchema } from '@engram/database';
 import { z } from 'zod';
 
-export const updateMemoryToolSchema = z.object({
-  userId: userIdSchema,
-  memoryId: memoryIdSchema,
-  content: z
-    .string()
-    .min(1, 'Content cannot be empty')
-    .max(10240, 'Content cannot exceed 10KB')
-    .optional(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
-  tags: z.array(z.string().min(1).max(100)).max(50).optional(),
-  ttl: z.coerce.number().int().min(60).max(604800).optional(),
-});
+export const updateMemoryToolSchema = z
+  .object({
+    userId: userIdSchema,
+    memoryId: memoryIdSchema,
+    content: z
+      .string()
+      .min(1, 'Content cannot be empty')
+      .max(10240, 'Content cannot exceed 10KB')
+      .optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+    tags: z.array(z.string().min(1).max(100)).max(50).optional(),
+    ttl: z.coerce.number().int().min(60).max(604800).optional(),
+    /**
+     * Optional namespace used to locate the memory. Scope is immutable, so this
+     * filters which memory is updated rather than changing its scope.
+     */
+    scope: z.string().min(1).max(256).optional(),
+  })
+  .strict();
 
 export type UpdateMemoryToolInput = z.infer<typeof updateMemoryToolSchema>;

--- a/apps/mcp-server/src/memory/memory.c1.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.c1.service.spec.ts
@@ -236,6 +236,50 @@ describe('MemoryService — C1 High-Level Agent UX Methods', () => {
       expect(result.candidates).toHaveLength(1);
       expect(result.candidates[0]!.memoryId).toBe('clm2222222222222222222222');
     });
+
+    it('confines both the search and the deletions to the provided scope', async () => {
+      const mem1 = makeMemory({
+        id: 'clm2222222222222222222222',
+        content: 'scoped secret',
+        scope: 'agent:alpha',
+      });
+      ltmService.semanticSearch.mockResolvedValue([
+        { memory: mem1, score: 0.95 },
+      ]);
+      mockStmService.delete.mockRejectedValue(
+        new StmMemoryNotFoundError('clm2222222222222222222222'),
+      );
+      mockLtmService.delete.mockResolvedValue(true);
+
+      await service.forget({
+        userId: USER_ID,
+        query: 'secret',
+        limit: 5,
+        confirm: true,
+        minScore: 0.7,
+        scope: 'agent:alpha',
+      });
+
+      // The semantic search is scoped to the caller's namespace…
+      expect(ltmService.semanticSearch).toHaveBeenCalledWith(
+        USER_ID,
+        'secret',
+        expect.objectContaining({ scope: 'agent:alpha' }),
+      );
+      // …and the deletion carries that scope through to both stores.
+      expect(mockStmService.delete).toHaveBeenCalledWith(
+        USER_ID,
+        'clm2222222222222222222222',
+        undefined,
+        'agent:alpha',
+      );
+      expect(mockLtmService.delete).toHaveBeenCalledWith(
+        USER_ID,
+        'clm2222222222222222222222',
+        undefined,
+        'agent:alpha',
+      );
+    });
   });
 
   // ─── reflect ────────────────────────────────────────────────────────────────

--- a/apps/mcp-server/src/memory/memory.controller.spec.ts
+++ b/apps/mcp-server/src/memory/memory.controller.spec.ts
@@ -544,6 +544,7 @@ describe('MemoryController', () => {
       expect(mockMemoryService.getMemory).toHaveBeenCalledWith(
         userId,
         memoryId,
+        undefined,
       );
     });
 
@@ -644,6 +645,7 @@ describe('MemoryController', () => {
           tags: undefined,
           ttl: undefined,
         },
+        undefined,
       );
       expect(response.content[0]?.text).toContain(memoryId);
     });
@@ -678,6 +680,7 @@ describe('MemoryController', () => {
       expect(mockMemoryService.deleteMemory).toHaveBeenCalledWith(
         userId,
         memoryId,
+        undefined,
       );
     });
 
@@ -714,6 +717,7 @@ describe('MemoryController', () => {
       expect(mockMemoryService.promoteMemory).toHaveBeenCalledWith(
         userId,
         memoryId,
+        undefined,
       );
       expect(response.content[0]?.text).toContain('Successfully promoted');
       expect(response.content[0]?.text).toContain(memoryId);

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -160,6 +160,7 @@ export class MemoryController {
       const memory = await this.memoryService.getMemory(
         validatedInput.userId,
         validatedInput.memoryId,
+        validatedInput.scope,
       );
 
       if (!memory) {
@@ -271,6 +272,7 @@ export class MemoryController {
         validatedInput.userId,
         validatedInput.memoryId,
         updateDto,
+        validatedInput.scope,
       );
 
       return {
@@ -307,6 +309,7 @@ export class MemoryController {
       const deleted = await this.memoryService.deleteMemory(
         validatedInput.userId,
         validatedInput.memoryId,
+        validatedInput.scope,
       );
 
       return {
@@ -345,6 +348,7 @@ export class MemoryController {
       const promotedMemory = await this.memoryService.promoteMemory(
         validatedInput.userId,
         validatedInput.memoryId,
+        validatedInput.scope,
       );
 
       return {
@@ -751,6 +755,7 @@ export class MemoryController {
         limit: validated.limit,
         confirm: validated.confirm,
         minScore: validated.minScore,
+        scope: validated.scope,
       });
 
       return {

--- a/apps/mcp-server/src/memory/memory.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.service.spec.ts
@@ -137,7 +137,12 @@ describe('MemoryService', () => {
       const result = await service.getMemory('user-1', 'stm-123');
 
       expect(result).toEqual(mockStmMemory);
-      expect(stmService.findById).toHaveBeenCalledWith('user-1', 'stm-123');
+      expect(stmService.findById).toHaveBeenCalledWith(
+        'user-1',
+        'stm-123',
+        undefined,
+        undefined,
+      );
       expect(ltmService.get).not.toHaveBeenCalled();
     });
 
@@ -150,8 +155,18 @@ describe('MemoryService', () => {
       const result = await service.getMemory('user-1', 'ltm-456');
 
       expect(result).toEqual(mockLtmMemory);
-      expect(stmService.findById).toHaveBeenCalledWith('user-1', 'ltm-456');
-      expect(ltmService.get).toHaveBeenCalledWith('user-1', 'ltm-456');
+      expect(stmService.findById).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        undefined,
+      );
+      expect(ltmService.get).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        undefined,
+      );
     });
 
     it('should return null if memory not found in either store', async () => {
@@ -173,6 +188,28 @@ describe('MemoryService', () => {
         'Redis connection failed',
       );
       expect(ltmService.get).not.toHaveBeenCalled();
+    });
+
+    it('forwards a provided scope to both STM and LTM lookups', async () => {
+      stmService.findById.mockRejectedValue(
+        new StmMemoryNotFoundError('ltm-456'),
+      );
+      ltmService.get.mockResolvedValue(mockLtmMemory);
+
+      await service.getMemory('user-1', 'ltm-456', 'agent:alpha');
+
+      expect(stmService.findById).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        'agent:alpha',
+      );
+      expect(ltmService.get).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        'agent:alpha',
+      );
     });
   });
 
@@ -321,6 +358,34 @@ describe('MemoryService', () => {
       expect(result.startCursor).toBeUndefined();
       expect(result.endCursor).toBeUndefined();
     });
+
+    it('forwards the scope filter to BOTH the STM and LTM list calls', async () => {
+      stmService.list.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+      ltmService.list.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+
+      await service.listMemories('user-1', { limit: 20, scope: 'agent:alpha' });
+
+      // Regression: STM previously dropped the scope filter, leaking other
+      // namespaces' short-term memories into a scoped list.
+      expect(stmService.list).toHaveBeenCalledWith('user-1', {
+        limit: 20,
+        scope: 'agent:alpha',
+      });
+      expect(ltmService.list).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ scope: 'agent:alpha' }),
+      );
+    });
   });
 
   describe('updateMemory', () => {
@@ -336,12 +401,18 @@ describe('MemoryService', () => {
       });
 
       expect(result.content).toBe('Updated content');
-      expect(stmService.update).toHaveBeenCalledWith('user-1', 'stm-123', {
-        content: 'Updated content',
-        metadata: undefined,
-        tags: [],
-        ttl: undefined,
-      });
+      expect(stmService.update).toHaveBeenCalledWith(
+        'user-1',
+        'stm-123',
+        {
+          content: 'Updated content',
+          metadata: undefined,
+          tags: [],
+          ttl: undefined,
+        },
+        undefined,
+        undefined,
+      );
     });
 
     it('should update memory in LTM if not found in STM', async () => {
@@ -359,11 +430,17 @@ describe('MemoryService', () => {
       });
 
       expect(result.content).toBe('Updated content');
-      expect(ltmService.update).toHaveBeenCalledWith('user-1', 'ltm-456', {
-        content: 'Updated content',
-        metadata: undefined,
-        tags: undefined,
-      });
+      expect(ltmService.update).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        {
+          content: 'Updated content',
+          metadata: undefined,
+          tags: undefined,
+        },
+        undefined,
+        undefined,
+      );
     });
 
     it('should throw NotFoundException if memory not found in either store', async () => {
@@ -398,7 +475,12 @@ describe('MemoryService', () => {
       const result = await service.deleteMemory('user-1', 'stm-123');
 
       expect(result).toBe(true);
-      expect(stmService.delete).toHaveBeenCalledWith('user-1', 'stm-123');
+      expect(stmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'stm-123',
+        undefined,
+        undefined,
+      );
     });
 
     it('should delete from LTM successfully', async () => {
@@ -410,7 +492,12 @@ describe('MemoryService', () => {
       const result = await service.deleteMemory('user-1', 'ltm-456');
 
       expect(result).toBe(true);
-      expect(ltmService.delete).toHaveBeenCalledWith('user-1', 'ltm-456');
+      expect(ltmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'ltm-456',
+        undefined,
+        undefined,
+      );
     });
 
     it('should return false if not found in either store', async () => {
@@ -430,8 +517,18 @@ describe('MemoryService', () => {
 
       const result = await service.deleteMemory('user-1', 'dual-store-id');
 
-      expect(stmService.delete).toHaveBeenCalledWith('user-1', 'dual-store-id');
-      expect(ltmService.delete).toHaveBeenCalledWith('user-1', 'dual-store-id');
+      expect(stmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'dual-store-id',
+        undefined,
+        undefined,
+      );
+      expect(ltmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'dual-store-id',
+        undefined,
+        undefined,
+      );
       expect(result).toBe(true);
     });
 
@@ -456,6 +553,26 @@ describe('MemoryService', () => {
         'Database connection failed',
       );
     });
+
+    it('forwards a provided scope to both STM and LTM deletes', async () => {
+      stmService.delete.mockResolvedValue(undefined);
+      ltmService.delete.mockResolvedValue(true);
+
+      await service.deleteMemory('user-1', 'mem-1', 'agent:alpha');
+
+      expect(stmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'mem-1',
+        undefined,
+        'agent:alpha',
+      );
+      expect(ltmService.delete).toHaveBeenCalledWith(
+        'user-1',
+        'mem-1',
+        undefined,
+        'agent:alpha',
+      );
+    });
   });
 
   describe('promoteMemory', () => {
@@ -465,7 +582,12 @@ describe('MemoryService', () => {
       const result = await service.promoteMemory('user-1', 'stm-123');
 
       expect(result).toEqual(mockLtmMemory);
-      expect(ltmService.promote).toHaveBeenCalledWith('user-1', 'stm-123');
+      expect(ltmService.promote).toHaveBeenCalledWith(
+        'user-1',
+        'stm-123',
+        undefined,
+        undefined,
+      );
     });
   });
 

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -30,7 +30,12 @@ type StmServiceContract = {
     tags?: string[];
     ttl?: number;
   }) => Promise<Memory>;
-  findById: (userId: string, memoryId: string) => Promise<Memory>;
+  findById: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<Memory>;
   update: (
     userId: string,
     memoryId: string,
@@ -40,11 +45,18 @@ type StmServiceContract = {
       tags?: string[];
       ttl?: number;
     },
+    organizationId?: string,
+    scope?: string,
   ) => Promise<Memory>;
-  delete: (userId: string, memoryId: string) => Promise<void>;
+  delete: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<void>;
   list: (
     userId: string,
-    options: { limit: number },
+    options: { limit: number; scope?: string },
   ) => Promise<MemoryListResult>;
 };
 
@@ -57,7 +69,12 @@ type LtmServiceContract = {
     tags?: string[];
     skipDuplicateCheck?: boolean;
   }) => Promise<Memory>;
-  get: (userId: string, memoryId: string) => Promise<Memory | null>;
+  get: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<Memory | null>;
   update: (
     userId: string,
     memoryId: string,
@@ -66,8 +83,15 @@ type LtmServiceContract = {
       metadata?: Record<string, unknown>;
       tags?: string[];
     },
+    organizationId?: string,
+    scope?: string,
   ) => Promise<Memory>;
-  delete: (userId: string, memoryId: string) => Promise<boolean>;
+  delete: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<boolean>;
   list: (
     userId: string,
     options: {
@@ -80,7 +104,12 @@ type LtmServiceContract = {
       sortOrder?: 'asc' | 'desc';
     },
   ) => Promise<MemoryListResult>;
-  promote: (userId: string, memoryId: string) => Promise<Memory>;
+  promote: (
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string,
+  ) => Promise<Memory>;
   semanticSearch: (
     userId: string,
     query: string,
@@ -281,19 +310,34 @@ export class MemoryService {
   /**
    * Get a memory - tries STM first, then falls back to LTM
    */
-  async getMemory(userId: string, memoryId: string): Promise<Memory | null> {
+  async getMemory(
+    userId: string,
+    memoryId: string,
+    scope?: string,
+  ): Promise<Memory | null> {
     this.logger.debug(`Getting memory ${memoryId} for user: ${userId}`);
 
     try {
-      // Try STM first (faster access)
-      const stmMemory = await this.stm.findById(userId, memoryId);
+      // Try STM first (faster access). Scope is forwarded so a namespaced
+      // caller cannot read another scope's memory by id.
+      const stmMemory = await this.stm.findById(
+        userId,
+        memoryId,
+        undefined,
+        scope,
+      );
       return stmMemory;
     } catch (error) {
       if (error instanceof StmMemoryNotFoundError) {
         // Not in STM, try LTM
         this.logger.debug(`Memory ${memoryId} not found in STM, checking LTM`);
         try {
-          const ltmMemory = await this.ltm.get(userId, memoryId);
+          const ltmMemory = await this.ltm.get(
+            userId,
+            memoryId,
+            undefined,
+            scope,
+          );
           return ltmMemory;
         } catch (ltmError) {
           if (ltmError instanceof LtmMemoryNotFoundError) {
@@ -325,7 +369,7 @@ export class MemoryService {
     // Note: STM list is not fully implemented yet, but we'll call it anyway
     const [stmResult, ltmResult] = await Promise.all([
       this.stm
-        .list(userId, { limit })
+        .list(userId, { limit, scope: options.scope })
         .catch(() => ({ items: [] as Memory[], totalCount: 0 })),
       this.ltm.list(userId, {
         limit,
@@ -371,40 +415,59 @@ export class MemoryService {
     userId: string,
     memoryId: string,
     updates: UpdateMemoryDto,
+    scope?: string,
   ): Promise<Memory> {
     this.logger.debug(
       `Updating memory ${memoryId} for user: ${userId} with updates:`,
       updates,
     );
 
-    // Try to find the memory first to determine which service to use
+    // Try to find the memory first to determine which service to use. Scope is
+    // forwarded so a namespaced caller cannot locate or modify a foreign memory.
     try {
       // Try STM first
-      await this.stm.findById(userId, memoryId);
+      await this.stm.findById(userId, memoryId, undefined, scope);
 
       // Found in STM, update it
-      return await this.stm.update(userId, memoryId, {
-        content: updates.content,
-        metadata: updates.metadata,
-        tags: updates.tags ?? ([] as string[]),
-        ttl: updates.ttl,
-      });
+      return await this.stm.update(
+        userId,
+        memoryId,
+        {
+          content: updates.content,
+          metadata: updates.metadata,
+          tags: updates.tags ?? ([] as string[]),
+          ttl: updates.ttl,
+        },
+        undefined,
+        scope,
+      );
     } catch (error) {
       if (error instanceof StmMemoryNotFoundError) {
         // Not in STM, try LTM
         this.logger.debug(`Memory ${memoryId} not in STM, trying LTM`);
 
-        const ltmMemory = await this.ltm.get(userId, memoryId);
+        const ltmMemory = await this.ltm.get(
+          userId,
+          memoryId,
+          undefined,
+          scope,
+        );
         if (!ltmMemory) {
           throw new NotFoundException(`Memory ${memoryId} not found`);
         }
 
         // Update in LTM (TTL is ignored for LTM)
-        return await this.ltm.update(userId, memoryId, {
-          content: updates.content,
-          metadata: updates.metadata,
-          tags: updates.tags,
-        });
+        return await this.ltm.update(
+          userId,
+          memoryId,
+          {
+            content: updates.content,
+            metadata: updates.metadata,
+            tags: updates.tags,
+          },
+          undefined,
+          scope,
+        );
       }
       throw error;
     }
@@ -413,15 +476,20 @@ export class MemoryService {
   /**
    * Delete a memory - tries both STM and LTM
    */
-  async deleteMemory(userId: string, memoryId: string): Promise<boolean> {
+  async deleteMemory(
+    userId: string,
+    memoryId: string,
+    scope?: string,
+  ): Promise<boolean> {
     this.logger.debug(`Deleting memory ${memoryId} for user: ${userId}`);
 
     let deletedFromStm = false;
     let deletedFromLtm = false;
 
-    // Try to delete from STM
+    // Try to delete from STM. Scope is forwarded so a namespaced caller cannot
+    // delete a memory that lives in a different scope.
     try {
-      await this.stm.delete(userId, memoryId);
+      await this.stm.delete(userId, memoryId, undefined, scope);
       deletedFromStm = true;
       this.logger.debug(`Memory ${memoryId} deleted from STM`);
     } catch (error) {
@@ -432,7 +500,12 @@ export class MemoryService {
 
     // Try to delete from LTM
     try {
-      deletedFromLtm = await this.ltm.delete(userId, memoryId);
+      deletedFromLtm = await this.ltm.delete(
+        userId,
+        memoryId,
+        undefined,
+        scope,
+      );
       if (deletedFromLtm) {
         this.logger.debug(`Memory ${memoryId} deleted from LTM`);
       }
@@ -449,13 +522,18 @@ export class MemoryService {
   /**
    * Promote a memory from STM to LTM
    */
-  async promoteMemory(userId: string, memoryId: string): Promise<Memory> {
+  async promoteMemory(
+    userId: string,
+    memoryId: string,
+    scope?: string,
+  ): Promise<Memory> {
     this.logger.debug(
       `Promoting memory ${memoryId} from STM to LTM for user: ${userId}`,
     );
 
-    // Use LTM service's promote method which handles the transfer
-    return await this.ltm.promote(userId, memoryId);
+    // Use LTM service's promote method which handles the transfer. Scope is
+    // forwarded so a namespaced caller cannot promote a foreign-scope memory.
+    return await this.ltm.promote(userId, memoryId, undefined, scope);
   }
 
   /**
@@ -536,9 +614,13 @@ export class MemoryService {
     limit: number;
     confirm: boolean;
     minScore: number;
+    scope?: string;
   }): Promise<ForgetResult> {
+    // Confine both the search and the deletion to the caller's namespace so a
+    // scoped `forget` cannot surface or remove memories from another scope.
     const hits = await this.ltm.semanticSearch(input.userId, input.query, {
       limit: input.limit,
+      scope: input.scope,
     });
 
     const candidates: ForgetCandidate[] = hits
@@ -552,7 +634,9 @@ export class MemoryService {
     let deleted = 0;
     if (input.confirm && candidates.length > 0) {
       const results = await Promise.allSettled(
-        candidates.map((c) => this.deleteMemory(input.userId, c.memoryId)),
+        candidates.map((c) =>
+          this.deleteMemory(input.userId, c.memoryId, input.scope),
+        ),
       );
       deleted = results.filter(
         (r) => r.status === 'fulfilled' && r.value,

--- a/apps/mcp-server/test/memory-promotion.integration.spec.ts
+++ b/apps/mcp-server/test/memory-promotion.integration.spec.ts
@@ -85,7 +85,12 @@ describe('MemoryService Promotion Integration', () => {
       const result = await service.promoteMemory(TEST_USER_ID, STM_ID);
 
       expect(result).toEqual(promoted);
-      expect(ltmService.promote).toHaveBeenCalledWith(TEST_USER_ID, STM_ID);
+      expect(ltmService.promote).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        STM_ID,
+        undefined,
+        undefined,
+      );
       expect(ltmService.promote).toHaveBeenCalledTimes(1);
     });
 
@@ -202,10 +207,14 @@ describe('MemoryService Promotion Integration', () => {
       expect(stmService.findById).toHaveBeenCalledWith(
         TEST_USER_ID,
         promotedResult.id,
+        undefined,
+        undefined,
       );
       expect(ltmService.get).toHaveBeenCalledWith(
         TEST_USER_ID,
         promotedResult.id,
+        undefined,
+        undefined,
       );
     });
   });

--- a/apps/mcp-server/test/memory.integration.spec.ts
+++ b/apps/mcp-server/test/memory.integration.spec.ts
@@ -142,7 +142,12 @@ describe('MemoryService Integration', () => {
       const result = await service.getMemory(TEST_USER_ID, STM_ID);
 
       expect(result).toEqual(memory);
-      expect(stmService.findById).toHaveBeenCalledWith(TEST_USER_ID, STM_ID);
+      expect(stmService.findById).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        STM_ID,
+        undefined,
+        undefined,
+      );
       expect(ltmService.get).not.toHaveBeenCalled();
     });
 
@@ -168,7 +173,12 @@ describe('MemoryService Integration', () => {
       const result = await service.deleteMemory(TEST_USER_ID, STM_ID);
 
       expect(result).toBe(true);
-      expect(stmService.delete).toHaveBeenCalledWith(TEST_USER_ID, STM_ID);
+      expect(stmService.delete).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        STM_ID,
+        undefined,
+        undefined,
+      );
     });
   });
 
@@ -205,8 +215,18 @@ describe('MemoryService Integration', () => {
       const result = await service.getMemory(TEST_USER_ID, LTM_ID);
 
       expect(result).toEqual(memory);
-      expect(stmService.findById).toHaveBeenCalledWith(TEST_USER_ID, LTM_ID);
-      expect(ltmService.get).toHaveBeenCalledWith(TEST_USER_ID, LTM_ID);
+      expect(stmService.findById).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        LTM_ID,
+        undefined,
+        undefined,
+      );
+      expect(ltmService.get).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        LTM_ID,
+        undefined,
+        undefined,
+      );
     });
 
     it('should update LTM memory when not found in STM', async () => {
@@ -231,7 +251,12 @@ describe('MemoryService Integration', () => {
       const result = await service.deleteMemory(TEST_USER_ID, LTM_ID);
 
       expect(result).toBe(true);
-      expect(ltmService.delete).toHaveBeenCalledWith(TEST_USER_ID, LTM_ID);
+      expect(ltmService.delete).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        LTM_ID,
+        undefined,
+        undefined,
+      );
     });
   });
 

--- a/packages/memory-ltm/src/memory-ltm.reindex.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.reindex.spec.ts
@@ -10,7 +10,9 @@ function buildMemory(id: string, overrides: Record<string, unknown> = {}) {
     id,
     userId: mockUserId,
     content: `content-${id}`,
-    metadata: { scope: 'session-1' },
+    // Scope is a first-class column; the vector payload is derived from it.
+    scope: 'session-1',
+    metadata: null,
     tags: ['test'],
     type: MemoryType.LONG_TERM,
     createdAt: new Date('2025-01-01T00:00:00Z'),

--- a/packages/memory-ltm/src/memory-ltm.scope-isolation.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.scope-isolation.spec.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryLtmService } from './memory-ltm.service';
+import { DuplicateDetectionService } from './duplicate-detection.service';
+import { ContradictionDetectionService } from './contradiction-detection.service';
+import { MemoryType } from '@engram/database';
+import type { VectorStore } from '@engram/vector-store';
+
+/**
+ * Regression coverage for cross-scope leaks in the LTM create/promote paths:
+ *  - exact-content dedup ({@link MemoryLtmService} findExactDuplicate)
+ *  - semantic dedup (findDuplicate)
+ *  - contradiction / supersession (findContradictionCandidate)
+ *
+ * An unscoped write must never collapse into — or supersede — a scoped memory,
+ * and a scoped write must stay inside its own namespace.
+ */
+
+const USER = 'cldx4k8xp000108l83h4y8v2q';
+const SCOPE_A = 'agent:alpha';
+
+type Row = {
+  id: string;
+  userId: string;
+  organizationId: string | null;
+  scope: string | null;
+  content: string;
+  metadata: Record<string, unknown> | null;
+  tags: string[];
+  type: string;
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: null;
+  embedding: number[];
+};
+
+function makeRow(overrides: Partial<Row>): Row {
+  return {
+    id: 'row-1',
+    userId: USER,
+    organizationId: null,
+    scope: null,
+    content: 'content',
+    metadata: null,
+    tags: [],
+    type: MemoryType.LONG_TERM,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    expiresAt: null,
+    embedding: [0.1, 0.2, 0.3],
+    ...overrides,
+  };
+}
+
+/**
+ * Faithful Prisma `where` matcher: a `scope` key set to `null` means "scope IS
+ * NULL" (only unscoped rows), a string means that exact scope, and an absent
+ * key means no scope constraint — exactly how Prisma treats it.
+ */
+function whereMatches(row: Row, where: Record<string, unknown>): boolean {
+  if (where.userId && row.userId !== where.userId) return false;
+  if (where.type && row.type !== where.type) return false;
+  if (where.content !== undefined && row.content !== where.content) return false;
+  if ('scope' in where && row.scope !== (where.scope ?? null)) return false;
+  if (where.id) {
+    if (typeof where.id === 'object' && where.id !== null && 'in' in where.id) {
+      if (!(where.id as { in: string[] }).in.includes(row.id)) return false;
+    } else if (row.id !== where.id) {
+      return false;
+    }
+  }
+  return true;
+}
+
+describe('MemoryLtmService — create/promote scope isolation', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let db: Row[];
+
+  function buildPrisma(rows: Row[]) {
+    db = rows;
+    return {
+      memory: {
+        findFirst: vi.fn(({ where }) => Promise.resolve(db.find((r) => whereMatches(r, where)) ?? null)),
+        findMany: vi.fn(({ where }) => Promise.resolve(db.filter((r) => whereMatches(r, where)))),
+        create: vi.fn(({ data }: { data: Partial<Row> }) =>
+          Promise.resolve(makeRow({ ...data, id: 'row-new' }))
+        ),
+        update: vi.fn(({ data }: { data: Record<string, unknown> }) =>
+          Promise.resolve(makeRow({ id: 'row-existing', ...data }))
+        ),
+        count: vi.fn().mockResolvedValue(0),
+      },
+      $transaction: vi.fn(),
+    };
+  }
+
+  const embeddings = {
+    generate: vi.fn().mockResolvedValue({ embedding: [0.1, 0.2, 0.3] }),
+  };
+
+  function makeVectorStore(hits: Array<{ id: string; score: number; payload?: Record<string, unknown> }>) {
+    return {
+      backend: 'qdrant',
+      ensureReady: vi.fn().mockResolvedValue(undefined),
+      upsert: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      search: vi.fn().mockResolvedValue(hits),
+    } as unknown as VectorStore & { search: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    embeddings.generate.mockResolvedValue({ embedding: [0.1, 0.2, 0.3] });
+  });
+
+  // ── #4 exact-content dedup ────────────────────────────────────────────────
+  describe('exact-content dedup (findExactDuplicate)', () => {
+    it('an unscoped create does NOT dedup against a scoped memory with identical content', async () => {
+      prisma = buildPrisma([makeRow({ id: 'scoped', scope: SCOPE_A, content: 'shared text' })]);
+      const service = new MemoryLtmService(prisma);
+
+      const result = await service.create({ userId: USER, content: 'shared text' });
+
+      // A brand-new unscoped row is written rather than returning the scoped one.
+      expect(prisma.memory.create).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe('row-new');
+      // The dedup probe constrained scope to NULL (unscoped only).
+      expect(prisma.memory.findFirst).toHaveBeenCalledWith({
+        where: expect.objectContaining({ content: 'shared text', scope: null }),
+      });
+    });
+
+    it('a scoped create does NOT dedup against an unscoped memory with identical content', async () => {
+      prisma = buildPrisma([makeRow({ id: 'unscoped', scope: null, content: 'shared text' })]);
+      const service = new MemoryLtmService(prisma);
+
+      const result = await service.create({ userId: USER, scope: SCOPE_A, content: 'shared text' });
+
+      expect(prisma.memory.create).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe('row-new');
+      expect(prisma.memory.findFirst).toHaveBeenCalledWith({
+        where: expect.objectContaining({ content: 'shared text', scope: SCOPE_A }),
+      });
+    });
+
+    it('a scoped create DOES dedup against a same-scope memory with identical content', async () => {
+      prisma = buildPrisma([makeRow({ id: 'same-scope', scope: SCOPE_A, content: 'shared text' })]);
+      const service = new MemoryLtmService(prisma);
+
+      const result = await service.create({ userId: USER, scope: SCOPE_A, content: 'shared text' });
+
+      // Existing row returned; no new write.
+      expect(prisma.memory.create).not.toHaveBeenCalled();
+      expect(result.id).toBe('same-scope');
+    });
+
+    it('an unscoped create DOES dedup against an unscoped memory with identical content', async () => {
+      prisma = buildPrisma([makeRow({ id: 'unscoped', scope: null, content: 'shared text' })]);
+      const service = new MemoryLtmService(prisma);
+
+      const result = await service.create({ userId: USER, content: 'shared text' });
+
+      expect(prisma.memory.create).not.toHaveBeenCalled();
+      expect(result.id).toBe('unscoped');
+    });
+  });
+
+  // ── #6 semantic dedup ─────────────────────────────────────────────────────
+  describe('semantic dedup (findDuplicate)', () => {
+    it('passes the create scope into the vector-store search filter', async () => {
+      prisma = buildPrisma([]);
+      const vectorStore = makeVectorStore([]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService()
+      );
+
+      await service.create({ userId: USER, scope: SCOPE_A, content: 'new fact' });
+
+      expect(vectorStore.search).toHaveBeenCalledWith(
+        [0.1, 0.2, 0.3],
+        expect.objectContaining({ scope: SCOPE_A, type: MemoryType.LONG_TERM }),
+        expect.any(Number)
+      );
+    });
+
+    it('drops a cross-scope vector hit so an unscoped create is not deduped against a scoped memory', async () => {
+      prisma = buildPrisma([makeRow({ id: 'scoped', scope: SCOPE_A, content: 'similar' })]);
+      // A near-identical hit, but it belongs to SCOPE_A.
+      const vectorStore = makeVectorStore([{ id: 'scoped', score: 0.999, payload: { userId: USER, scope: SCOPE_A } }]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService()
+      );
+
+      const result = await service.create({ userId: USER, content: 'similar' });
+
+      // Not deduped: a fresh unscoped row is written, the scoped one is untouched.
+      expect(prisma.memory.create).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe('row-new');
+    });
+
+    it('dedups against a same-scope vector hit', async () => {
+      prisma = buildPrisma([makeRow({ id: 'row-existing', scope: SCOPE_A, content: 'similar' })]);
+      const vectorStore = makeVectorStore([{ id: 'row-existing', score: 0.999, payload: { userId: USER, scope: SCOPE_A } }]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService()
+      );
+
+      const result = await service.create({ userId: USER, scope: SCOPE_A, content: 'similar' });
+
+      // Linked to the existing row (annotated via update), no new row created.
+      expect(prisma.memory.create).not.toHaveBeenCalled();
+      expect(result.id).toBe('row-existing');
+    });
+  });
+
+  // ── #7 contradiction / supersession ───────────────────────────────────────
+  describe('contradiction detection (findContradictionCandidate)', () => {
+    it('confines the candidate content query to the create scope', async () => {
+      prisma = buildPrisma([]);
+      const vectorStore = makeVectorStore([{ id: 'other', score: 0.5, payload: { userId: USER } }]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService(),
+        undefined,
+        new ContradictionDetectionService()
+      );
+
+      await service.create({ userId: USER, scope: SCOPE_A, content: 'the sky is green' });
+
+      // The content-hydration query for contradiction candidates is scoped.
+      const scopedFindMany = prisma.memory.findMany.mock.calls.find(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (call: any) => call[0]?.where && 'id' in call[0].where && call[0].where.id?.in
+      );
+      expect(scopedFindMany).toBeDefined();
+      expect(scopedFindMany![0].where.scope).toBe(SCOPE_A);
+    });
+
+    it('uses scope IS NULL for the candidate content query on an unscoped create', async () => {
+      prisma = buildPrisma([]);
+      const vectorStore = makeVectorStore([{ id: 'other', score: 0.5, payload: { userId: USER } }]);
+      const service = new MemoryLtmService(
+        prisma,
+        undefined,
+        embeddings as never,
+        vectorStore,
+        undefined,
+        new DuplicateDetectionService(),
+        undefined,
+        new ContradictionDetectionService()
+      );
+
+      await service.create({ userId: USER, content: 'the sky is green' });
+
+      const scopedFindMany = prisma.memory.findMany.mock.calls.find(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (call: any) => call[0]?.where && 'id' in call[0].where && call[0].where.id?.in
+      );
+      expect(scopedFindMany).toBeDefined();
+      expect(scopedFindMany![0].where.scope).toBeNull();
+    });
+  });
+});

--- a/packages/memory-ltm/src/memory-ltm.semantic.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.semantic.spec.ts
@@ -11,7 +11,10 @@ function buildMemory(overrides: Record<string, unknown> = {}): Record<string, un
     id: mockMemoryId,
     userId: mockUserId,
     content: 'Test memory content',
-    metadata: { scope: 'session-1' },
+    // Scope is a first-class column (not metadata) — the vector payload reads it
+    // from here, so the mock row must carry it as a top-level field.
+    scope: 'session-1',
+    metadata: null,
     tags: ['test'],
     type: MemoryType.LONG_TERM,
     createdAt: new Date('2025-01-01T00:00:00Z'),
@@ -68,7 +71,7 @@ describe('MemoryLtmService — vector lifecycle & semantic search', () => {
       await service.create({
         userId: mockUserId,
         content: 'Test memory content',
-        metadata: { scope: 'session-1' },
+        scope: 'session-1',
         tags: ['test'],
       });
 

--- a/packages/memory-ltm/src/memory-ltm.service.spec.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.spec.ts
@@ -569,7 +569,12 @@ describe('MemoryLtmService', () => {
 
       const result = await service.promote(mockUserId, mockMemoryId);
 
-      expect(stmService.findById).toHaveBeenCalledWith(mockUserId, mockMemoryId, undefined);
+      expect(stmService.findById).toHaveBeenCalledWith(
+        mockUserId,
+        mockMemoryId,
+        undefined,
+        undefined,
+      );
       expect(stmService.delete).toHaveBeenCalledWith(mockUserId, mockMemoryId, undefined);
       expect(result).toEqual(
         expect.objectContaining({

--- a/packages/memory-ltm/src/memory-ltm.service.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.ts
@@ -3,7 +3,12 @@ import { PrismaService } from '@engram/database';
 import { MemoryType, PaginatedResult } from '@engram/database';
 import { MemoryStmService } from '@engram/memory-stm';
 import { EmbeddingsService } from '@engram/embeddings';
-import { VECTOR_STORE_TOKEN, type VectorStore, type VectorPayload } from '@engram/vector-store';
+import {
+  VECTOR_STORE_TOKEN,
+  type VectorStore,
+  type VectorPayload,
+  type VectorSearchResult,
+} from '@engram/vector-store';
 import { rankResults, DEFAULT_RANKING_WEIGHTS, type RankingWeights } from './rank';
 import { ImportanceScoringService } from './importance.service';
 import { DuplicateDetectionService } from './duplicate-detection.service';
@@ -133,9 +138,16 @@ export class MemoryLtmService {
       }
 
       // ── Step 2 (vector): semantic duplicate detection ──────────────────
+      // Scope is passed so dedup stays within the create's namespace — an
+      // unscoped write must never collapse into a scoped memory, or vice-versa.
       const duplicate =
         !input.skipDuplicateCheck &&
-        (await this.findDuplicate(validatedInput.userId, validatedInput.organizationId, embedding));
+        (await this.findDuplicate(
+          validatedInput.userId,
+          validatedInput.organizationId,
+          validatedInput.scope,
+          embedding
+        ));
       if (duplicate) {
         return await this.linkDuplicateAndReturn(
           duplicate.memoryId,
@@ -147,9 +159,11 @@ export class MemoryLtmService {
       }
 
       // ── Step B1: contradiction detection ──────────────────────────────
+      // Scope-bound so a write can only supersede memories in its own namespace.
       const contradiction = await this.findContradictionCandidate(
         validatedInput.userId,
         validatedInput.organizationId,
+        validatedInput.scope,
         processedContent,
         embedding
       );
@@ -283,7 +297,8 @@ export class MemoryLtmService {
     userId: string,
     memoryId: string,
     input: UpdateLtmMemoryData,
-    organizationId?: string
+    organizationId?: string,
+    scope?: string
   ): Promise<LtmMemory> {
     this.logger.debug(`Updating LTM memory: ${memoryId} for user: ${userId}`);
 
@@ -291,7 +306,9 @@ export class MemoryLtmService {
     const validatedInput = validateUpdateLtmMemory(input);
 
     try {
-      const existingRow = await this.findRawMemory(userId, memoryId, organizationId);
+      // Pass scope so a caller bound to a namespace cannot update memories
+      // outside it — a mismatch resolves to not-found.
+      const existingRow = await this.findRawMemory(userId, memoryId, organizationId, scope);
       if (!existingRow) {
         throw new LtmMemoryNotFoundError(memoryId);
       }
@@ -387,7 +404,12 @@ export class MemoryLtmService {
    * Pass `organizationId` in user-facing paths to prevent cross-tenant deletes.
    * See `get()` for the full isolation contract.
    */
-  async delete(userId: string, memoryId: string, organizationId?: string): Promise<boolean> {
+  async delete(
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string
+  ): Promise<boolean> {
     this.logger.debug(`Deleting LTM memory: ${memoryId} for user: ${userId}`);
 
     try {
@@ -398,6 +420,10 @@ export class MemoryLtmService {
       };
       if (organizationId !== undefined) {
         deleteWhere.organizationId = organizationId;
+      }
+      // Namespace isolation: a scoped caller can only delete within its scope.
+      if (scope !== undefined) {
+        deleteWhere.scope = scope;
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (this.prisma as any).memory.deleteMany({ where: deleteWhere });
@@ -614,8 +640,9 @@ export class MemoryLtmService {
     }
 
     try {
-      // Step 1: Get memory from STM service (org-scoped so we find the right key)
-      const stmMemory = await this.stmService.findById(userId, memoryId, organizationId);
+      // Step 1: Get memory from STM service (org- and scope-scoped so we find
+      // the right key and refuse to promote a memory from another namespace).
+      const stmMemory = await this.stmService.findById(userId, memoryId, organizationId, scope);
       if (!stmMemory) {
         throw new LtmPromotionError(memoryId, 'Memory not found in short-term storage');
       }
@@ -663,7 +690,12 @@ export class MemoryLtmService {
         embedding = result?.embedding ?? [];
       }
 
-      const duplicate = await this.findDuplicate(userId, resolvedOrgId ?? undefined, embedding);
+      const duplicate = await this.findDuplicate(
+        userId,
+        resolvedOrgId ?? undefined,
+        resolvedScope ?? undefined,
+        embedding
+      );
       if (duplicate) {
         const existing = await this.linkDuplicateAndReturn(
           duplicate.memoryId,
@@ -1173,7 +1205,8 @@ export class MemoryLtmService {
   private async findRawMemory(
     userId: string,
     memoryId: string,
-    organizationId?: string
+    organizationId?: string,
+    scope?: string
   ): Promise<PrismaMemory | null> {
     const where: Record<string, unknown> = {
       id: memoryId,
@@ -1182,6 +1215,9 @@ export class MemoryLtmService {
     };
     if (organizationId !== undefined) {
       where.organizationId = organizationId;
+    }
+    if (scope !== undefined) {
+      where.scope = scope;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.prisma as any).memory.findFirst({ where }) as Promise<PrismaMemory | null>;
@@ -1256,16 +1292,32 @@ export class MemoryLtmService {
     if (organizationId !== undefined) {
       where.organizationId = organizationId;
     }
-    if (scope !== undefined) {
-      where.scope = scope;
-    }
+    // Always constrain by namespace. `scope ?? null` means an unscoped create
+    // only matches unscoped rows (scope IS NULL) and a scoped create only
+    // matches the same scope — never across the boundary.
+    where.scope = scope ?? null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.prisma as any).memory.findFirst({ where }) as Promise<PrismaMemory | null>;
+  }
+
+  /**
+   * Keep only candidates that share the create's namespace. The vector store
+   * filter cannot express "scope IS NULL", so for an unscoped create we drop any
+   * hit that carries a scope in its payload; for a scoped create the store has
+   * already filtered, and this simply re-asserts the invariant.
+   */
+  private hitMatchesScope(hit: VectorSearchResult, scope: string | undefined): boolean {
+    const hitScope =
+      typeof hit.payload?.scope === 'string' && hit.payload.scope.length > 0
+        ? hit.payload.scope
+        : undefined;
+    return hitScope === scope;
   }
 
   private async findDuplicate(
     userId: string,
     organizationId: string | undefined,
+    scope: string | undefined,
     embedding: number[]
   ): Promise<DuplicateDetectionMatch | null> {
     if (!this.vectorStore || !this.duplicateDetectionService || embedding.length === 0) {
@@ -1273,15 +1325,17 @@ export class MemoryLtmService {
     }
     const hits = await this.vectorStore.search(
       embedding,
-      { userId, organizationId, type: MemoryType.LONG_TERM },
+      { userId, organizationId, scope, type: MemoryType.LONG_TERM },
       3
     );
-    return this.duplicateDetectionService.findMatch(hits);
+    const scopedHits = hits.filter((hit) => this.hitMatchesScope(hit, scope));
+    return this.duplicateDetectionService.findMatch(scopedHits);
   }
 
   private async findContradictionCandidate(
     userId: string,
     organizationId: string | undefined,
+    scope: string | undefined,
     content: string,
     embedding: number[]
   ): Promise<ContradictionMatch | null> {
@@ -1290,18 +1344,21 @@ export class MemoryLtmService {
     }
     const hits = await this.vectorStore.search(
       embedding,
-      { userId, organizationId, type: MemoryType.LONG_TERM },
+      { userId, organizationId, scope, type: MemoryType.LONG_TERM },
       5
     );
     if (hits.length === 0) return null;
 
     // Fetch content for all hit candidates in one query, scoped to the same
-    // tenant so a vector-store misconfiguration cannot surface foreign rows.
+    // tenant *and namespace* so neither a vector-store misconfiguration nor an
+    // unscoped search can surface foreign rows. `scope ?? null` confines the
+    // match to the create's own namespace (NULL = unscoped).
     const hitIds = hits.map((h) => h.id);
     const contentWhere: Record<string, unknown> = {
       id: { in: hitIds },
       userId,
       type: MemoryType.LONG_TERM,
+      scope: scope ?? null,
     };
     if (organizationId !== undefined) {
       contentWhere.organizationId = organizationId;

--- a/packages/memory-ltm/src/memory-ltm.service.ts
+++ b/packages/memory-ltm/src/memory-ltm.service.ts
@@ -1292,9 +1292,9 @@ export class MemoryLtmService {
     if (organizationId !== undefined) {
       where.organizationId = organizationId;
     }
-    // Always constrain by namespace. `scope ?? null` means an unscoped create
-    // only matches unscoped rows (scope IS NULL) and a scoped create only
-    // matches the same scope — never across the boundary.
+    // Always constrain by namespace for dedup. Note that `scope` is treated differently
+    // here than in read/update/delete paths: `undefined` means "unscoped only"
+    // (scope IS NULL), not "no scope filter".
     where.scope = scope ?? null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.prisma as any).memory.findFirst({ where }) as Promise<PrismaMemory | null>;

--- a/packages/memory-stm/src/memory-stm.scope.spec.ts
+++ b/packages/memory-stm/src/memory-stm.scope.spec.ts
@@ -148,6 +148,55 @@ describe('MemoryStmService — scope isolation', () => {
     });
   });
 
+  describe('delete — scope verification', () => {
+    it('deletes the memory when the scope matches', async () => {
+      const created = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      await service.delete(USER_A, created.id, undefined, SCOPE_A);
+
+      await expect(service.findById(USER_A, created.id)).rejects.toThrow(
+        StmMemoryNotFoundError
+      );
+    });
+
+    it('does NOT delete and throws when the scope does not match', async () => {
+      const created = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      await expect(
+        service.delete(USER_A, created.id, undefined, SCOPE_B)
+      ).rejects.toThrow(StmMemoryNotFoundError);
+
+      // The memory must still be present — a foreign scope cannot delete it.
+      const stillThere = await service.findById(USER_A, created.id);
+      expect(stillThere.scope).toBe(SCOPE_A);
+    });
+
+    it('deletes without a scope check when scope is not provided', async () => {
+      const created = await service.create({
+        userId: USER_A,
+        scope: SCOPE_A,
+        content: 'scoped fact',
+        ttl: TTL,
+      });
+
+      await service.delete(USER_A, created.id);
+
+      await expect(service.findById(USER_A, created.id)).rejects.toThrow(
+        StmMemoryNotFoundError
+      );
+    });
+  });
+
   describe('list — scope filter', () => {
     beforeEach(async () => {
       await Promise.all([

--- a/packages/memory-stm/src/memory-stm.service.ts
+++ b/packages/memory-stm/src/memory-stm.service.ts
@@ -150,15 +150,17 @@ export class MemoryStmService {
     userId: string,
     memoryId: string,
     input: UpdateStmMemoryData,
-    organizationId?: string
+    organizationId?: string,
+    scope?: string
   ): Promise<StmMemory> {
     this.logger.debug(`Updating STM memory: ${memoryId} for user: ${userId}`);
 
     // Validate input
     const validatedInput = updateStmMemorySchema.parse(input);
 
-    // Get existing memory (must use same org scope to find the key)
-    const existing = await this.findById(userId, memoryId, organizationId);
+    // Get existing memory (must use same org scope to find the key). Passing
+    // scope enforces namespace isolation — a mismatch surfaces as not-found.
+    const existing = await this.findById(userId, memoryId, organizationId, scope);
 
     // Validate new TTL if provided
     const newTtl = validatedInput.ttl ?? existing.ttl;
@@ -192,10 +194,36 @@ export class MemoryStmService {
   /**
    * Delete a short-term memory
    */
-  async delete(userId: string, memoryId: string, organizationId?: string): Promise<void> {
+  async delete(
+    userId: string,
+    memoryId: string,
+    organizationId?: string,
+    scope?: string
+  ): Promise<void> {
     this.logger.debug(`Deleting STM memory: ${memoryId} for user: ${userId}`);
 
     const redisKey = this.keyBuilder.buildMemoryKey(userId, memoryId, organizationId);
+
+    // Scope isolation: the Redis key does not encode scope, so when a scope is
+    // supplied we must read the record and verify it before deleting. A mismatch
+    // is treated as not-found so a caller bound to one namespace cannot delete
+    // another's memory.
+    if (scope !== undefined) {
+      const raw = await this.redisService.get(redisKey);
+      if (!raw) {
+        throw new StmMemoryNotFoundError(memoryId);
+      }
+      let memory: StmMemory;
+      try {
+        memory = this.deserializeStmMemory(JSON.parse(raw));
+      } catch {
+        throw new StmMemoryNotFoundError(memoryId);
+      }
+      if (memory.scope !== scope) {
+        throw new StmMemoryNotFoundError(memoryId);
+      }
+    }
+
     const deleted = await this.redisService.del(redisKey);
 
     if (deleted === 0) {

--- a/prisma/migrations/20260623000000_add_memory_scope/migration.sql
+++ b/prisma/migrations/20260623000000_add_memory_scope/migration.sql
@@ -1,4 +1,16 @@
 -- Add scope column and index to memories table for agent/session/project namespacing
 ALTER TABLE "memories" ADD COLUMN "scope" TEXT;
 
+-- Backfill the new first-class column from the legacy metadata.scope value so
+-- pre-existing memories keep their namespace. Before this column existed, scope
+-- was stored inside the `metadata` JSONB blob (`metadata.scope`); the application
+-- no longer reads it from there, so without this backfill those memories would
+-- silently lose their scope and leak across namespace boundaries.
+-- Only copy non-empty string values; leave everything else NULL (unscoped).
+UPDATE "memories"
+SET "scope" = "metadata"->>'scope'
+WHERE "scope" IS NULL
+  AND jsonb_typeof("metadata"->'scope') = 'string'
+  AND length("metadata"->>'scope') > 0;
+
 CREATE INDEX "memories_userId_scope_idx" ON "memories"("userId", "scope");


### PR DESCRIPTION
## Summary

Implements scope (namespace) isolation across memory create, promote, and delete operations to prevent cross-namespace leaks. Scoped writes now stay within their namespace, and unscoped writes cannot collapse into or be superseded by scoped memories.

## Key Changes

### Core Isolation Logic
- **MemoryLtmService**: Pass `scope` parameter through `findDuplicate()` and `findContradictionCandidate()` to confine dedup and contradiction detection to the caller's namespace
- **MemoryStmService**: Add scope verification in `delete()` — when a scope is provided, the record is read and validated before deletion to prevent cross-namespace deletes
- **MemoryLtmService.delete()**: Add scope constraint to the delete query so a scoped caller can only delete within its own namespace

### API Surface Updates
- Add optional `scope?: string` parameter to:
  - `MemoryService.getMemory()`, `updateMemory()`, `deleteMemory()`, `promoteMemory()`
  - `MemoryStmService.findById()`, `update()`, `delete()`
  - `MemoryLtmService.get()`, `update()`, `delete()`, `promote()`
- Update `MemoryService.listMemories()` to forward scope filter to both STM and LTM list calls (fixes regression where STM was dropping the scope filter)
- Add `scope` field to `GetMemoryToolSchema` and `UpdateMemoryToolSchema` DTOs

### Test Coverage
- **New regression suite** (`memory-ltm.scope-isolation.spec.ts`): 282 lines covering exact-content dedup, semantic dedup, and contradiction detection across scope boundaries
- **STM scope tests** (`memory-stm.scope.spec.ts`): Add delete scope verification tests
- **Integration tests**: Update call expectations to include scope parameter; add new test for `forget()` operation with scope confinement
- **Unit tests**: Update mock call assertions across memory service, controller, and LTM service specs

### Database
- Add `scope` column to `memories` table with backfill from legacy `metadata.scope` to preserve existing namespace assignments

## Implementation Details

- Scope is treated as immutable — the `scope` parameter in update/delete operations filters which memory is modified, not changes its scope
- When scope is `undefined`, no scope constraint is applied (backward compatible)
- Scope `null` in Prisma queries means "scope IS NULL" (unscoped memories only), matching Prisma's semantics
- Vector store searches now receive scope in the filter payload to prevent cross-namespace semantic dedup
- Contradiction detection queries are scoped so a write can only supersede memories in its own namespace

https://claude.ai/code/session_01NeZnFHTxMNth7EHqNrPUWK