### PR TITLE
feat(auth): OAuth/JWT auth, tenant enforcement & rate limiting (E4) (#128, #132)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,38 @@ VECTOR_DIMENSIONS=1536
 # PGVECTOR_HNSW_EF_CONSTRUCTION=64
 # PGVECTOR_HNSW_EF_SEARCH=100
 
-# JWT Authentication
+# ─── Authentication & Multi-tenancy (Epic E4) ───────────────────────────────
+# JWT signing secret for interactive sessions. MUST be >= 32 chars and is
+# REQUIRED when AUTH_REQUIRED=true. Keep this out of logs and source control.
 JWT_SECRET=your-secret-key-change-in-production-min-32-chars
+# JWT lifetime: a duration string (7d, 24h, 30m, 3600s) or a plain number of seconds.
 JWT_EXPIRES_IN=7d
+
+# Enforce authentication on the /mcp endpoint. When true, every tool call must
+# carry a valid JWT (Authorization: Bearer <jwt>) or API key (X-API-Key /
+# Authorization: Bearer eng_...), and the acting userId is taken from that
+# credential — the userId in tool input is ignored. Default false keeps the
+# existing trusted-caller behaviour. Only enforced over the streamable-http transport.
+# AUTH_REQUIRED=false
+
+# OAuth login (enterprise). Set a provider's id AND secret to enable it.
+# Callback URLs are <OAUTH_REDIRECT_BASE_URL>/auth/<provider>/callback —
+# register exactly those with the provider.
+# OAUTH_REDIRECT_BASE_URL=http://localhost:3000
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# ─── Rate limiting (#132) ────────────────────────────────────────────────────
+# Redis-backed per-tenant / per-key / per-IP rate limiting (enterprise only).
+# RATE_LIMIT_ENABLED=false
+# RATE_LIMIT_WINDOW_SEC=60          # window length; *_RPM values are per this window
+# RATE_LIMIT_USER_RPM=120          # per authenticated user
+# RATE_LIMIT_ORG_RPM=6000          # aggregated per organization
+# RATE_LIMIT_IP_RPM=60             # per unauthenticated client IP
+# Per-tool overrides as JSON, e.g. stricter limit on expensive admin tools:
+# RATE_LIMIT_TOOL_OVERRIDES={"reindex_memories":{"limit":2,"windowSeconds":3600}}
 
 # BullMQ Queue
 BULL_QUEUE_NAME=engram-jobs

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -24,6 +24,7 @@
     "test:e2e:docker": "pnpm -w exec turbo run build --ui=stream && docker compose -f ../../docker-compose.test.yml up -d --wait && DATABASE_URL=postgresql://engram_test:test_password@localhost:5433/engram_test pnpm -w db:migrate:deploy && DATABASE_URL=postgresql://engram_test:test_password@localhost:5433/engram_test REDIS_URL=redis://localhost:6380 QDRANT_URL=http://localhost:6335 NODE_ENV=test E2E_ENABLED=true jest --config ./test/jest-e2e.json --no-cache; status=$?; docker compose -f ../../docker-compose.test.yml down -v || status=$?; exit $status"
   },
   "dependencies": {
+    "@engram/auth": "workspace:^",
     "@engram/config": "workspace:^",
     "@engram/core": "workspace:^",
     "@engram/database": "workspace:^",
@@ -126,6 +127,7 @@
     },
     "testEnvironment": "node",
     "moduleNameMapper": {
+      "^@engram/auth$": "<rootDir>/../../packages/auth/src/index.ts",
       "^@engram/database$": "<rootDir>/../../packages/database/src/index.ts",
       "^@engram/embeddings$": "<rootDir>/../../packages/embeddings/src/index.ts",
       "^@engram/memory-lite$": "<rootDir>/../../packages/memory-lite/src/index.ts",

--- a/apps/mcp-server/src/api-keys/api-keys.controller.ts
+++ b/apps/mcp-server/src/api-keys/api-keys.controller.ts
@@ -176,6 +176,9 @@ export class ApiKeysController {
         description:
           'Issue a new API key for programmatic agent access. The raw key is returned once and never stored — save it securely.',
         inputSchema: createApiKeyToolSchema,
+        // Admin-gated: issues a key FOR an arbitrary userId, so the caller's
+        // identity must not overwrite the target userId.
+        auth: 'admin',
         handler: this.createApiKey.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -185,6 +188,8 @@ export class ApiKeysController {
         description:
           'List all active (non-revoked, non-expired) API keys for a user. Returns key metadata only — the raw key is never shown again after creation.',
         inputSchema: listApiKeysToolSchema,
+        // Identity-scoped: under enforcement a caller may only list their own keys.
+        auth: 'identity',
         handler: this.listApiKeys.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -194,6 +199,8 @@ export class ApiKeysController {
         description:
           'Immediately revoke an API key by ID. The key will be rejected on all subsequent requests.',
         inputSchema: revokeApiKeyToolSchema,
+        // Identity-scoped: under enforcement a caller may only revoke their own keys.
+        auth: 'identity',
         handler: this.revokeApiKey.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,

--- a/apps/mcp-server/src/app.module.ts
+++ b/apps/mcp-server/src/app.module.ts
@@ -20,6 +20,7 @@ import { QdrantModule } from '@engram/vector-store';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ApiKeysModule } from './api-keys/api-keys.module';
+import { AuthModule } from './auth/auth.module';
 import { HealthModule } from './health/health.module';
 import { MemoryModule } from './memory/memory.module';
 
@@ -70,6 +71,9 @@ function buildImportsForProfile(
 
   if (capabilities.requiresDatabase) {
     imports.push(PrismaModule);
+    // Auth needs Postgres (API keys, user upsert). OAuth/sessions/rate-limiting
+    // inside AuthModule are further gated on Redis (enterprise) internally.
+    imports.push(AuthModule.forRoot(capabilities));
   }
   if (capabilities.requiresRedis) {
     imports.push(RedisModule.forRoot());

--- a/apps/mcp-server/src/auth/auth-resolver.service.spec.ts
+++ b/apps/mcp-server/src/auth/auth-resolver.service.spec.ts
@@ -1,0 +1,130 @@
+import { JwtService } from '@engram/auth';
+import { AuthResolver } from './auth-resolver.service';
+import type { ApiKeysService } from '../api-keys/api-keys.service';
+
+const SECRET = 'unit-test-secret-at-least-32-characters-long';
+
+type VerifyResult = Awaited<ReturnType<ApiKeysService['verifyApiKey']>>;
+
+function makeApiKeys(
+  verify: (raw: string) => Promise<VerifyResult> | VerifyResult,
+): ApiKeysService {
+  return { verifyApiKey: jest.fn(verify) } as unknown as ApiKeysService;
+}
+
+const sampleKey = (
+  over: Partial<NonNullable<VerifyResult>> = {},
+): NonNullable<VerifyResult> => ({
+  id: 'k1',
+  name: 'k',
+  prefix: 'eng_abcd',
+  userId: 'user-1',
+  organizationId: 'org-1',
+  scopes: ['memories:read'],
+  lastUsedAt: null,
+  expiresAt: null,
+  revokedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...over,
+});
+
+describe('AuthResolver', () => {
+  const jwt = new JwtService({ secret: SECRET });
+
+  it('returns anonymous when no credentials are presented', async () => {
+    const resolver = new AuthResolver(
+      makeApiKeys(() => null),
+      jwt,
+    );
+    expect(await resolver.authenticate({})).toEqual({ status: 'anonymous' });
+  });
+
+  it('authenticates via X-API-Key', async () => {
+    const resolver = new AuthResolver(
+      makeApiKeys(() => sampleKey()),
+      jwt,
+    );
+    const outcome = await resolver.authenticate({ 'x-api-key': 'eng_abcdef' });
+    expect(outcome).toMatchObject({
+      status: 'authenticated',
+      identity: {
+        userId: 'user-1',
+        organizationId: 'org-1',
+        scopes: ['memories:read'],
+        method: 'api-key',
+        apiKeyId: 'k1',
+      },
+    });
+  });
+
+  it('authenticates an eng_ key supplied as a Bearer token', async () => {
+    const apiKeys = makeApiKeys(() => sampleKey());
+    const resolver = new AuthResolver(apiKeys, jwt);
+    const outcome = await resolver.authenticate({
+      authorization: 'Bearer eng_abcdef123',
+    });
+    expect(outcome.status).toBe('authenticated');
+    expect(apiKeys.verifyApiKey).toHaveBeenCalledWith('eng_abcdef123');
+  });
+
+  it('authenticates a JWT bearer token', async () => {
+    const token = jwt.issue({ userId: 'user-2', scopes: ['memories:write'] });
+    const resolver = new AuthResolver(
+      makeApiKeys(() => null),
+      jwt,
+    );
+    const outcome = await resolver.authenticate({
+      authorization: `Bearer ${token}`,
+    });
+    expect(outcome).toMatchObject({
+      status: 'authenticated',
+      identity: { userId: 'user-2', method: 'jwt' },
+    });
+  });
+
+  it('reports invalid (never anonymous) for a bad API key', async () => {
+    const resolver = new AuthResolver(
+      makeApiKeys(() => null),
+      jwt,
+    );
+    const outcome = await resolver.authenticate({ 'x-api-key': 'eng_bad' });
+    expect(outcome.status).toBe('invalid');
+  });
+
+  it('reports invalid for a malformed JWT', async () => {
+    const resolver = new AuthResolver(
+      makeApiKeys(() => null),
+      jwt,
+    );
+    const outcome = await resolver.authenticate({
+      authorization: 'Bearer not.a.jwt',
+    });
+    expect(outcome.status).toBe('invalid');
+  });
+
+  it('reports invalid for a JWT when JWT auth is not configured', async () => {
+    const resolver = new AuthResolver(
+      makeApiKeys(() => null),
+      undefined,
+    );
+    const outcome = await resolver.authenticate({
+      authorization: 'Bearer something',
+    });
+    expect(outcome).toEqual({
+      status: 'invalid',
+      reason: 'JWT auth is not configured',
+    });
+  });
+
+  it('reports invalid when API key verification throws', async () => {
+    const resolver = new AuthResolver(
+      makeApiKeys(() => {
+        throw new Error('db down');
+      }),
+      jwt,
+    );
+    const outcome = await resolver.authenticate({ 'x-api-key': 'eng_x' });
+    expect(outcome.status).toBe('invalid');
+  });
+});

--- a/apps/mcp-server/src/auth/auth-resolver.service.ts
+++ b/apps/mcp-server/src/auth/auth-resolver.service.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { JwtService, type AuthIdentity } from '@engram/auth';
+import { ApiKeysService } from '../api-keys/api-keys.service';
+
+export type AuthOutcome =
+  | { status: 'anonymous' }
+  | { status: 'authenticated'; identity: AuthIdentity }
+  | { status: 'invalid'; reason: string };
+
+/** Headers as exposed by Node's http/express request. */
+export type RequestHeaders = Record<string, string | string[] | undefined>;
+
+const API_KEY_PREFIX = 'eng_';
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+/**
+ * Resolves the principal behind a request from its credentials, supporting:
+ *   - `X-API-Key: eng_...` or `Authorization: Bearer eng_...` (programmatic)
+ *   - `Authorization: Bearer <jwt>` (interactive session)
+ *
+ * Returns `anonymous` when no credential is presented, `invalid` when one is
+ * presented but fails verification, and `authenticated` with the resolved
+ * {@link AuthIdentity} otherwise. A presented-but-invalid credential is never
+ * silently downgraded to anonymous.
+ */
+@Injectable()
+export class AuthResolver {
+  private readonly logger = new Logger(AuthResolver.name);
+
+  constructor(
+    private readonly apiKeys: ApiKeysService,
+    @Optional() private readonly jwt?: JwtService,
+  ) {}
+
+  async authenticate(headers: RequestHeaders): Promise<AuthOutcome> {
+    const apiKeyHeader = firstHeader(headers['x-api-key']);
+    const authHeader = firstHeader(headers['authorization']);
+
+    let rawApiKey: string | undefined = apiKeyHeader?.trim() || undefined;
+    let bearer: string | undefined;
+
+    if (authHeader) {
+      const match = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+      if (match?.[1]) {
+        const token = match[1].trim();
+        if (token.startsWith(API_KEY_PREFIX)) {
+          rawApiKey ??= token;
+        } else {
+          bearer = token;
+        }
+      }
+    }
+
+    if (rawApiKey) {
+      return this.authenticateApiKey(rawApiKey);
+    }
+    if (bearer) {
+      return this.authenticateJwt(bearer);
+    }
+    return { status: 'anonymous' };
+  }
+
+  private async authenticateApiKey(rawKey: string): Promise<AuthOutcome> {
+    let record: Awaited<ReturnType<ApiKeysService['verifyApiKey']>>;
+    try {
+      record = await this.apiKeys.verifyApiKey(rawKey);
+    } catch (error) {
+      this.logger.warn(`API key verification error: ${String(error)}`);
+      return { status: 'invalid', reason: 'API key verification failed' };
+    }
+    if (!record) {
+      return { status: 'invalid', reason: 'Invalid or revoked API key' };
+    }
+    return {
+      status: 'authenticated',
+      identity: {
+        userId: record.userId,
+        organizationId: record.organizationId ?? null,
+        email: null,
+        scopes: record.scopes,
+        method: 'api-key',
+        apiKeyId: record.id,
+      },
+    };
+  }
+
+  private authenticateJwt(token: string): AuthOutcome {
+    if (!this.jwt) {
+      return { status: 'invalid', reason: 'JWT auth is not configured' };
+    }
+    try {
+      const claims = this.jwt.verify(token);
+      return {
+        status: 'authenticated',
+        identity: {
+          userId: claims.sub,
+          organizationId: claims.org,
+          email: claims.email,
+          scopes: claims.scopes,
+          method: 'jwt',
+          apiKeyId: null,
+        },
+      };
+    } catch (error) {
+      return {
+        status: 'invalid',
+        reason: error instanceof Error ? error.message : 'Invalid token',
+      };
+    }
+  }
+}

--- a/apps/mcp-server/src/auth/auth.config.spec.ts
+++ b/apps/mcp-server/src/auth/auth.config.spec.ts
@@ -1,0 +1,197 @@
+import {
+  buildOAuthProviders,
+  isAuthRequired,
+  isFlagEnabled,
+  oauthRedirectBaseUrl,
+  parseDurationToSeconds,
+  parseJwtConfig,
+  parseRateLimitConfig,
+} from './auth.config';
+
+const SECRET = 'unit-test-secret-at-least-32-characters-long';
+
+describe('auth.config', () => {
+  describe('isFlagEnabled', () => {
+    it.each(['true', '1', 'yes', 'on', 'TRUE', ' On '])(
+      'is true for %p',
+      (value) => {
+        expect(isFlagEnabled(value)).toBe(true);
+      },
+    );
+
+    it.each([undefined, '', 'false', '0', 'no', 'off', 'maybe'])(
+      'is false for %p',
+      (value) => {
+        expect(isFlagEnabled(value)).toBe(false);
+      },
+    );
+  });
+
+  describe('parseDurationToSeconds', () => {
+    it('returns the fallback when value is undefined', () => {
+      expect(parseDurationToSeconds(undefined, 42)).toBe(42);
+    });
+
+    it('treats a plain integer as seconds', () => {
+      expect(parseDurationToSeconds('3600')).toBe(3600);
+    });
+
+    it.each([
+      ['30s', 30],
+      ['30m', 1800],
+      ['24h', 86_400],
+      ['7d', 604_800],
+      ['2H', 7200],
+    ])('parses %p', (value, expected) => {
+      expect(parseDurationToSeconds(value)).toBe(expected);
+    });
+
+    it('returns the fallback for unrecognised input', () => {
+      expect(parseDurationToSeconds('not-a-duration', 99)).toBe(99);
+      expect(parseDurationToSeconds('10y', 99)).toBe(99);
+    });
+  });
+
+  describe('parseJwtConfig', () => {
+    it('returns null when no secret is configured', () => {
+      expect(parseJwtConfig({})).toBeNull();
+    });
+
+    it('returns null when the secret is too short', () => {
+      expect(parseJwtConfig({ JWT_SECRET: 'short' })).toBeNull();
+    });
+
+    it('returns config with a default TTL when valid', () => {
+      expect(parseJwtConfig({ JWT_SECRET: SECRET })).toEqual({
+        secret: SECRET,
+        expiresInSeconds: 7 * 24 * 60 * 60,
+      });
+    });
+
+    it('honours JWT_EXPIRES_IN', () => {
+      expect(
+        parseJwtConfig({ JWT_SECRET: SECRET, JWT_EXPIRES_IN: '1h' }),
+      ).toEqual({ secret: SECRET, expiresInSeconds: 3600 });
+    });
+  });
+
+  describe('oauthRedirectBaseUrl', () => {
+    it('defaults to localhost on the default port', () => {
+      expect(oauthRedirectBaseUrl({})).toBe('http://localhost:3000');
+    });
+
+    it('uses PORT when set', () => {
+      expect(oauthRedirectBaseUrl({ PORT: '8080' })).toBe(
+        'http://localhost:8080',
+      );
+    });
+
+    it('strips trailing slashes from an explicit base URL', () => {
+      expect(
+        oauthRedirectBaseUrl({ OAUTH_REDIRECT_BASE_URL: 'https://x.test/' }),
+      ).toBe('https://x.test');
+    });
+  });
+
+  describe('buildOAuthProviders', () => {
+    it('returns no providers when no credentials are configured', () => {
+      expect(buildOAuthProviders({})).toHaveLength(0);
+    });
+
+    it('builds only GitHub when only its credentials are present', () => {
+      const providers = buildOAuthProviders({
+        GITHUB_CLIENT_ID: 'id',
+        GITHUB_CLIENT_SECRET: 'secret',
+      });
+      expect(providers.map((p) => p.name)).toEqual(['github']);
+    });
+
+    it('builds both providers when both are configured', () => {
+      const providers = buildOAuthProviders({
+        GITHUB_CLIENT_ID: 'id',
+        GITHUB_CLIENT_SECRET: 'secret',
+        GOOGLE_CLIENT_ID: 'gid',
+        GOOGLE_CLIENT_SECRET: 'gsecret',
+      });
+      expect(providers.map((p) => p.name).sort()).toEqual(['github', 'google']);
+    });
+  });
+
+  describe('parseRateLimitConfig', () => {
+    it('uses defaults when nothing is set', () => {
+      expect(parseRateLimitConfig({})).toEqual({
+        enabled: false,
+        windowSeconds: 60,
+        userRpm: 120,
+        orgRpm: 6000,
+        ipRpm: 60,
+        toolOverrides: {},
+      });
+    });
+
+    it('parses numeric overrides and the enabled flag', () => {
+      const config = parseRateLimitConfig({
+        RATE_LIMIT_ENABLED: 'true',
+        RATE_LIMIT_WINDOW_SEC: '30',
+        RATE_LIMIT_USER_RPM: '10',
+        RATE_LIMIT_ORG_RPM: '100',
+        RATE_LIMIT_IP_RPM: '5',
+      });
+      expect(config).toMatchObject({
+        enabled: true,
+        windowSeconds: 30,
+        userRpm: 10,
+        orgRpm: 100,
+        ipRpm: 5,
+      });
+    });
+
+    it('falls back to defaults for non-positive / non-numeric values', () => {
+      const config = parseRateLimitConfig({
+        RATE_LIMIT_WINDOW_SEC: '0',
+        RATE_LIMIT_USER_RPM: '-5',
+        RATE_LIMIT_IP_RPM: 'abc',
+      });
+      expect(config).toMatchObject({
+        windowSeconds: 60,
+        userRpm: 120,
+        ipRpm: 60,
+      });
+    });
+
+    it('accepts a valid tool-overrides JSON object', () => {
+      const config = parseRateLimitConfig({
+        RATE_LIMIT_TOOL_OVERRIDES: JSON.stringify({
+          recall: { limit: 5, windowSeconds: 10 },
+        }),
+      });
+      expect(config.toolOverrides).toEqual({
+        recall: { limit: 5, windowSeconds: 10 },
+      });
+    });
+
+    it('ignores malformed override JSON (defensive fallback)', () => {
+      expect(
+        parseRateLimitConfig({ RATE_LIMIT_TOOL_OVERRIDES: '{ not json' })
+          .toolOverrides,
+      ).toEqual({});
+    });
+
+    it('ignores overrides that fail schema validation', () => {
+      expect(
+        parseRateLimitConfig({
+          RATE_LIMIT_TOOL_OVERRIDES: JSON.stringify({
+            recall: { limit: -1, windowSeconds: 10 },
+          }),
+        }).toolOverrides,
+      ).toEqual({});
+    });
+  });
+
+  describe('isAuthRequired', () => {
+    it('reflects the AUTH_REQUIRED flag', () => {
+      expect(isAuthRequired({ AUTH_REQUIRED: 'true' })).toBe(true);
+      expect(isAuthRequired({})).toBe(false);
+    });
+  });
+});

--- a/apps/mcp-server/src/auth/auth.config.ts
+++ b/apps/mcp-server/src/auth/auth.config.ts
@@ -1,0 +1,143 @@
+/**
+ * Parses ENGRAM auth/rate-limit configuration from the environment into the
+ * structured options the `@engram/auth` services expect. Reads `process.env`
+ * directly (consistent with the rest of the app) — values are already
+ * validated at boot by `@engram/config`'s `validateEnv`.
+ */
+import { z } from 'zod';
+import {
+  FetchOAuthHttpClient,
+  GitHubOAuthProvider,
+  GoogleOAuthProvider,
+  type OAuthProvider,
+  type RateLimitRule,
+} from '@engram/auth';
+
+type Env = NodeJS.ProcessEnv;
+
+const DEFAULT_JWT_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+const TRUTHY = new Set(['true', '1', 'yes', 'on']);
+export function isFlagEnabled(value: string | undefined): boolean {
+  return value != null && TRUTHY.has(value.trim().toLowerCase());
+}
+
+/**
+ * Convert a duration string (`7d`, `24h`, `30m`, `3600s`) or a plain number of
+ * seconds to seconds. Falls back to 7 days for unrecognised input.
+ */
+export function parseDurationToSeconds(
+  value: string | undefined,
+  fallback = DEFAULT_JWT_TTL_SECONDS,
+): number {
+  if (!value) return fallback;
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) return Number.parseInt(trimmed, 10);
+  const match = /^(\d+)\s*([smhd])$/i.exec(trimmed);
+  if (!match || !match[1] || !match[2]) return fallback;
+  const amount = Number.parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+  const multiplier =
+    unit === 's' ? 1 : unit === 'm' ? 60 : unit === 'h' ? 3600 : 86_400;
+  return amount * multiplier;
+}
+
+export interface JwtConfig {
+  secret: string;
+  expiresInSeconds: number;
+}
+
+/** Returns JWT config, or null when no `JWT_SECRET` is configured. */
+export function parseJwtConfig(env: Env = process.env): JwtConfig | null {
+  const secret = env.JWT_SECRET;
+  if (!secret || secret.length < 32) return null;
+  return {
+    secret,
+    expiresInSeconds: parseDurationToSeconds(env.JWT_EXPIRES_IN),
+  };
+}
+
+/** Base URL used to build OAuth callback URLs. Defaults to localhost:PORT. */
+export function oauthRedirectBaseUrl(env: Env = process.env): string {
+  return (
+    env.OAUTH_REDIRECT_BASE_URL ?? `http://localhost:${env.PORT ?? '3000'}`
+  ).replace(/\/+$/, '');
+}
+
+/** Instantiate the OAuth providers whose credentials are configured. */
+export function buildOAuthProviders(env: Env = process.env): OAuthProvider[] {
+  const http = new FetchOAuthHttpClient();
+  const providers: OAuthProvider[] = [];
+  if (env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET) {
+    providers.push(
+      new GitHubOAuthProvider(
+        {
+          clientId: env.GITHUB_CLIENT_ID,
+          clientSecret: env.GITHUB_CLIENT_SECRET,
+        },
+        http,
+      ),
+    );
+  }
+  if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
+    providers.push(
+      new GoogleOAuthProvider(
+        {
+          clientId: env.GOOGLE_CLIENT_ID,
+          clientSecret: env.GOOGLE_CLIENT_SECRET,
+        },
+        http,
+      ),
+    );
+  }
+  return providers;
+}
+
+export interface RateLimitConfig {
+  enabled: boolean;
+  windowSeconds: number;
+  userRpm: number;
+  orgRpm: number;
+  ipRpm: number;
+  toolOverrides: Record<string, RateLimitRule>;
+}
+
+const ruleSchema = z
+  .object({
+    limit: z.number().int().positive(),
+    windowSeconds: z.number().int().positive(),
+  })
+  .strict();
+const overridesSchema = z.record(z.string(), ruleSchema);
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+/** Parse rate-limit configuration; invalid tool overrides are ignored. */
+export function parseRateLimitConfig(env: Env = process.env): RateLimitConfig {
+  let toolOverrides: Record<string, RateLimitRule> = {};
+  if (env.RATE_LIMIT_TOOL_OVERRIDES) {
+    try {
+      const parsed = overridesSchema.safeParse(
+        JSON.parse(env.RATE_LIMIT_TOOL_OVERRIDES),
+      );
+      if (parsed.success) toolOverrides = parsed.data;
+    } catch {
+      // Malformed JSON → no overrides (already validated at boot if present).
+    }
+  }
+  return {
+    enabled: isFlagEnabled(env.RATE_LIMIT_ENABLED),
+    windowSeconds: positiveInt(env.RATE_LIMIT_WINDOW_SEC, 60),
+    userRpm: positiveInt(env.RATE_LIMIT_USER_RPM, 120),
+    orgRpm: positiveInt(env.RATE_LIMIT_ORG_RPM, 6000),
+    ipRpm: positiveInt(env.RATE_LIMIT_IP_RPM, 60),
+    toolOverrides,
+  };
+}
+
+export function isAuthRequired(env: Env = process.env): boolean {
+  return isFlagEnabled(env.AUTH_REQUIRED);
+}

--- a/apps/mcp-server/src/auth/auth.config.ts
+++ b/apps/mcp-server/src/auth/auth.config.ts
@@ -115,7 +115,11 @@ function positiveInt(value: string | undefined, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
 
-/** Parse rate-limit configuration; invalid tool overrides are ignored. */
+/**
+ * Parse rate-limit configuration. A malformed `RATE_LIMIT_TOOL_OVERRIDES` is
+ * already rejected at boot by `@engram/config`'s `validateEnv` (fail-fast), so
+ * it cannot reach here in practice; the guard below is defensive fallback.
+ */
 export function parseRateLimitConfig(env: Env = process.env): RateLimitConfig {
   let toolOverrides: Record<string, RateLimitRule> = {};
   if (env.RATE_LIMIT_TOOL_OVERRIDES) {
@@ -125,7 +129,8 @@ export function parseRateLimitConfig(env: Env = process.env): RateLimitConfig {
       );
       if (parsed.success) toolOverrides = parsed.data;
     } catch {
-      // Malformed JSON → no overrides (already validated at boot if present).
+      // Defensive only: boot-time validateEnv already fails fast on malformed
+      // overrides, so this fallback to "no overrides" should be unreachable.
     }
   }
   return {

--- a/apps/mcp-server/src/auth/auth.controller.spec.ts
+++ b/apps/mcp-server/src/auth/auth.controller.spec.ts
@@ -94,7 +94,11 @@ function build(
 }
 
 function mockRes(): Response {
-  return { redirect: jest.fn(), cookie: jest.fn() } as unknown as Response;
+  return {
+    redirect: jest.fn(),
+    cookie: jest.fn(),
+    clearCookie: jest.fn(),
+  } as unknown as Response;
 }
 
 describe('AuthController', () => {
@@ -125,12 +129,13 @@ describe('AuthController', () => {
         'github',
         { code: 'c', state: 'state-1' },
         res,
-      )) as { token: string; sessionId: string };
+      )) as { token: string; sessionId?: string };
       expect(sessions.consumeOAuthState).toHaveBeenCalledWith('state-1');
       expect(users.upsertByEmail).toHaveBeenCalledWith('octo@gh.com');
       expect(jwt.issue).toHaveBeenCalled();
       expect(result.token).toBe('jwt-token');
-      expect(result.sessionId).toBe('sess-1');
+      // The session id must NOT be echoed in the body — cookie only.
+      expect(result.sessionId).toBeUndefined();
       expect(res.cookie).toHaveBeenCalledWith(
         'engram_session',
         'sess-1',
@@ -194,10 +199,23 @@ describe('AuthController', () => {
       ).rejects.toBeInstanceOf(UnauthorizedException);
     });
 
-    it('destroys the session on logout', async () => {
+    it('destroys the session named by the cookie and clears it', async () => {
       const { controller, sessions } = build();
-      await controller.logout({ sessionId: 'sess-1' });
+      const res = mockRes();
+      await controller.logout(
+        { headers: { cookie: 'foo=bar; engram_session=sess-1' } } as never,
+        res,
+      );
       expect(sessions.destroySession).toHaveBeenCalledWith('sess-1');
+      expect(res.clearCookie).toHaveBeenCalledWith('engram_session');
+    });
+
+    it('is a no-op destroy when no session cookie is present', async () => {
+      const { controller, sessions } = build();
+      const res = mockRes();
+      await controller.logout({ headers: {} } as never, res);
+      expect(sessions.destroySession).not.toHaveBeenCalled();
+      expect(res.clearCookie).toHaveBeenCalledWith('engram_session');
     });
   });
 });

--- a/apps/mcp-server/src/auth/auth.controller.spec.ts
+++ b/apps/mcp-server/src/auth/auth.controller.spec.ts
@@ -1,0 +1,203 @@
+import {
+  BadRequestException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { AuthController } from './auth.controller';
+
+function build(
+  overrides: {
+    isEnabled?: (n: string) => boolean;
+    consumeState?: () => unknown;
+    exchange?: () => unknown;
+    authenticate?: () => unknown;
+  } = {},
+): {
+  controller: AuthController;
+  oauth: { isEnabled: jest.Mock; getProvider: jest.Mock };
+  sessions: {
+    createOAuthState: jest.Mock;
+    consumeOAuthState: jest.Mock;
+    createSession: jest.Mock;
+    destroySession: jest.Mock;
+  };
+  jwt: { issue: jest.Mock; tokenLifetimeSeconds: number };
+  users: { upsertByEmail: jest.Mock };
+  resolver: { authenticate: jest.Mock };
+} {
+  const oauth = {
+    isEnabled: jest.fn(
+      overrides.isEnabled ?? ((n: string): boolean => n === 'github'),
+    ),
+    getProvider: jest.fn(() => ({
+      getAuthorizationUrl: jest.fn(() => 'https://github.test/auth?state=s'),
+      exchangeCodeForProfile: jest.fn(
+        overrides.exchange ??
+          ((): Promise<{
+            provider: string;
+            providerAccountId: string;
+            email: string;
+            name: string;
+          }> =>
+            Promise.resolve({
+              provider: 'github',
+              providerAccountId: '1',
+              email: 'octo@gh.com',
+              name: 'Octo',
+            })),
+      ),
+    })),
+  };
+  const sessions = {
+    createOAuthState: jest.fn(() => Promise.resolve('state-1')),
+    consumeOAuthState: jest.fn(
+      overrides.consumeState ??
+        ((): Promise<{ provider: string; createdAt: number }> =>
+          Promise.resolve({ provider: 'github', createdAt: 1 })),
+    ),
+    createSession: jest.fn(() => Promise.resolve('sess-1')),
+    destroySession: jest.fn(() => Promise.resolve(undefined)),
+  };
+  const jwt = { issue: jest.fn(() => 'jwt-token'), tokenLifetimeSeconds: 3600 };
+  const users = {
+    upsertByEmail: jest.fn(() =>
+      Promise.resolve({
+        id: 'user-1',
+        email: 'octo@gh.com',
+        organizationId: null,
+      }),
+    ),
+  };
+  const resolver = {
+    authenticate: jest.fn(
+      overrides.authenticate ??
+        ((): Promise<{
+          status: string;
+          identity: { userId: string; method: string };
+        }> =>
+          Promise.resolve({
+            status: 'authenticated',
+            identity: { userId: 'user-1', method: 'jwt' },
+          })),
+    ),
+  };
+  const controller = new AuthController(
+    oauth as never,
+    sessions as never,
+    jwt as never,
+    users as never,
+    resolver as never,
+    'https://api.example.com',
+  );
+  return { controller, oauth, sessions, jwt, users, resolver };
+}
+
+function mockRes(): Response {
+  return { redirect: jest.fn(), cookie: jest.fn() } as unknown as Response;
+}
+
+describe('AuthController', () => {
+  describe('login', () => {
+    it('redirects to the provider with a fresh state', async () => {
+      const { controller, sessions } = build();
+      const res = mockRes();
+      await controller.login('github', res);
+      expect(sessions.createOAuthState).toHaveBeenCalledWith('github');
+      expect(res.redirect).toHaveBeenCalledWith(
+        'https://github.test/auth?state=s',
+      );
+    });
+
+    it('404s for a disabled provider', async () => {
+      const { controller } = build({ isEnabled: () => false });
+      await expect(
+        controller.login('github', mockRes()),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('callback', () => {
+    it('exchanges the code, upserts the user, and issues a token + session', async () => {
+      const { controller, users, sessions, jwt } = build();
+      const res = mockRes();
+      const result = (await controller.callback(
+        'github',
+        { code: 'c', state: 'state-1' },
+        res,
+      )) as { token: string; sessionId: string };
+      expect(sessions.consumeOAuthState).toHaveBeenCalledWith('state-1');
+      expect(users.upsertByEmail).toHaveBeenCalledWith('octo@gh.com');
+      expect(jwt.issue).toHaveBeenCalled();
+      expect(result.token).toBe('jwt-token');
+      expect(result.sessionId).toBe('sess-1');
+      expect(res.cookie).toHaveBeenCalledWith(
+        'engram_session',
+        'sess-1',
+        expect.objectContaining({ httpOnly: true }),
+      );
+    });
+
+    it('rejects an unknown/expired state', async () => {
+      const { controller } = build({
+        consumeState: () => Promise.resolve(null),
+      });
+      await expect(
+        controller.callback('github', { code: 'c', state: 'x' }, mockRes()),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects a state minted for a different provider', async () => {
+      const { controller } = build({
+        consumeState: () =>
+          Promise.resolve({ provider: 'google', createdAt: 1 }),
+      });
+      await expect(
+        controller.callback('github', { code: 'c', state: 's' }, mockRes()),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects missing code or state', async () => {
+      const { controller } = build();
+      await expect(
+        controller.callback('github', { state: 's' }, mockRes()),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('maps an OAuth exchange failure to 401', async () => {
+      const { controller } = build({
+        exchange: () => {
+          throw new Error('exchange failed');
+        },
+      });
+      await expect(
+        controller.callback('github', { code: 'c', state: 's' }, mockRes()),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+
+  describe('me / logout', () => {
+    it('returns the resolved identity', async () => {
+      const { controller } = build();
+      const result = (await controller.me({ headers: {} } as never)) as {
+        user: { userId: string };
+      };
+      expect(result.user.userId).toBe('user-1');
+    });
+
+    it('401s when unauthenticated', async () => {
+      const { controller } = build({
+        authenticate: () => Promise.resolve({ status: 'anonymous' }),
+      });
+      await expect(
+        controller.me({ headers: {} } as never),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('destroys the session on logout', async () => {
+      const { controller, sessions } = build();
+      await controller.logout({ sessionId: 'sess-1' });
+      expect(sessions.destroySession).toHaveBeenCalledWith('sess-1');
+    });
+  });
+});

--- a/apps/mcp-server/src/auth/auth.controller.ts
+++ b/apps/mcp-server/src/auth/auth.controller.ts
@@ -1,0 +1,180 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Inject,
+  Logger,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  Req,
+  Res,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import {
+  JwtService,
+  OAuthService,
+  SessionService,
+  type OAuthProviderName,
+  type OAuthUserProfile,
+} from '@engram/auth';
+import { AuthResolver } from './auth-resolver.service';
+import { UserService } from './user.service';
+
+/** DI token carrying the base URL used to build OAuth callback URLs. */
+export const OAUTH_REDIRECT_BASE_URL = Symbol.for('engram.oauth-redirect-base');
+
+/**
+ * Scopes granted to an interactive session established via OAuth — full control
+ * over the user's own memories (read/write/delete), but not `admin`.
+ */
+const SESSION_SCOPES = ['memories:read', 'memories:write', 'memories:delete'];
+
+const callbackQuerySchema = z.object({
+  code: z.string().min(1),
+  state: z.string().min(1),
+});
+
+function isProviderName(value: string): value is OAuthProviderName {
+  return value === 'github' || value === 'google';
+}
+
+/**
+ * HTTP OAuth login endpoints. Mounts under `/auth`:
+ *   - `GET  /auth/:provider/login`    → redirect to the provider with CSRF state
+ *   - `GET  /auth/:provider/callback` → exchange code, upsert user, issue JWT + session
+ *   - `GET  /auth/me`                 → resolve the caller's identity
+ *   - `POST /auth/logout`             → destroy a session
+ */
+@Controller('auth')
+export class AuthController {
+  private readonly logger = new Logger(AuthController.name);
+
+  constructor(
+    private readonly oauth: OAuthService,
+    private readonly sessions: SessionService,
+    private readonly jwt: JwtService,
+    private readonly users: UserService,
+    private readonly resolver: AuthResolver,
+    @Inject(OAUTH_REDIRECT_BASE_URL) private readonly redirectBase: string,
+  ) {}
+
+  private providerOrThrow(name: string): OAuthProviderName {
+    if (!isProviderName(name) || !this.oauth.isEnabled(name)) {
+      throw new NotFoundException(`OAuth provider "${name}" is not enabled`);
+    }
+    return name;
+  }
+
+  private callbackUri(provider: OAuthProviderName): string {
+    return `${this.redirectBase}/auth/${provider}/callback`;
+  }
+
+  @Get(':provider/login')
+  async login(
+    @Param('provider') providerName: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const provider = this.providerOrThrow(providerName);
+    const state = await this.sessions.createOAuthState(provider);
+    const url = this.oauth.getProvider(provider).getAuthorizationUrl({
+      state,
+      redirectUri: this.callbackUri(provider),
+    });
+    res.redirect(url);
+  }
+
+  @Get(':provider/callback')
+  async callback(
+    @Param('provider') providerName: string,
+    @Query() query: unknown,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<unknown> {
+    const provider = this.providerOrThrow(providerName);
+
+    const parsed = callbackQuerySchema.safeParse(query);
+    if (!parsed.success) {
+      throw new BadRequestException('Missing OAuth code or state');
+    }
+    const { code, state } = parsed.data;
+
+    // One-time, provider-bound state check (CSRF + replay protection).
+    const stateData = await this.sessions.consumeOAuthState(state);
+    if (!stateData || stateData.provider !== provider) {
+      throw new BadRequestException('Invalid or expired OAuth state');
+    }
+
+    let profile: OAuthUserProfile;
+    try {
+      profile = await this.oauth.getProvider(provider).exchangeCodeForProfile({
+        code,
+        redirectUri: this.callbackUri(provider),
+      });
+    } catch {
+      this.logger.warn(`oauth_exchange_failed provider=${provider}`);
+      throw new UnauthorizedException('OAuth authentication failed');
+    }
+
+    const user = await this.users.upsertByEmail(profile.email);
+    const token = this.jwt.issue({
+      userId: user.id,
+      email: user.email,
+      organizationId: user.organizationId,
+      scopes: SESSION_SCOPES,
+    });
+    const sessionId = await this.sessions.createSession({
+      userId: user.id,
+      organizationId: user.organizationId,
+      email: user.email,
+      scopes: SESSION_SCOPES,
+    });
+
+    res.cookie('engram_session', sessionId, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: this.jwt.tokenLifetimeSeconds * 1000,
+    });
+
+    this.logger.log(`oauth_login_ok provider=${provider} userId=${user.id}`);
+    return {
+      token,
+      tokenType: 'Bearer',
+      expiresIn: this.jwt.tokenLifetimeSeconds,
+      sessionId,
+      user: {
+        id: user.id,
+        email: user.email,
+        organizationId: user.organizationId,
+      },
+    };
+  }
+
+  @Get('me')
+  async me(@Req() req: Request): Promise<unknown> {
+    const outcome = await this.resolver.authenticate(req.headers);
+    if (outcome.status !== 'authenticated') {
+      throw new UnauthorizedException();
+    }
+    return { user: outcome.identity };
+  }
+
+  @Post('logout')
+  @HttpCode(204)
+  async logout(@Body() body: unknown): Promise<void> {
+    const sessionId =
+      body &&
+      typeof body === 'object' &&
+      typeof (body as { sessionId?: unknown }).sessionId === 'string'
+        ? (body as { sessionId: string }).sessionId
+        : undefined;
+    if (sessionId) {
+      await this.sessions.destroySession(sessionId);
+    }
+  }
+}

--- a/apps/mcp-server/src/auth/auth.controller.ts
+++ b/apps/mcp-server/src/auth/auth.controller.ts
@@ -1,6 +1,5 @@
 import {
   BadRequestException,
-  Body,
   Controller,
   Get,
   HttpCode,
@@ -35,6 +34,27 @@ export const OAUTH_REDIRECT_BASE_URL = Symbol.for('engram.oauth-redirect-base');
  */
 const SESSION_SCOPES = ['memories:read', 'memories:write', 'memories:delete'];
 
+/** Name of the httpOnly cookie carrying the interactive session id. */
+const SESSION_COOKIE = 'engram_session';
+
+/**
+ * Read the session id from the httpOnly `engram_session` cookie. The id is
+ * never returned in a response body (that would defeat `httpOnly` and expose
+ * it to XSS), so logout recovers it from the cookie the browser sends back.
+ */
+function readSessionCookie(req: Request): string | undefined {
+  const header = req.headers.cookie;
+  if (!header) return undefined;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === SESSION_COOKIE) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+  return undefined;
+}
+
 const callbackQuerySchema = z.object({
   code: z.string().min(1),
   state: z.string().min(1),
@@ -49,7 +69,7 @@ function isProviderName(value: string): value is OAuthProviderName {
  *   - `GET  /auth/:provider/login`    → redirect to the provider with CSRF state
  *   - `GET  /auth/:provider/callback` → exchange code, upsert user, issue JWT + session
  *   - `GET  /auth/me`                 → resolve the caller's identity
- *   - `POST /auth/logout`             → destroy a session
+ *   - `POST /auth/logout`             → destroy the session named by its cookie
  */
 @Controller('auth')
 export class AuthController {
@@ -134,7 +154,7 @@ export class AuthController {
       scopes: SESSION_SCOPES,
     });
 
-    res.cookie('engram_session', sessionId, {
+    res.cookie(SESSION_COOKIE, sessionId, {
       httpOnly: true,
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',
@@ -142,11 +162,13 @@ export class AuthController {
     });
 
     this.logger.log(`oauth_login_ok provider=${provider} userId=${user.id}`);
+    // The session id is intentionally NOT echoed in the body — it lives only in
+    // the httpOnly cookie above. The Bearer token is the credential for API
+    // clients; logout recovers the session id from the cookie.
     return {
       token,
       tokenType: 'Bearer',
       expiresIn: this.jwt.tokenLifetimeSeconds,
-      sessionId,
       user: {
         id: user.id,
         email: user.email,
@@ -166,15 +188,14 @@ export class AuthController {
 
   @Post('logout')
   @HttpCode(204)
-  async logout(@Body() body: unknown): Promise<void> {
-    const sessionId =
-      body &&
-      typeof body === 'object' &&
-      typeof (body as { sessionId?: unknown }).sessionId === 'string'
-        ? (body as { sessionId: string }).sessionId
-        : undefined;
+  async logout(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<void> {
+    const sessionId = readSessionCookie(req);
     if (sessionId) {
       await this.sessions.destroySession(sessionId);
     }
+    res.clearCookie(SESSION_COOKIE);
   }
 }

--- a/apps/mcp-server/src/auth/auth.module.ts
+++ b/apps/mcp-server/src/auth/auth.module.ts
@@ -1,0 +1,112 @@
+import {
+  Module,
+  type DynamicModule,
+  type Provider,
+  type Type,
+} from '@nestjs/common';
+import { JwtService, OAuthService, SessionService } from '@engram/auth';
+import { RedisModule } from '@engram/redis';
+import type { ProfileCapabilities } from '@engram/config';
+import { ApiKeysModule } from '../api-keys/api-keys.module';
+import { AuthController, OAUTH_REDIRECT_BASE_URL } from './auth.controller';
+import { AuthResolver } from './auth-resolver.service';
+import { UserService } from './user.service';
+import { RedisSessionStore } from './redis-session.store';
+import { RedisRateLimitStore } from './redis-rate-limit.store';
+import { McpAuthMiddleware } from './mcp-auth.middleware';
+import { McpRateLimitMiddleware } from './mcp-rate-limit.middleware';
+import {
+  buildOAuthProviders,
+  isAuthRequired,
+  oauthRedirectBaseUrl,
+  parseJwtConfig,
+  parseRateLimitConfig,
+} from './auth.config';
+
+/**
+ * Authentication & multi-tenancy wiring for the MCP server (Epic E4).
+ *
+ * Profile-gated: imported by `app.module` only when the profile has a database
+ * (lite + enterprise). JWT verification and API-key auth need only Postgres, so
+ * they are available in `lite`; OAuth login, Redis-backed sessions, and rate
+ * limiting require Redis and are wired only in `enterprise`.
+ */
+@Module({})
+export class AuthModule {
+  static forRoot(capabilities: ProfileCapabilities): DynamicModule {
+    const jwtConfig = parseJwtConfig();
+    const redisEnabled = capabilities.requiresRedis;
+    const rateLimitConfig = parseRateLimitConfig();
+
+    const imports: Array<Type<unknown> | DynamicModule> = [ApiKeysModule];
+    if (redisEnabled) {
+      imports.push(RedisModule.forRoot());
+    }
+
+    const providers: Provider[] = [UserService, AuthResolver];
+    const exports: Array<Type<unknown> | symbol> = [AuthResolver, UserService];
+    const controllers: Array<Type<unknown>> = [];
+
+    // JWT signing/verification — only when a secret is configured.
+    if (jwtConfig) {
+      providers.push({
+        provide: JwtService,
+        useFactory: (): JwtService =>
+          new JwtService({
+            secret: jwtConfig.secret,
+            expiresInSeconds: jwtConfig.expiresInSeconds,
+          }),
+      });
+      exports.push(JwtService);
+    }
+
+    // /mcp auth resolution + enforcement (works with API keys and/or JWT).
+    providers.push({
+      provide: McpAuthMiddleware,
+      useFactory: (resolver: AuthResolver): McpAuthMiddleware =>
+        new McpAuthMiddleware(resolver, isAuthRequired()),
+      inject: [AuthResolver],
+    });
+    exports.push(McpAuthMiddleware);
+
+    if (redisEnabled) {
+      providers.push(RedisSessionStore, RedisRateLimitStore);
+
+      providers.push({
+        provide: SessionService,
+        useFactory: (store: RedisSessionStore): SessionService =>
+          new SessionService(store, {
+            sessionTtlSeconds: jwtConfig?.expiresInSeconds,
+          }),
+        inject: [RedisSessionStore],
+      });
+      providers.push({
+        provide: OAuthService,
+        useFactory: (): OAuthService => new OAuthService(buildOAuthProviders()),
+      });
+      providers.push({
+        provide: OAUTH_REDIRECT_BASE_URL,
+        useValue: oauthRedirectBaseUrl(),
+      });
+      exports.push(SessionService, OAuthService);
+
+      // Rate-limit middleware — only when explicitly enabled.
+      if (rateLimitConfig.enabled) {
+        providers.push({
+          provide: McpRateLimitMiddleware,
+          useFactory: (store: RedisRateLimitStore): McpRateLimitMiddleware =>
+            new McpRateLimitMiddleware(store, rateLimitConfig),
+          inject: [RedisRateLimitStore],
+        });
+        exports.push(McpRateLimitMiddleware);
+      }
+
+      // OAuth login endpoints require both sessions (Redis) and JWT issuance.
+      if (jwtConfig) {
+        controllers.push(AuthController);
+      }
+    }
+
+    return { module: AuthModule, imports, controllers, providers, exports };
+  }
+}

--- a/apps/mcp-server/src/auth/mcp-auth.middleware.spec.ts
+++ b/apps/mcp-server/src/auth/mcp-auth.middleware.spec.ts
@@ -1,0 +1,156 @@
+import type { Request, Response } from 'express';
+import {
+  McpAuthMiddleware,
+  toolCallNames,
+  type AuthedRequest,
+} from './mcp-auth.middleware';
+import type { AuthResolver, AuthOutcome } from './auth-resolver.service';
+
+function mockRes(): Response & {
+  statusCode: number;
+  body: unknown;
+  headers: Record<string, string>;
+} {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    headersSent: false,
+  };
+  const r = res as unknown as Response & typeof res;
+  r.status = jest.fn((code: number) => {
+    res.statusCode = code;
+    return r;
+  }) as never;
+  r.json = jest.fn((b: unknown) => {
+    res.body = b;
+    res.headersSent = true;
+    return r;
+  }) as never;
+  r.set = jest.fn((k: string, v: string) => {
+    res.headers[k] = v;
+    return r;
+  }) as never;
+  return r as never;
+}
+
+function resolverReturning(outcome: AuthOutcome): AuthResolver {
+  return {
+    authenticate: jest.fn(() => Promise.resolve(outcome)),
+  } as unknown as AuthResolver;
+}
+
+const identityOutcome: AuthOutcome = {
+  status: 'authenticated',
+  identity: {
+    userId: 'user-9',
+    organizationId: 'org-9',
+    email: 'a@b.com',
+    scopes: ['memories:read'],
+    method: 'jwt',
+    apiKeyId: null,
+  },
+};
+
+describe('toolCallNames', () => {
+  it('extracts a single tools/call name', () => {
+    expect(
+      toolCallNames({ method: 'tools/call', params: { name: 'recall' } }),
+    ).toEqual(['recall']);
+  });
+  it('extracts names from a batch', () => {
+    expect(
+      toolCallNames([
+        { method: 'tools/call', params: { name: 'a' } },
+        { method: 'initialize' },
+        { method: 'tools/call', params: { name: 'b' } },
+      ]),
+    ).toEqual(['a', 'b']);
+  });
+  it('ignores non tools/call bodies', () => {
+    expect(toolCallNames({ method: 'tools/list' })).toEqual([]);
+    expect(toolCallNames(undefined)).toEqual([]);
+  });
+});
+
+describe('McpAuthMiddleware', () => {
+  const callBody = (
+    name: string,
+  ): { method: string; params: { name: string } } => ({
+    method: 'tools/call',
+    params: { name },
+  });
+
+  it('attaches req.auth when authenticated', async () => {
+    const mw = new McpAuthMiddleware(resolverReturning(identityOutcome), false);
+    const req = { headers: {}, body: callBody('recall') } as Request;
+    const res = mockRes();
+    const next = jest.fn();
+    await mw.handle(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect((req as AuthedRequest).auth?.extra.userId).toBe('user-9');
+  });
+
+  it('rejects a presented-but-invalid credential with 401', async () => {
+    const mw = new McpAuthMiddleware(
+      resolverReturning({ status: 'invalid', reason: 'bad' }),
+      false,
+    );
+    const res = mockRes();
+    const next = jest.fn();
+    await mw.handle(
+      { headers: {}, body: callBody('recall') } as Request,
+      res,
+      next,
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects protected tool calls when auth is required and absent', async () => {
+    const mw = new McpAuthMiddleware(
+      resolverReturning({ status: 'anonymous' }),
+      true,
+    );
+    const res = mockRes();
+    const next = jest.fn();
+    await mw.handle(
+      { headers: {}, body: callBody('recall') } as Request,
+      res,
+      next,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows public tools without auth even when required', async () => {
+    const mw = new McpAuthMiddleware(
+      resolverReturning({ status: 'anonymous' }),
+      true,
+    );
+    const res = mockRes();
+    const next = jest.fn();
+    await mw.handle(
+      { headers: {}, body: callBody('ping') } as Request,
+      res,
+      next,
+    );
+    expect(next).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('passes through anonymous requests when auth is not required', async () => {
+    const mw = new McpAuthMiddleware(
+      resolverReturning({ status: 'anonymous' }),
+      false,
+    );
+    const res = mockRes();
+    const next = jest.fn();
+    await mw.handle(
+      { headers: {}, body: callBody('recall') } as Request,
+      res,
+      next,
+    );
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/apps/mcp-server/src/auth/mcp-auth.middleware.ts
+++ b/apps/mcp-server/src/auth/mcp-auth.middleware.ts
@@ -9,7 +9,7 @@ const PUBLIC_TOOLS = new Set(['ping']);
 /**
  * The auth info attached to the request. The MCP streamable-http transport
  * forwards `req.auth` to tool handlers as `extra.authInfo`; the dispatch layer
- * reads `extra.userId` to derive the acting tenant.
+ * reads `extra.authInfo.extra.userId` to derive the acting tenant.
  */
 export interface McpAuthInfo {
   token: string;

--- a/apps/mcp-server/src/auth/mcp-auth.middleware.ts
+++ b/apps/mcp-server/src/auth/mcp-auth.middleware.ts
@@ -1,0 +1,117 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { Request, Response, NextFunction } from 'express';
+import type { AuthIdentity } from '@engram/auth';
+import { AuthResolver } from './auth-resolver.service';
+
+/** Tools callable without authentication even when enforcement is on. */
+const PUBLIC_TOOLS = new Set(['ping']);
+
+/**
+ * The auth info attached to the request. The MCP streamable-http transport
+ * forwards `req.auth` to tool handlers as `extra.authInfo`; the dispatch layer
+ * reads `extra.userId` to derive the acting tenant.
+ */
+export interface McpAuthInfo {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  extra: {
+    userId: string;
+    organizationId: string | null;
+    email: string | null;
+    method: AuthIdentity['method'];
+    apiKeyId: string | null;
+  };
+}
+
+export type AuthedRequest = Request & { auth?: McpAuthInfo };
+
+function toAuthInfo(identity: AuthIdentity): McpAuthInfo {
+  return {
+    // Never the raw credential — just a non-sensitive method marker.
+    token: identity.method,
+    clientId: identity.userId,
+    scopes: identity.scopes,
+    extra: {
+      userId: identity.userId,
+      organizationId: identity.organizationId,
+      email: identity.email,
+      method: identity.method,
+      apiKeyId: identity.apiKeyId,
+    },
+  };
+}
+
+/** Extract the names of every `tools/call` in a JSON-RPC body (single or batch). */
+export function toolCallNames(body: unknown): string[] {
+  const entries = Array.isArray(body) ? body : [body];
+  const names: string[] = [];
+  for (const entry of entries) {
+    if (
+      entry &&
+      typeof entry === 'object' &&
+      (entry as { method?: unknown }).method === 'tools/call'
+    ) {
+      const name = (entry as { params?: { name?: unknown } }).params?.name;
+      if (typeof name === 'string') names.push(name);
+    }
+  }
+  return names;
+}
+
+function jsonRpcError(res: Response, status: number, message: string): void {
+  res
+    .status(status)
+    .set('WWW-Authenticate', 'Bearer realm="engram"')
+    .json({
+      jsonrpc: '2.0',
+      error: { code: -32001, message },
+      id: null,
+    });
+}
+
+/**
+ * Express middleware for `/mcp`. Authenticates the request (JWT or API key) and
+ * attaches `req.auth`; when `AUTH_REQUIRED` is on, rejects `tools/call`s to
+ * protected tools that carry no valid identity with a 401. A credential that is
+ * present but invalid is always rejected, regardless of enforcement.
+ */
+@Injectable()
+export class McpAuthMiddleware {
+  private readonly logger = new Logger(McpAuthMiddleware.name);
+
+  constructor(
+    private readonly resolver: AuthResolver,
+    private readonly authRequired: boolean,
+  ) {}
+
+  handle = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const outcome = await this.resolver.authenticate(req.headers);
+
+    if (outcome.status === 'invalid') {
+      this.logger.warn(`auth_rejected reason=${outcome.reason}`);
+      jsonRpcError(res, 401, `Unauthorized: ${outcome.reason}`);
+      return;
+    }
+
+    if (outcome.status === 'authenticated') {
+      (req as AuthedRequest).auth = toAuthInfo(outcome.identity);
+    }
+
+    if (this.authRequired && outcome.status !== 'authenticated') {
+      const protectedCall = toolCallNames(req.body).some(
+        (name) => !PUBLIC_TOOLS.has(name),
+      );
+      if (protectedCall) {
+        jsonRpcError(res, 401, 'Unauthorized: authentication is required');
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/apps/mcp-server/src/auth/mcp-rate-limit.middleware.spec.ts
+++ b/apps/mcp-server/src/auth/mcp-rate-limit.middleware.spec.ts
@@ -1,0 +1,169 @@
+import type { Request, Response } from 'express';
+import type { RateLimitStore, RateLimitIncrementResult } from '@engram/auth';
+import { McpRateLimitMiddleware } from './mcp-rate-limit.middleware';
+import type { RateLimitConfig } from './auth.config';
+import type { AuthedRequest, McpAuthInfo } from './mcp-auth.middleware';
+
+class FakeStore implements RateLimitStore {
+  private counters = new Map<string, { count: number; expiresAt: number }>();
+  now = 0;
+  increment(
+    key: string,
+    windowSeconds: number,
+  ): Promise<RateLimitIncrementResult> {
+    const existing = this.counters.get(key);
+    if (!existing || existing.expiresAt <= this.now) {
+      this.counters.set(key, { count: 1, expiresAt: this.now + windowSeconds });
+      return Promise.resolve({ count: 1, ttlSeconds: windowSeconds });
+    }
+    existing.count += 1;
+    return Promise.resolve({
+      count: existing.count,
+      ttlSeconds: existing.expiresAt - this.now,
+    });
+  }
+}
+
+function mockRes(): Response & {
+  statusCode: number;
+  headers: Record<string, string>;
+} {
+  const res = { statusCode: 200, headers: {} as Record<string, string> };
+  const r = res as unknown as Response & typeof res;
+  r.status = jest.fn((c: number) => {
+    res.statusCode = c;
+    return r;
+  }) as never;
+  r.json = jest.fn(() => r) as never;
+  r.set = jest.fn((k: string, v: string) => {
+    res.headers[k] = v;
+    return r;
+  }) as never;
+  return r as never;
+}
+
+const config = (over: Partial<RateLimitConfig> = {}): RateLimitConfig => ({
+  enabled: true,
+  windowSeconds: 60,
+  userRpm: 2,
+  orgRpm: 100,
+  ipRpm: 1,
+  toolOverrides: {},
+  ...over,
+});
+
+const authInfo = (over: Partial<McpAuthInfo['extra']> = {}): McpAuthInfo => ({
+  token: 'jwt',
+  clientId: 'user-1',
+  scopes: [],
+  extra: {
+    userId: 'user-1',
+    organizationId: null,
+    email: null,
+    method: 'jwt',
+    apiKeyId: null,
+    ...over,
+  },
+});
+
+describe('McpRateLimitMiddleware', () => {
+  it('meters authenticated users and 429s past the limit', async () => {
+    const mw = new McpRateLimitMiddleware(new FakeStore(), config());
+    const makeReq = (): AuthedRequest =>
+      ({ headers: {}, body: {}, auth: authInfo() }) as unknown as AuthedRequest;
+
+    const next = jest.fn();
+    const res1 = mockRes();
+    await mw.handle(makeReq() as Request, res1, next);
+    expect(res1.statusCode).toBe(200);
+    expect(res1.headers['X-RateLimit-Limit']).toBe('2');
+
+    await mw.handle(makeReq() as Request, mockRes(), next); // 2nd allowed
+
+    const blockedRes = mockRes();
+    await mw.handle(makeReq() as Request, blockedRes, jest.fn());
+    expect(blockedRes.statusCode).toBe(429);
+    expect(blockedRes.headers['Retry-After']).toBeDefined();
+  });
+
+  it('meters unauthenticated requests by IP', async () => {
+    const mw = new McpRateLimitMiddleware(new FakeStore(), config());
+    const req = (): Request =>
+      ({ headers: {}, body: {}, ip: '9.9.9.9' }) as unknown as Request;
+
+    const allowed = mockRes();
+    await mw.handle(req(), allowed, jest.fn());
+    expect(allowed.statusCode).toBe(200);
+    expect(allowed.headers['X-RateLimit-Limit']).toBe('1');
+
+    const blocked = mockRes();
+    await mw.handle(req(), blocked, jest.fn());
+    expect(blocked.statusCode).toBe(429);
+  });
+
+  it('applies stricter per-tool overrides on a separate bucket', async () => {
+    const mw = new McpRateLimitMiddleware(
+      new FakeStore(),
+      config({
+        userRpm: 100,
+        toolOverrides: { reindex_memories: { limit: 1, windowSeconds: 60 } },
+      }),
+    );
+    const reindexReq = (): Request =>
+      ({
+        headers: {},
+        body: { method: 'tools/call', params: { name: 'reindex_memories' } },
+        auth: authInfo(),
+      }) as unknown as Request;
+
+    await mw.handle(reindexReq(), mockRes(), jest.fn());
+    const blocked = mockRes();
+    await mw.handle(reindexReq(), blocked, jest.fn());
+    expect(blocked.statusCode).toBe(429);
+  });
+
+  it('meters per API key — two keys of one user have independent budgets', async () => {
+    const mw = new McpRateLimitMiddleware(
+      new FakeStore(),
+      config({ userRpm: 1 }),
+    );
+    const reqWithKey = (apiKeyId: string): Request =>
+      ({
+        headers: {},
+        body: {},
+        auth: authInfo({ apiKeyId }),
+      }) as unknown as Request;
+
+    // key-A exhausts its own budget...
+    await mw.handle(reqWithKey('key-A'), mockRes(), jest.fn());
+    const blockedA = mockRes();
+    await mw.handle(reqWithKey('key-A'), blockedA, jest.fn());
+    expect(blockedA.statusCode).toBe(429);
+
+    // ...but key-B (same user) is unaffected.
+    const allowedB = mockRes();
+    await mw.handle(reqWithKey('key-B'), allowedB, jest.fn());
+    expect(allowedB.statusCode).toBe(200);
+  });
+
+  it('meters every tool call in a JSON-RPC batch (no batch bypass)', async () => {
+    const mw = new McpRateLimitMiddleware(
+      new FakeStore(),
+      config({ userRpm: 2 }),
+    );
+    // A single request carrying 3 tools/call entries must exceed a limit of 2.
+    const batchReq = (): Request =>
+      ({
+        headers: {},
+        body: [
+          { method: 'tools/call', params: { name: 'recall' } },
+          { method: 'tools/call', params: { name: 'recall' } },
+          { method: 'tools/call', params: { name: 'recall' } },
+        ],
+        auth: authInfo(),
+      }) as unknown as Request;
+    const res = mockRes();
+    await mw.handle(batchReq(), res, jest.fn());
+    expect(res.statusCode).toBe(429);
+  });
+});

--- a/apps/mcp-server/src/auth/mcp-rate-limit.middleware.ts
+++ b/apps/mcp-server/src/auth/mcp-rate-limit.middleware.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@nestjs/common';
+import type { Request, Response, NextFunction } from 'express';
+import {
+  RateLimitService,
+  type RateLimitResult,
+  type RateLimitStore,
+} from '@engram/auth';
+import type { RateLimitConfig } from './auth.config';
+import { toolCallNames, type AuthedRequest } from './mcp-auth.middleware';
+
+function clientIp(req: Request): string {
+  // req.ip is the direct TCP peer unless Express `trust proxy` is configured.
+  // Behind a reverse proxy, configure trust proxy at the edge so per-IP limits
+  // apply per client; the authenticated per-user/key buckets are the primary
+  // control and are unaffected.
+  return req.ip ?? req.socket?.remoteAddress ?? 'unknown';
+}
+
+function jsonRpcId(body: unknown): unknown {
+  if (
+    body &&
+    typeof body === 'object' &&
+    !Array.isArray(body) &&
+    'id' in body
+  ) {
+    return (body as { id?: unknown }).id ?? null;
+  }
+  return null;
+}
+
+/**
+ * Express middleware for `/mcp` applying Redis-backed fixed-window rate limits.
+ * Authenticated requests are metered per-user (and per-org when applicable);
+ * unauthenticated requests are metered per client IP. Per-tool overrides apply
+ * to the user/IP bucket. Exceeding any applicable bucket yields a 429 with
+ * `Retry-After`; every response carries `X-RateLimit-*` headers.
+ */
+@Injectable()
+export class McpRateLimitMiddleware {
+  private readonly userLimiter: RateLimitService;
+  private readonly ipLimiter: RateLimitService;
+  private readonly orgLimiter: RateLimitService;
+
+  constructor(store: RateLimitStore, config: RateLimitConfig) {
+    const windowSeconds = config.windowSeconds;
+    this.userLimiter = new RateLimitService(store, {
+      defaultRule: { limit: config.userRpm, windowSeconds },
+      toolOverrides: config.toolOverrides,
+    });
+    this.ipLimiter = new RateLimitService(store, {
+      defaultRule: { limit: config.ipRpm, windowSeconds },
+      toolOverrides: config.toolOverrides,
+    });
+    this.orgLimiter = new RateLimitService(store, {
+      defaultRule: { limit: config.orgRpm, windowSeconds },
+    });
+  }
+
+  handle = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const auth = (req as AuthedRequest).auth;
+    // Meter EVERY tool call in the request — a JSON-RPC batch executes all of
+    // its tools/call entries, so charging only the first would let a single
+    // batched request bypass the limit. Requests with no tools/call (e.g.
+    // initialize) are charged once against the default bucket.
+    const names = toolCallNames(req.body);
+    const calls: Array<string | undefined> =
+      names.length > 0 ? names : [undefined];
+
+    // Meter per-key for API keys (independent budget per key) and per-user for
+    // interactive JWT sessions — satisfying #132's "per tenant/key".
+    const principalKey = auth?.extra.apiKeyId
+      ? `key:${auth.extra.apiKeyId}`
+      : `user:${auth?.extra.userId}`;
+
+    const results: RateLimitResult[] = [];
+    for (const tool of calls) {
+      if (auth) {
+        results.push(
+          await this.userLimiter.consume({ key: principalKey, tool }),
+        );
+        if (auth.extra.organizationId) {
+          results.push(
+            await this.orgLimiter.consume({
+              key: `org:${auth.extra.organizationId}`,
+            }),
+          );
+        }
+      } else {
+        results.push(
+          await this.ipLimiter.consume({ key: `ip:${clientIp(req)}`, tool }),
+        );
+      }
+    }
+
+    // Report headers from the tightest applicable bucket.
+    const tightest = results.reduce((a, b) =>
+      b.remaining < a.remaining ? b : a,
+    );
+    res.set('X-RateLimit-Limit', String(tightest.limit));
+    res.set('X-RateLimit-Remaining', String(tightest.remaining));
+    res.set('X-RateLimit-Reset', String(tightest.resetSeconds));
+
+    const blocked = results.find((r) => !r.allowed);
+    if (blocked) {
+      res
+        .set('Retry-After', String(blocked.retryAfterSeconds))
+        .status(429)
+        .json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32002,
+            message: 'Rate limit exceeded',
+            data: { retryAfterSeconds: blocked.retryAfterSeconds },
+          },
+          id: jsonRpcId(req.body),
+        });
+      return;
+    }
+
+    next();
+  };
+}

--- a/apps/mcp-server/src/auth/redis-rate-limit.store.spec.ts
+++ b/apps/mcp-server/src/auth/redis-rate-limit.store.spec.ts
@@ -1,0 +1,87 @@
+import { RedisRateLimitStore } from './redis-rate-limit.store';
+import type { RedisService } from '@engram/redis';
+
+function makeRedis(
+  over: Partial<Record<string, jest.Mock>> = {},
+  client: { eval?: jest.Mock } = {},
+): RedisService {
+  return {
+    incr: over.incr ?? jest.fn().mockResolvedValue(1),
+    expire: over.expire ?? jest.fn().mockResolvedValue(true),
+    ttl: over.ttl ?? jest.fn().mockResolvedValue(60),
+    getClient: jest.fn().mockReturnValue(client),
+  } as unknown as RedisService;
+}
+
+describe('RedisRateLimitStore', () => {
+  it('uses the atomic Lua eval path when available', async () => {
+    const evalMock = jest.fn().mockResolvedValue([3, 42]);
+    const redis = makeRedis({}, { eval: evalMock });
+    const store = new RedisRateLimitStore(redis);
+
+    const result = await store.increment('rl:user:1', 60);
+
+    expect(result).toEqual({ count: 3, ttlSeconds: 42 });
+    expect(evalMock).toHaveBeenCalledWith(
+      expect.stringContaining('INCR'),
+      1,
+      'rl:user:1',
+      60,
+    );
+    expect(redis.incr).not.toHaveBeenCalled();
+  });
+
+  it('falls back to discrete commands when eval throws', async () => {
+    const evalMock = jest.fn().mockRejectedValue(new Error('NOSCRIPT'));
+    const redis = makeRedis(
+      { incr: jest.fn().mockResolvedValue(1) },
+      { eval: evalMock },
+    );
+    const store = new RedisRateLimitStore(redis);
+
+    const result = await store.increment('rl:user:1', 60);
+
+    expect(result).toEqual({ count: 1, ttlSeconds: 60 });
+    expect(redis.expire).toHaveBeenCalledWith('rl:user:1', 60);
+  });
+
+  it('falls back when the client cannot eval', async () => {
+    const redis = makeRedis({ incr: jest.fn().mockResolvedValue(1) });
+    const store = new RedisRateLimitStore(redis);
+
+    expect(await store.increment('k', 30)).toEqual({
+      count: 1,
+      ttlSeconds: 30,
+    });
+  });
+
+  it('returns the existing TTL on subsequent hits within the window', async () => {
+    const redis = makeRedis({
+      incr: jest.fn().mockResolvedValue(5),
+      ttl: jest.fn().mockResolvedValue(17),
+    });
+    const store = new RedisRateLimitStore(redis);
+
+    expect(await store.increment('k', 60)).toEqual({
+      count: 5,
+      ttlSeconds: 17,
+    });
+    expect(redis.expire).not.toHaveBeenCalled();
+  });
+
+  it('re-anchors the window when an existing key has no expiry', async () => {
+    const expireMock = jest.fn().mockResolvedValue(true);
+    const redis = makeRedis({
+      incr: jest.fn().mockResolvedValue(5),
+      ttl: jest.fn().mockResolvedValue(-1),
+      expire: expireMock,
+    });
+    const store = new RedisRateLimitStore(redis);
+
+    expect(await store.increment('k', 60)).toEqual({
+      count: 5,
+      ttlSeconds: 60,
+    });
+    expect(expireMock).toHaveBeenCalledWith('k', 60);
+  });
+});

--- a/apps/mcp-server/src/auth/redis-rate-limit.store.ts
+++ b/apps/mcp-server/src/auth/redis-rate-limit.store.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from '@engram/redis';
+import type { RateLimitStore, RateLimitIncrementResult } from '@engram/auth';
+
+/** Minimal view of the underlying client for the atomic Lua increment. */
+interface EvalCapable {
+  eval?: (
+    script: string,
+    numKeys: number,
+    ...args: Array<string | number>
+  ) => Promise<unknown>;
+}
+
+// Atomically: increment the counter; set the window TTL only on the first hit;
+// return [count, ttl]. Keeping this in one round-trip avoids a window that can
+// grow without ever expiring if the process dies between INCR and EXPIRE.
+const INCR_SCRIPT = `
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('TTL', KEYS[1])
+return {count, ttl}
+`;
+
+/**
+ * Redis-backed fixed-window counter for {@link RateLimitService}. Uses a Lua
+ * script for an atomic INCR + first-hit EXPIRE + TTL read; falls back to
+ * discrete commands if the client cannot `eval`.
+ */
+@Injectable()
+export class RedisRateLimitStore implements RateLimitStore {
+  private readonly logger = new Logger(RedisRateLimitStore.name);
+
+  constructor(private readonly redis: RedisService) {}
+
+  async increment(
+    key: string,
+    windowSeconds: number,
+  ): Promise<RateLimitIncrementResult> {
+    const client = this.redis.getClient() as EvalCapable;
+    if (typeof client.eval === 'function') {
+      try {
+        const result = (await client.eval(
+          INCR_SCRIPT,
+          1,
+          key,
+          windowSeconds,
+        )) as [number, number];
+        return { count: Number(result[0]), ttlSeconds: Number(result[1]) };
+      } catch (error) {
+        this.logger.warn(
+          `Rate-limit eval failed; falling back to discrete commands: ${String(error)}`,
+        );
+      }
+    }
+    return this.incrementWithoutEval(key, windowSeconds);
+  }
+
+  private async incrementWithoutEval(
+    key: string,
+    windowSeconds: number,
+  ): Promise<RateLimitIncrementResult> {
+    const count = await this.redis.incr(key);
+    if (count === 1) {
+      await this.redis.expire(key, windowSeconds);
+      return { count, ttlSeconds: windowSeconds };
+    }
+    let ttl = await this.redis.ttl(key);
+    if (ttl < 0) {
+      // The key exists without an expiry (a prior EXPIRE was lost, e.g. the
+      // process died between INCR and EXPIRE). Re-anchor the window so the
+      // counter cannot wedge permanently and block the identity forever.
+      await this.redis.expire(key, windowSeconds);
+      ttl = windowSeconds;
+    }
+    return { count, ttlSeconds: ttl };
+  }
+}

--- a/apps/mcp-server/src/auth/redis-session.store.spec.ts
+++ b/apps/mcp-server/src/auth/redis-session.store.spec.ts
@@ -1,0 +1,61 @@
+import { RedisSessionStore } from './redis-session.store';
+import type { RedisService } from '@engram/redis';
+
+function makeRedis(over: Partial<Record<string, jest.Mock>> = {}): {
+  redis: RedisService;
+  client: { getdel?: jest.Mock };
+} {
+  const client: { getdel?: jest.Mock } = {};
+  const redis = {
+    set: over.set ?? jest.fn().mockResolvedValue(undefined),
+    get: over.get ?? jest.fn().mockResolvedValue(null),
+    del: over.del ?? jest.fn().mockResolvedValue(1),
+    getClient: jest.fn().mockReturnValue(client),
+  } as unknown as RedisService;
+  return { redis, client };
+}
+
+describe('RedisSessionStore', () => {
+  it('set/get/delete delegate to RedisService', async () => {
+    const { redis } = makeRedis({
+      get: jest.fn().mockResolvedValue('value'),
+    });
+    const store = new RedisSessionStore(redis);
+
+    await store.set('k', 'v', 30);
+    expect(redis.set).toHaveBeenCalledWith('k', 'v', 30);
+    expect(await store.get('k')).toBe('value');
+    await store.delete('k');
+    expect(redis.del).toHaveBeenCalledWith('k');
+  });
+
+  it('getDelete uses atomic GETDEL when the client supports it', async () => {
+    const { redis, client } = makeRedis();
+    client.getdel = jest.fn().mockResolvedValue('state-value');
+    const store = new RedisSessionStore(redis);
+
+    expect(await store.getDelete('state')).toBe('state-value');
+    expect(client.getdel).toHaveBeenCalledWith('state');
+    expect(redis.del).not.toHaveBeenCalled();
+  });
+
+  it('getDelete falls back to GET+DEL when value is present', async () => {
+    const { redis } = makeRedis({
+      get: jest.fn().mockResolvedValue('state-value'),
+    });
+    const store = new RedisSessionStore(redis);
+
+    expect(await store.getDelete('state')).toBe('state-value');
+    expect(redis.del).toHaveBeenCalledWith('state');
+  });
+
+  it('getDelete fallback does not DEL when the key is absent', async () => {
+    const { redis } = makeRedis({
+      get: jest.fn().mockResolvedValue(null),
+    });
+    const store = new RedisSessionStore(redis);
+
+    expect(await store.getDelete('state')).toBeNull();
+    expect(redis.del).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mcp-server/src/auth/redis-session.store.ts
+++ b/apps/mcp-server/src/auth/redis-session.store.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { RedisService } from '@engram/redis';
+import type { SessionStore } from '@engram/auth';
+
+/** Minimal view of the underlying client for the atomic GETDEL command. */
+interface GetDelCapable {
+  getdel?: (key: string) => Promise<string | null>;
+}
+
+/**
+ * Redis-backed {@link SessionStore} for interactive sessions and one-time OAuth
+ * state. `getDelete` prefers the atomic `GETDEL` (Redis 6.2+) so a one-time
+ * OAuth `state` cannot be replayed; it falls back to GET+DEL otherwise.
+ */
+@Injectable()
+export class RedisSessionStore implements SessionStore {
+  constructor(private readonly redis: RedisService) {}
+
+  async set(key: string, value: string, ttlSeconds: number): Promise<void> {
+    await this.redis.set(key, value, ttlSeconds);
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.redis.get(key);
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.redis.del(key);
+  }
+
+  async getDelete(key: string): Promise<string | null> {
+    const client = this.redis.getClient() as GetDelCapable;
+    if (typeof client.getdel === 'function') {
+      return client.getdel(key);
+    }
+    const value = await this.redis.get(key);
+    if (value !== null) {
+      await this.redis.del(key);
+    }
+    return value;
+  }
+}

--- a/apps/mcp-server/src/auth/user.service.spec.ts
+++ b/apps/mcp-server/src/auth/user.service.spec.ts
@@ -1,0 +1,64 @@
+import { UserService } from './user.service';
+import type { PrismaService } from '@engram/database';
+
+interface PrismaStub {
+  user: { upsert: jest.Mock };
+  membership: { findMany: jest.Mock };
+}
+
+function makePrisma(over?: {
+  user?: { id: string; email: string };
+  memberships?: Array<{ organizationId: string }>;
+}): { prisma: PrismaService; stub: PrismaStub } {
+  const stub: PrismaStub = {
+    user: {
+      upsert: jest
+        .fn()
+        .mockResolvedValue(over?.user ?? { id: 'u1', email: 'a@b.test' }),
+    },
+    membership: {
+      findMany: jest.fn().mockResolvedValue(over?.memberships ?? []),
+    },
+  };
+  return { prisma: stub as unknown as PrismaService, stub };
+}
+
+describe('UserService', () => {
+  it('upserts by email and selects the single org as the default tenant', async () => {
+    const { prisma, stub } = makePrisma({
+      user: { id: 'u1', email: 'a@b.test' },
+      memberships: [{ organizationId: 'org-1' }],
+    });
+    const service = new UserService(prisma);
+
+    const result = await service.upsertByEmail('a@b.test');
+
+    expect(result).toEqual({
+      id: 'u1',
+      email: 'a@b.test',
+      organizationId: 'org-1',
+    });
+    expect(stub.user.upsert).toHaveBeenCalledWith({
+      where: { email: 'a@b.test' },
+      create: { email: 'a@b.test' },
+      update: {},
+      select: { id: true, email: true },
+    });
+  });
+
+  it('leaves the org unset when the user has no memberships', async () => {
+    const { prisma } = makePrisma({ memberships: [] });
+    const service = new UserService(prisma);
+
+    expect((await service.upsertByEmail('a@b.test')).organizationId).toBeNull();
+  });
+
+  it('leaves the org unset when the user has multiple memberships', async () => {
+    const { prisma } = makePrisma({
+      memberships: [{ organizationId: 'org-1' }, { organizationId: 'org-2' }],
+    });
+    const service = new UserService(prisma);
+
+    expect((await service.upsertByEmail('a@b.test')).organizationId).toBeNull();
+  });
+});

--- a/apps/mcp-server/src/auth/user.service.ts
+++ b/apps/mcp-server/src/auth/user.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@engram/database';
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  organizationId: string | null;
+}
+
+/**
+ * Resolves ENGRAM users for the auth layer. A successful OAuth login upserts a
+ * user keyed by email; if the user belongs to exactly one organization that org
+ * becomes their acting tenant for the session.
+ */
+@Injectable()
+export class UserService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Upsert a user by email and resolve their default organization (if unambiguous). */
+  async upsertByEmail(email: string): Promise<AuthenticatedUser> {
+    const user = await this.prisma.user.upsert({
+      where: { email },
+      create: { email },
+      update: {},
+      select: { id: true, email: true },
+    });
+    const organizationId = await this.resolveDefaultOrg(user.id);
+    return { id: user.id, email: user.email, organizationId };
+  }
+
+  /**
+   * A user with exactly one membership acts within that org by default. With
+   * zero or multiple memberships we leave the org unset (callers may select one
+   * explicitly later) to avoid silently picking a tenant.
+   */
+  private async resolveDefaultOrg(userId: string): Promise<string | null> {
+    const memberships = await this.prisma.membership.findMany({
+      where: { userId },
+      select: { organizationId: true },
+      take: 2,
+    });
+    return memberships.length === 1 && memberships[0]
+      ? memberships[0].organizationId
+      : null;
+  }
+}

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -13,11 +13,21 @@ import type { McpServerConfig } from '@engram/core';
 import { ApiKeysController } from './api-keys/api-keys.controller';
 import { MemoryController } from './memory/memory.controller';
 import { MetricsService } from './metrics/metrics.service';
+import { McpAuthMiddleware } from './auth/mcp-auth.middleware';
+import { McpRateLimitMiddleware } from './auth/mcp-rate-limit.middleware';
+import { isAuthRequired } from './auth/auth.config';
+
+type ExpressMiddleware = (
+  req: Request,
+  res: Response,
+  next: (err?: unknown) => void,
+) => void;
 
 type McpHandlerContract = {
   registerAdditionalTools: (
     tools: ReturnType<MemoryController['getMcpTools']>,
   ) => void;
+  setAuthPolicy: (policy: { required: boolean }) => void;
   start: (options: McpServerConfig) => Promise<void>;
   createConfiguredServer: (options: McpServerConfig) => {
     connect: (t: StreamableHTTPServerTransport) => Promise<void>;
@@ -59,6 +69,35 @@ async function bootstrap(): Promise<void> {
   });
   const mcpTransport = process.env.MCP_TRANSPORT ?? 'stdio';
 
+  // Auth enforcement only applies over the HTTP transport (stdio is trusted
+  // local). When enabled, non-public tools require an authenticated identity
+  // and the acting userId is derived from the credential, not tool input.
+  const authRequired = isAuthRequired() && mcpTransport === 'streamable-http';
+  mcpHandler.setAuthPolicy({ required: authRequired });
+
+  // Resolve auth/rate-limit middleware if the active profile wired them.
+  const tryGet = <T>(token: unknown): T | undefined => {
+    try {
+      return app.get<T>(token as never, { strict: false });
+    } catch {
+      return undefined;
+    }
+  };
+  const authMiddleware = tryGet<McpAuthMiddleware>(McpAuthMiddleware);
+  const rateLimitMiddleware = tryGet<McpRateLimitMiddleware>(
+    McpRateLimitMiddleware,
+  );
+  if (authRequired && !authMiddleware) {
+    logger.error(
+      'AUTH_REQUIRED is set but no auth middleware is available for this profile — refusing to start unprotected.',
+    );
+    throw new Error('AUTH_REQUIRED but auth is not wired for this profile');
+  }
+  logger.log(
+    `MCP auth: required=${authRequired} rateLimiting=${Boolean(rateLimitMiddleware)}`,
+    'Bootstrap',
+  );
+
   try {
     const memoryTools = memoryController.getMcpTools();
     const apiKeyTools = apiKeysController.getMcpTools();
@@ -77,6 +116,37 @@ async function bootstrap(): Promise<void> {
         .getHttpAdapter()
         .getInstance() as express.Application;
       const mcpJsonParser = express.json({ limit: '4mb' });
+
+      // Auth + rate-limit run after JSON parsing (they inspect the body) and
+      // before the MCP handler. Async rejections are converted to a 500 so they
+      // never hang the request.
+      const wrapAsync =
+        (
+          fn: (
+            req: Request,
+            res: Response,
+            next: (err?: unknown) => void,
+          ) => void | Promise<void>,
+        ): ExpressMiddleware =>
+        (req, res, next): void => {
+          void Promise.resolve(fn(req, res, next)).catch((err: unknown) => {
+            logger.error('Error in /mcp middleware:', err);
+            if (!res.headersSent) {
+              res.status(500).json({
+                jsonrpc: '2.0',
+                error: { code: -32603, message: 'Internal server error' },
+                id: null,
+              });
+            }
+          });
+        };
+      const mcpPreHandlers: ExpressMiddleware[] = [];
+      if (authMiddleware) {
+        mcpPreHandlers.push(wrapAsync(authMiddleware.handle));
+      }
+      if (rateLimitMiddleware) {
+        mcpPreHandlers.push(wrapAsync(rateLimitMiddleware.handle));
+      }
 
       const handleSessionRequest = async (
         req: Request,
@@ -102,6 +172,7 @@ async function bootstrap(): Promise<void> {
       expressApp.post(
         '/mcp',
         mcpJsonParser,
+        ...mcpPreHandlers,
         async (req: Request, res: Response) => {
           try {
             const sessionId = req.headers['mcp-session-id'];

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -42,6 +42,11 @@ type ApiKeysControllerContract = {
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule.forRoot(), {
     bufferLogs: true,
+    // Without this, Nest's exception zone calls process.exit(1) when a later
+    // app.get() resolves a provider that the active profile didn't wire (e.g.
+    // McpAuthMiddleware in profile-memory, McpRateLimitMiddleware when rate
+    // limiting is off) — killing the process before tryGet's catch can run.
+    abortOnError: false,
   });
 
   app.useLogger(app.get(Logger));

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -1170,6 +1170,7 @@ export class MemoryController {
         description:
           'Rebuild the vector store from Postgres (admin/maintenance). Backfills embeddings for one user or all users; idempotent and cursor-resumable',
         inputSchema: reindexToolSchema,
+        auth: 'admin',
         handler: this.reindexMemories.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -1179,6 +1180,7 @@ export class MemoryController {
         description:
           'Queue asynchronous vector reindexing with persisted progress and resumability cursor',
         inputSchema: reindexQueueToolSchema,
+        auth: 'admin',
         handler: this.queueReindexMemories.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -1188,6 +1190,7 @@ export class MemoryController {
         description:
           'Get status and progress for a queued reindex job (queued/running/completed/failed)',
         inputSchema: reindexStatusToolSchema,
+        auth: 'admin',
         handler: this.getReindexStatus.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -1197,6 +1200,7 @@ export class MemoryController {
         description:
           'Cancel a queued/running reindex job and preserve progress cursor',
         inputSchema: reindexCancelToolSchema,
+        auth: 'admin',
         handler: this.cancelReindexJob.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -1206,6 +1210,7 @@ export class MemoryController {
         description:
           'Retry a failed/cancelled reindex job from its last persisted cursor',
         inputSchema: reindexRetryToolSchema,
+        auth: 'admin',
         handler: this.retryReindexJob.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -1215,6 +1220,7 @@ export class MemoryController {
         description:
           'Trigger a synchronous STM→LTM consolidation pass (admin). Promotes short-term memories that meet the access-count threshold into long-term storage.',
         inputSchema: consolidateToolSchema,
+        auth: 'admin',
         handler: this.consolidateMemories.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -1285,7 +1291,34 @@ export class MemoryController {
       },
     ];
 
-    return this.filterToolsByProfile(all);
+    // Make API-key/JWT scopes load-bearing: each memory tool requires the
+    // matching scope (the `admin` scope satisfies any). Read tools need
+    // `memories:read`, mutations `memories:write`, deletions `memories:delete`.
+    // Admin maintenance tools (reindex/consolidate) gate on MCP_ADMIN_TOKEN and
+    // intentionally carry no scope here. Enforced in the core dispatch only when
+    // a request is authenticated.
+    const scopeByTool: Record<string, string> = {
+      create_memory: 'memories:write',
+      update_memory: 'memories:write',
+      promote_memory: 'memories:write',
+      remember: 'memories:write',
+      ingest_conversation: 'memories:write',
+      delete_memory: 'memories:delete',
+      forget: 'memories:delete',
+      get_memory: 'memories:read',
+      list_memories: 'memories:read',
+      recall: 'memories:read',
+      reflect: 'memories:read',
+      compress_context: 'memories:read',
+      load_context: 'memories:read',
+      prompt_context: 'memories:read',
+    };
+    const scoped = all.map((tool) => {
+      const requiredScope = scopeByTool[tool.name];
+      return requiredScope ? { ...tool, requiredScope } : tool;
+    });
+
+    return this.filterToolsByProfile(scoped);
   }
 
   /**

--- a/apps/mcp-server/test/auth.e2e-spec.ts
+++ b/apps/mcp-server/test/auth.e2e-spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Auth & Multi-tenancy E2E (Epic 101)
+ *
+ * Proves the epic's Definition of Done — "a tenant can only read/write its own
+ * memories" — against real Postgres/Redis/Qdrant. Gate with E2E_ENABLED=true.
+ *
+ * Run (after `docker compose -f docker-compose.test.yml up -d --wait` + migrate):
+ *   E2E_ENABLED=true \
+ *   DATABASE_URL=postgresql://engram_test:test_password@localhost:5433/engram_test \
+ *   REDIS_URL=redis://localhost:6380 QDRANT_URL=http://localhost:6335 \
+ *   NODE_ENV=test pnpm --filter mcp-server test:e2e
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV ?? 'test';
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ??
+  'postgresql://engram_test:test_password@localhost:5433/engram_test';
+process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6380';
+process.env.QDRANT_URL = process.env.QDRANT_URL ?? 'http://localhost:6335';
+process.env.EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER ?? 'local';
+// Enable auth enforcement for this run.
+process.env.AUTH_REQUIRED = 'true';
+process.env.JWT_SECRET =
+  process.env.JWT_SECRET ?? 'e2e-jwt-secret-at-least-32-characters-long!!';
+
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Server as HttpServer } from 'node:http';
+import request from 'supertest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { registerTools, type AuthPolicy, type Tool } from '@engram/core';
+import { JwtService } from '@engram/auth';
+import { PrismaService } from '@engram/database';
+import { AppModule } from '../src/app.module';
+import { MemoryController } from '../src/memory/memory.controller';
+import { AuthResolver } from '../src/auth/auth-resolver.service';
+import { ApiKeysService } from '../src/api-keys/api-keys.service';
+
+const E2E_ENABLED = process.env.E2E_ENABLED === 'true';
+const suite = E2E_ENABLED ? describe : describe.skip;
+
+// Capture the call_tool dispatch handler the same way the MCP server registers
+// it, so we can drive real tool handlers with a crafted authInfo.
+const requestMethod = (schema: unknown): string | undefined =>
+  (
+    schema as {
+      def?: { shape?: { method?: { def?: { values?: string[] } } } };
+    }
+  )?.def?.shape?.method?.def?.values?.[0];
+
+type CallHandler = (
+  request: { params: { name: string; arguments?: unknown } },
+  extra?: { authInfo?: { scopes?: string[]; extra?: Record<string, unknown> } },
+) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+
+function captureCallHandler(tools: Tool[], policy: AuthPolicy): CallHandler {
+  const server = new Server(
+    { name: 'e2e', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+  let handler: CallHandler | undefined;
+  jest
+    .spyOn(server, 'setRequestHandler')
+    .mockImplementation((schema: unknown, fn: unknown) => {
+      if (requestMethod(schema) === 'tools/call') handler = fn as CallHandler;
+    });
+  registerTools(server, tools, policy);
+  if (!handler) throw new Error('call handler not captured');
+  return handler;
+}
+
+suite('Auth & Multi-tenancy E2E', () => {
+  let app: INestApplication;
+  let httpServer: HttpServer;
+  let prisma: PrismaService;
+  let jwt: JwtService;
+  let resolver: AuthResolver;
+  let apiKeys: ApiKeysService;
+  let callTool: CallHandler;
+  const createdUserIds: string[] = [];
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.forRoot()],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    httpServer = app.getHttpServer() as HttpServer;
+    prisma = moduleFixture.get(PrismaService);
+    jwt = moduleFixture.get(JwtService);
+    resolver = moduleFixture.get(AuthResolver);
+    apiKeys = moduleFixture.get(ApiKeysService);
+    callTool = captureCallHandler(
+      moduleFixture.get(MemoryController).getMcpTools(),
+      { required: true },
+    );
+  });
+
+  afterAll(async () => {
+    for (const id of createdUserIds) {
+      await prisma.user.delete({ where: { id } }).catch(() => undefined);
+    }
+    await app.close();
+  });
+
+  const newUser = async (label: string): Promise<string> => {
+    const user = await prisma.user.create({
+      data: { email: `auth-e2e-${label}-${Date.now()}@e2e.local` },
+    });
+    createdUserIds.push(user.id);
+    return user.id;
+  };
+
+  describe('/auth HTTP endpoints', () => {
+    it('returns the identity for a valid JWT and 401 without one', async () => {
+      const token = jwt.issue({
+        userId: 'http-user',
+        scopes: ['memories:read'],
+      });
+      await request(httpServer)
+        .get('/auth/me')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.user.userId).toBe('http-user');
+          expect(res.body.user.method).toBe('jwt');
+        });
+      await request(httpServer).get('/auth/me').expect(401);
+    });
+
+    it('404s a login for a provider that is not configured', async () => {
+      await request(httpServer).get('/auth/github/login').expect(404);
+    });
+  });
+
+  describe('API key authentication', () => {
+    it('resolves a real API key to its owner', async () => {
+      const userId = await newUser('apikey');
+      const { rawKey } = await apiKeys.createApiKey({
+        userId,
+        name: 'e2e',
+        scopes: ['memories:read', 'memories:write'],
+      });
+      const outcome = await resolver.authenticate({ 'x-api-key': rawKey });
+      expect(outcome.status).toBe('authenticated');
+      if (outcome.status === 'authenticated') {
+        expect(outcome.identity.userId).toBe(userId);
+        expect(outcome.identity.method).toBe('api-key');
+      }
+    });
+  });
+
+  describe('Tenant isolation under enforcement (DoD)', () => {
+    it('rejects an unauthenticated protected tool call', async () => {
+      const result = await callTool({
+        params: {
+          name: 'create_memory',
+          arguments: { userId: 'x', content: 'y', type: 'long-term' },
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Unauthorized');
+    });
+
+    it('rejects a write tool when the credential lacks the write scope', async () => {
+      const carol = await newUser('carol');
+      const result = await callTool(
+        {
+          params: {
+            name: 'create_memory',
+            arguments: { content: 'nope', type: 'long-term' },
+          },
+        },
+        { authInfo: { scopes: ['memories:read'], extra: { userId: carol } } },
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('scope');
+    });
+
+    it('derives userId from the token, ignoring a spoofed input userId', async () => {
+      const alice = await newUser('alice');
+      const bob = await newUser('bob');
+      const secret = 'alice private memory about project zenith';
+
+      // Authenticated as Alice (with write scope), but the input claims Bob's userId.
+      const result = await callTool(
+        {
+          params: {
+            name: 'create_memory',
+            arguments: { userId: bob, content: secret, type: 'long-term' },
+          },
+        },
+        { authInfo: { scopes: ['memories:write'], extra: { userId: alice } } },
+      );
+      expect(result.isError).toBeFalsy();
+
+      // Assert directly against Postgres (the source of truth) — independent of
+      // vector-index timing. The memory was persisted under Alice (the token),
+      // NOT Bob (the spoofed input): the token's identity is the tenant boundary.
+      const aliceCount = await prisma.memory.count({
+        where: { userId: alice, content: secret },
+      });
+      expect(aliceCount).toBeGreaterThan(0);
+
+      const bobCount = await prisma.memory.count({
+        where: { userId: bob, content: secret },
+      });
+      expect(bobCount).toBe(0);
+    });
+  });
+});

--- a/apps/mcp-server/test/jest-e2e.json
+++ b/apps/mcp-server/test/jest-e2e.json
@@ -7,6 +7,7 @@
     "^.+\\.(t|j)s$": [
       "ts-jest",
       {
+        "isolatedModules": true,
         "tsconfig": {
           "module": "commonjs",
           "moduleResolution": "node",
@@ -17,16 +18,24 @@
           "allowSyntheticDefaultImports": true,
           "target": "ES2022",
           "strictNullChecks": true,
-          "skipLibCheck": true
+          "skipLibCheck": true,
+          "isolatedModules": true,
+          "noEmit": true,
+          "rootDir": "../.."
         }
       }
     ]
   },
   "automock": false,
-  "modulePathIgnorePatterns": ["<rootDir>/src/__mocks__"],
+  "roots": ["<rootDir>/test"],
+  "modulePathIgnorePatterns": [
+    "<rootDir>/src/__mocks__",
+    "<rootDir>/dist/__mocks__"
+  ],
   "setupFiles": ["<rootDir>/node_modules/reflect-metadata/Reflect.js"],
   "moduleNameMapper": {
     "^reflect-metadata$": "<rootDir>/node_modules/reflect-metadata/Reflect.js",
+    "^@engram/redis$": "<rootDir>/../../packages/redis/dist/index.js",
     "^(\\..+)\\.js$": "$1"
   },
   "testTimeout": 30000

--- a/apps/mcp-server/test/mcp-http-transport.e2e-spec.ts
+++ b/apps/mcp-server/test/mcp-http-transport.e2e-spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration test for the real HTTP → auth-middleware → MCP transport →
+ * dispatch chain. This is the linchpin the unit tests cannot cover: it verifies
+ * that `req.auth` set by McpAuthMiddleware actually reaches the tool dispatch as
+ * `extra.authInfo` THROUGH the real StreamableHTTPServerTransport, and that the
+ * binding is PER-REQUEST (not pinned to the session at connect time) — so two
+ * requests on the same session with different credentials act as different
+ * users. Runs in-process with a stub AuthResolver; no Postgres/Redis required.
+ *
+ * Lives under test/ (e2e jest config) because it imports express; the unit jest
+ * config's broad `.js` module mapper breaks express's transitive `ipaddr.js`.
+ * It is NOT gated by E2E_ENABLED — it needs no external infrastructure.
+ */
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import express, { type Request, type Response } from 'express';
+import request, { type Test } from 'supertest';
+import { z } from 'zod';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { registerTools, type Tool } from '@engram/core';
+import { McpAuthMiddleware } from '../src/auth/mcp-auth.middleware';
+import type {
+  AuthResolver,
+  AuthOutcome,
+} from '../src/auth/auth-resolver.service';
+
+const MCP_HEADERS = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json, text/event-stream',
+};
+
+const whoami: Tool = {
+  name: 'whoami',
+  description: 'echoes the acting userId',
+  inputSchema: z.object({ userId: z.string() }).strict(),
+  handler: (input) =>
+    Promise.resolve({ actingUserId: (input as { userId: string }).userId }),
+};
+
+// Stub resolver: "Authorization: Bearer user-<id>" authenticates as that user.
+const stubResolver: AuthResolver = {
+  authenticate: (headers: Record<string, string | string[] | undefined>) => {
+    const auth = headers['authorization'];
+    const value = Array.isArray(auth) ? auth[0] : auth;
+    if (!value) return Promise.resolve<AuthOutcome>({ status: 'anonymous' });
+    const match = /^Bearer user-(.+)$/.exec(value);
+    if (!match) {
+      return Promise.resolve<AuthOutcome>({ status: 'invalid', reason: 'bad' });
+    }
+    return Promise.resolve<AuthOutcome>({
+      status: 'authenticated',
+      identity: {
+        userId: `user-${match[1]}`,
+        organizationId: null,
+        email: null,
+        scopes: ['memories:read', 'memories:write'],
+        method: 'jwt',
+        apiKeyId: null,
+      },
+    });
+  },
+} as unknown as AuthResolver;
+
+function buildApp(): express.Express {
+  const app = express();
+  const authMiddleware = new McpAuthMiddleware(stubResolver, true);
+  const transports = new Map<string, StreamableHTTPServerTransport>();
+
+  const createServer = (): Server => {
+    const server = new Server(
+      { name: 'test', version: '1.0.0' },
+      { capabilities: { tools: {} } },
+    );
+    registerTools(server, [whoami], { required: true });
+    return server;
+  };
+
+  app.post(
+    '/mcp',
+    express.json(),
+    (req, res, next) => {
+      void authMiddleware.handle(req, res, next);
+    },
+    async (req: Request, res: Response) => {
+      const sessionId = req.headers['mcp-session-id'];
+      let transport =
+        typeof sessionId === 'string' ? transports.get(sessionId) : undefined;
+
+      if (!transport) {
+        if (!isInitializeRequest(req.body)) {
+          res.status(400).json({
+            jsonrpc: '2.0',
+            error: { code: -32000, message: 'no session' },
+            id: null,
+          });
+          return;
+        }
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: (): string => randomUUID(),
+          enableJsonResponse: true,
+          onsessioninitialized: (sid): void => {
+            transports.set(sid, transport!);
+          },
+        });
+        await createServer().connect(transport);
+      }
+
+      await transport.handleRequest(
+        req as IncomingMessage & { auth?: unknown },
+        res as ServerResponse,
+        req.body,
+      );
+    },
+  );
+
+  return app;
+}
+
+async function initSession(app: express.Express): Promise<string> {
+  const res = await request(app)
+    .post('/mcp')
+    .set(MCP_HEADERS)
+    .send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test', version: '1.0.0' },
+      },
+    });
+  expect(res.status).toBe(200);
+  const sessionId = res.headers['mcp-session-id'];
+  expect(typeof sessionId).toBe('string');
+  return sessionId as string;
+}
+
+function callWhoami(
+  app: express.Express,
+  sessionId: string,
+  bearer?: string,
+): Test {
+  const req = request(app)
+    .post('/mcp')
+    .set({ ...MCP_HEADERS, 'mcp-session-id': sessionId });
+  if (bearer) req.set('Authorization', bearer);
+  return req.send({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name: 'whoami', arguments: {} },
+  });
+}
+
+function actingUserId(body: unknown): string {
+  const typed = body as { result?: { content?: Array<{ text: string }> } };
+  const text = typed.result?.content?.[0]?.text ?? '{}';
+  return (JSON.parse(text) as { actingUserId?: string }).actingUserId ?? '';
+}
+
+describe('MCP HTTP transport -> auth -> dispatch (linchpin)', () => {
+  it('forwards req.auth to the dispatch as authInfo, per request', async () => {
+    const app = buildApp();
+    const sessionId = await initSession(app);
+
+    const asAlice = await callWhoami(app, sessionId, 'Bearer user-alice');
+    expect(asAlice.status).toBe(200);
+    expect(actingUserId(asAlice.body)).toBe('user-alice');
+
+    // SAME session, DIFFERENT credential -> must act as Bob, proving auth info
+    // is bound per-request and does not stick from the first call.
+    const asBob = await callWhoami(app, sessionId, 'Bearer user-bob');
+    expect(asBob.status).toBe(200);
+    expect(actingUserId(asBob.body)).toBe('user-bob');
+  });
+
+  it('rejects an unauthenticated tool call with 401 over HTTP', async () => {
+    const app = buildApp();
+    const sessionId = await initSession(app);
+    const res = await callWhoami(app, sessionId); // no Authorization
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,40 @@
+---
+title: ENGRAM Auth Package
+description: Authentication & authorization primitives (HS256 JWT, OAuth, sessions, rate limiting) for ENGRAM
+---
+
+# @engram/auth
+
+Authentication & authorization primitives for ENGRAM. Framework-agnostic plain
+classes — the NestJS wiring, Redis adapters, and HTTP controller live in the
+host app (`apps/mcp-server/src/auth`).
+
+## What's here
+
+| Building block                                | Responsibility                                                                |
+| --------------------------------------------- | ----------------------------------------------------------------------------- |
+| `JwtService`                                  | Issue/verify HS256 JWTs (`node:crypto`, no external deps).                    |
+| `OAuthService`                                | Registry of configured OAuth providers.                                       |
+| `GitHubOAuthProvider` / `GoogleOAuthProvider` | Authorization-URL build + code→profile exchange.                              |
+| `SessionService`                              | Redis-backed sessions + one-time OAuth `state` (CSRF), over a `SessionStore`. |
+| `RateLimitService`                            | Fixed-window per-identity / per-tool limiter, over a `RateLimitStore`.        |
+
+## Design notes
+
+- **JWT is hand-rolled HS256 on `node:crypto`** rather than `jose` (ESM-only,
+  incompatible with this package's CommonJS emit) or `jsonwebtoken` (extra dep).
+  Verification never reads the algorithm from the token to choose a strategy —
+  it always computes an HMAC-SHA256 and compares in constant time — so it is
+  structurally immune to algorithm-confusion (`none`/`RS256`) attacks.
+- **Stores are interfaces.** `SessionStore` and `RateLimitStore` are implemented
+  by the host (Redis in enterprise); the package ships only the logic, so unit
+  tests run with in-memory fakes and no external services.
+- **OAuth HTTP is injected** (`OAuthHttpClient`) so token exchange and profile
+  fetches are mockable without network access. `FetchOAuthHttpClient` is the
+  default platform-`fetch` implementation.
+
+## Testing
+
+```bash
+pnpm --filter @engram/auth test
+```

--- a/packages/auth/eslint.config.mjs
+++ b/packages/auth/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { config } from '@repo/eslint-config/base';
+
+export default config;

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@engram/auth",
+  "version": "0.1.0",
+  "description": "Authentication & authorization primitives for ENGRAM: HS256 JWT, OAuth (GitHub/Google), Redis-backed sessions, and fixed-window rate limiting.",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/**/*.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "engram",
+    "auth",
+    "jwt",
+    "oauth",
+    "rate-limit",
+    "multi-tenancy"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "@nestjs/testing": "^11.1.24",
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^25.9.1",
+    "eslint": "^9.39.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  },
+  "dependencies": {
+    "@nestjs/common": "^11.1.24",
+    "reflect-metadata": "^0.2.2",
+    "tslib": "^2.8.1",
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,0 +1,54 @@
+/**
+ * @engram/auth — authentication & authorization primitives for ENGRAM.
+ *
+ * Framework-agnostic building blocks (plain classes + interfaces). The NestJS
+ * wiring, Redis store adapters, and HTTP controller live in the host app
+ * (`apps/mcp-server/src/auth`), which composes these with config and DI.
+ */
+
+export type { AuthMethod, AuthIdentity, OAuthProviderName, OAuthUserProfile } from './types.js';
+
+export {
+  JwtService,
+  JwtError,
+  type JwtErrorCode,
+  type JwtClaims,
+  type JwtIssueInput,
+  type JwtServiceOptions,
+} from './jwt/jwt.service.js';
+
+export { OAuthService } from './oauth/oauth.service.js';
+export {
+  OAuthExchangeError,
+  type OAuthProvider,
+  type OAuthProviderCredentials,
+  type AuthorizationUrlParams,
+  type ExchangeCodeParams,
+} from './oauth/oauth-provider.js';
+export { GitHubOAuthProvider } from './oauth/github.provider.js';
+export { GoogleOAuthProvider } from './oauth/google.provider.js';
+export {
+  FetchOAuthHttpClient,
+  type OAuthHttpClient,
+  type OAuthHttpResponse,
+} from './oauth/http-client.js';
+
+export {
+  SessionService,
+  type SessionData,
+  type OAuthStateData,
+  type SessionServiceOptions,
+} from './session/session.service.js';
+export { type SessionStore } from './session/session-store.js';
+
+export {
+  RateLimitService,
+  type RateLimitRule,
+  type RateLimitOptions,
+  type ConsumeParams,
+  type RateLimitResult,
+} from './ratelimit/rate-limit.service.js';
+export {
+  type RateLimitStore,
+  type RateLimitIncrementResult,
+} from './ratelimit/rate-limit-store.js';

--- a/packages/auth/src/jwt/jwt.service.spec.ts
+++ b/packages/auth/src/jwt/jwt.service.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { JwtService, JwtError } from './jwt.service.js';
+
+const SECRET = 'test-secret-must-be-at-least-32-characters-long';
+
+function b64url(input: string): string {
+  return Buffer.from(input, 'utf8').toString('base64url');
+}
+
+describe('JwtService', () => {
+  it('rejects a secret shorter than 32 characters', () => {
+    expect(() => new JwtService({ secret: 'too-short' })).toThrow(/at least 32/);
+  });
+
+  it('issues and verifies a token, preserving claims', () => {
+    const svc = new JwtService({ secret: SECRET });
+    const token = svc.issue({
+      userId: 'user-1',
+      email: 'a@b.com',
+      organizationId: 'org-9',
+      scopes: ['memories:read', 'memories:write'],
+    });
+    const claims = svc.verify(token);
+    expect(claims.sub).toBe('user-1');
+    expect(claims.email).toBe('a@b.com');
+    expect(claims.org).toBe('org-9');
+    expect(claims.scopes).toEqual(['memories:read', 'memories:write']);
+    expect(claims.iss).toBe('engram');
+    expect(claims.exp).toBeGreaterThan(claims.iat);
+    expect(claims.jti).toBeTruthy();
+  });
+
+  it('defaults optional claims to null/empty', () => {
+    const svc = new JwtService({ secret: SECRET });
+    const claims = svc.verify(svc.issue({ userId: 'user-2' }));
+    expect(claims.email).toBeNull();
+    expect(claims.org).toBeNull();
+    expect(claims.scopes).toEqual([]);
+  });
+
+  it('rejects an expired token', () => {
+    const svc = new JwtService({ secret: SECRET, expiresInSeconds: 100 });
+    const issuedAt = 1_000_000;
+    const token = svc.issue({ userId: 'user-1' }, issuedAt);
+    // verify "now" past expiry
+    expect(() => svc.verify(token, issuedAt + 101)).toThrowError(
+      expect.objectContaining({ code: 'expired' })
+    );
+    // still valid just before expiry
+    expect(svc.verify(token, issuedAt + 99).sub).toBe('user-1');
+  });
+
+  it('rejects a token issued by a different secret', () => {
+    const a = new JwtService({ secret: SECRET });
+    const b = new JwtService({ secret: 'another-secret-also-32-chars-minimum-xx' });
+    const token = a.issue({ userId: 'user-1' });
+    expect(() => b.verify(token)).toThrowError(expect.objectContaining({ code: 'signature' }));
+  });
+
+  it('rejects a token with a tampered payload', () => {
+    const svc = new JwtService({ secret: SECRET });
+    const token = svc.issue({ userId: 'user-1', scopes: ['memories:read'] });
+    const [header, payload, signature] = token.split('.');
+    const decoded = JSON.parse(Buffer.from(payload!, 'base64url').toString('utf8')) as Record<
+      string,
+      unknown
+    >;
+    decoded.scopes = ['admin'];
+    decoded.sub = 'victim';
+    const forged = `${header}.${b64url(JSON.stringify(decoded))}.${signature}`;
+    expect(() => svc.verify(forged)).toThrowError(expect.objectContaining({ code: 'signature' }));
+  });
+
+  it('rejects alg-confusion: "none" tokens', () => {
+    const svc = new JwtService({ secret: SECRET });
+    const header = b64url(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+    const payload = b64url(
+      JSON.stringify({
+        sub: 'attacker',
+        email: null,
+        org: null,
+        scopes: ['admin'],
+        iss: 'engram',
+        iat: 1,
+        exp: 9_999_999_999,
+        jti: 'x',
+      })
+    );
+    // none token with empty signature
+    expect(() => svc.verify(`${header}.${payload}.`)).toThrow(JwtError);
+    // none token with no signature segment
+    expect(() => svc.verify(`${header}.${payload}`)).toThrow(JwtError);
+  });
+
+  it('rejects a token whose header lies about the algorithm', () => {
+    const svc = new JwtService({ secret: SECRET });
+    // Attacker forges header alg=HS512 but signs the HMAC-SHA256 we would accept.
+    const header = b64url(JSON.stringify({ alg: 'HS512', typ: 'JWT' }));
+    const payload = b64url(
+      JSON.stringify({
+        sub: 'attacker',
+        email: null,
+        org: null,
+        scopes: [],
+        iss: 'engram',
+        iat: 1,
+        exp: 9_999_999_999,
+        jti: 'x',
+      })
+    );
+    const sig = createHmac('sha256', SECRET).update(`${header}.${payload}`).digest('base64url');
+    expect(() => svc.verify(`${header}.${payload}.${sig}`)).toThrowError(
+      expect.objectContaining({ code: 'malformed' })
+    );
+  });
+
+  it('rejects a token with an unexpected issuer', () => {
+    const a = new JwtService({ secret: SECRET, issuer: 'evil' });
+    const b = new JwtService({ secret: SECRET, issuer: 'engram' });
+    const token = a.issue({ userId: 'user-1' });
+    expect(() => b.verify(token)).toThrowError(expect.objectContaining({ code: 'issuer' }));
+  });
+
+  it('rejects malformed tokens', () => {
+    const svc = new JwtService({ secret: SECRET });
+    expect(() => svc.verify('')).toThrow(JwtError);
+    expect(() => svc.verify('a.b')).toThrow(JwtError);
+    expect(() => svc.verify('not-base64!.b.c')).toThrow(JwtError);
+  });
+
+  it('rejects a token issued in the future beyond clock skew', () => {
+    const svc = new JwtService({ secret: SECRET });
+    const future = 2_000_000;
+    const token = svc.issue({ userId: 'user-1' }, future);
+    expect(() => svc.verify(token, future - 3_600)).toThrowError(
+      expect.objectContaining({ code: 'not-active' })
+    );
+  });
+});

--- a/packages/auth/src/jwt/jwt.service.ts
+++ b/packages/auth/src/jwt/jwt.service.ts
@@ -1,0 +1,212 @@
+/**
+ * HS256 JSON Web Token issuer/verifier.
+ *
+ * Deliberately hand-rolled on `node:crypto` rather than pulling in `jose`:
+ *   - `jose@6` is ESM-only (no `require` export), while this package emits
+ *     CommonJS — `require('jose')` would rely on fragile Node ESM-in-CJS interop.
+ *   - It matches the existing house style (API-key hashing already uses
+ *     `node:crypto` directly).
+ *   - It is *structurally* immune to algorithm-confusion attacks: verification
+ *     never reads the algorithm from the (attacker-controlled) token to choose a
+ *     strategy. We always compute an HMAC-SHA256 and compare in constant time,
+ *     and additionally require the header to declare `alg: "HS256"`. There is no
+ *     code path that honours `none`, `RS256`, or any asymmetric algorithm.
+ */
+
+import { createHmac, timingSafeEqual, randomUUID } from 'node:crypto';
+import { z } from 'zod';
+
+const ALG = 'HS256';
+const TOKEN_TYPE = 'JWT';
+const MIN_SECRET_LENGTH = 32;
+const DEFAULT_EXPIRES_SECONDS = 7 * 24 * 60 * 60; // 7 days
+const DEFAULT_ISSUER = 'engram';
+
+/** Reasons a token can fail verification. */
+export type JwtErrorCode =
+  | 'malformed'
+  | 'signature'
+  | 'expired'
+  | 'not-active'
+  | 'issuer'
+  | 'claims';
+
+/** Typed error thrown by {@link JwtService.verify}. */
+export class JwtError extends Error {
+  constructor(
+    public readonly code: JwtErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'JwtError';
+  }
+}
+
+export interface JwtServiceOptions {
+  /** HMAC secret. Must be at least 32 characters. */
+  secret: string;
+  /** Token lifetime in seconds. Defaults to 7 days. */
+  expiresInSeconds?: number;
+  /** Expected `iss` claim. Defaults to `"engram"`. */
+  issuer?: string;
+}
+
+export interface JwtIssueInput {
+  userId: string;
+  email?: string | null;
+  organizationId?: string | null;
+  scopes?: string[];
+}
+
+/** Verified, validated JWT claims. */
+export interface JwtClaims {
+  /** Subject — the ENGRAM user id (tenant). */
+  sub: string;
+  email: string | null;
+  /** Organization id, when the user acts within an org. */
+  org: string | null;
+  scopes: string[];
+  iss: string;
+  /** Issued-at (seconds since epoch). */
+  iat: number;
+  /** Expiry (seconds since epoch). */
+  exp: number;
+  /** Unique token id (jti) — enables future revocation lists. */
+  jti: string;
+}
+
+const claimsSchema = z
+  .object({
+    sub: z.string().min(1),
+    email: z.string().nullable(),
+    org: z.string().nullable(),
+    scopes: z.array(z.string()),
+    iss: z.string().min(1),
+    iat: z.number().int(),
+    exp: z.number().int(),
+    jti: z.string().min(1),
+  })
+  .strip();
+
+function base64urlEncode(input: string): string {
+  return Buffer.from(input, 'utf8').toString('base64url');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export class JwtService {
+  private readonly secret: string;
+  private readonly expiresInSeconds: number;
+  private readonly issuer: string;
+
+  constructor(options: JwtServiceOptions) {
+    if (typeof options.secret !== 'string' || options.secret.length < MIN_SECRET_LENGTH) {
+      throw new Error(`JWT secret must be at least ${MIN_SECRET_LENGTH} characters`);
+    }
+    this.secret = options.secret;
+    this.expiresInSeconds = options.expiresInSeconds ?? DEFAULT_EXPIRES_SECONDS;
+    this.issuer = options.issuer ?? DEFAULT_ISSUER;
+  }
+
+  /** Lifetime of issued tokens, in seconds. */
+  get tokenLifetimeSeconds(): number {
+    return this.expiresInSeconds;
+  }
+
+  private sign(signingInput: string): string {
+    return createHmac('sha256', this.secret).update(signingInput).digest('base64url');
+  }
+
+  /** Issue a signed token for the given principal. */
+  issue(input: JwtIssueInput, issuedAt: number = nowSeconds()): string {
+    const header = { alg: ALG, typ: TOKEN_TYPE };
+    const claims: JwtClaims = {
+      sub: input.userId,
+      email: input.email ?? null,
+      org: input.organizationId ?? null,
+      scopes: input.scopes ?? [],
+      iss: this.issuer,
+      iat: issuedAt,
+      exp: issuedAt + this.expiresInSeconds,
+      jti: randomUUID(),
+    };
+    const headerPart = base64urlEncode(JSON.stringify(header));
+    const payloadPart = base64urlEncode(JSON.stringify(claims));
+    const signingInput = `${headerPart}.${payloadPart}`;
+    const signature = this.sign(signingInput);
+    return `${signingInput}.${signature}`;
+  }
+
+  /**
+   * Verify a token and return its claims, or throw {@link JwtError}.
+   *
+   * Validation order is signature → structure → issuer → expiry so that a
+   * tampered token never reaches claim parsing.
+   */
+  verify(token: string, atSeconds: number = nowSeconds()): JwtClaims {
+    if (typeof token !== 'string' || token.length === 0) {
+      throw new JwtError('malformed', 'Empty token');
+    }
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      throw new JwtError('malformed', 'Token must have three segments');
+    }
+    const [headerPart, payloadPart, signaturePart] = parts;
+    if (!headerPart || !payloadPart || !signaturePart) {
+      throw new JwtError('malformed', 'Token has empty segments');
+    }
+
+    // Require a declared HS256 header. We never *choose* the algorithm from the
+    // token — this check only rejects obviously wrong tokens early; the
+    // constant-time HMAC comparison below is the real guarantee.
+    let header: unknown;
+    try {
+      header = JSON.parse(Buffer.from(headerPart, 'base64url').toString('utf8'));
+    } catch {
+      throw new JwtError('malformed', 'Unparseable header');
+    }
+    if (!isRecord(header) || header.alg !== ALG || header.typ !== TOKEN_TYPE) {
+      throw new JwtError('malformed', 'Unsupported token header');
+    }
+
+    // Constant-time signature comparison.
+    const expectedSignature = this.sign(`${headerPart}.${payloadPart}`);
+    const provided = Buffer.from(signaturePart);
+    const expected = Buffer.from(expectedSignature);
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+      throw new JwtError('signature', 'Invalid signature');
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(Buffer.from(payloadPart, 'base64url').toString('utf8'));
+    } catch {
+      throw new JwtError('malformed', 'Unparseable payload');
+    }
+
+    const parsed = claimsSchema.safeParse(payload);
+    if (!parsed.success) {
+      throw new JwtError('claims', 'Invalid token claims');
+    }
+    const claims = parsed.data;
+
+    if (claims.iss !== this.issuer) {
+      throw new JwtError('issuer', 'Unexpected token issuer');
+    }
+    if (atSeconds >= claims.exp) {
+      throw new JwtError('expired', 'Token has expired');
+    }
+    if (claims.iat > atSeconds + 60) {
+      // Reject tokens issued in the future (allow 60s clock skew).
+      throw new JwtError('not-active', 'Token issued in the future');
+    }
+
+    return claims;
+  }
+}

--- a/packages/auth/src/oauth/github.provider.ts
+++ b/packages/auth/src/oauth/github.provider.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import type { OAuthUserProfile } from '../types.js';
+import type { OAuthHttpClient } from './http-client.js';
+import {
+  OAuthExchangeError,
+  type AuthorizationUrlParams,
+  type ExchangeCodeParams,
+  type OAuthProvider,
+  type OAuthProviderCredentials,
+} from './oauth-provider.js';
+
+const AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
+const TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const USER_URL = 'https://api.github.com/user';
+const EMAILS_URL = 'https://api.github.com/user/emails';
+const SCOPES = ['read:user', 'user:email'];
+// GitHub rejects API requests without a User-Agent.
+const USER_AGENT = 'engram-auth';
+
+const tokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+});
+
+const userResponseSchema = z.object({
+  id: z.number(),
+  login: z.string(),
+  name: z.string().nullish(),
+  email: z.string().nullish(),
+});
+
+const emailEntrySchema = z.object({
+  email: z.string(),
+  primary: z.boolean(),
+  verified: z.boolean(),
+});
+
+export class GitHubOAuthProvider implements OAuthProvider {
+  readonly name = 'github' as const;
+
+  constructor(
+    private readonly credentials: OAuthProviderCredentials,
+    private readonly http: OAuthHttpClient
+  ) {}
+
+  getAuthorizationUrl(params: AuthorizationUrlParams): string {
+    const query = new URLSearchParams({
+      client_id: this.credentials.clientId,
+      redirect_uri: params.redirectUri,
+      scope: SCOPES.join(' '),
+      state: params.state,
+      allow_signup: 'false',
+    });
+    return `${AUTHORIZE_URL}?${query.toString()}`;
+  }
+
+  async exchangeCodeForProfile(params: ExchangeCodeParams): Promise<OAuthUserProfile> {
+    const tokenRes = await this.http.postForm(TOKEN_URL, {
+      client_id: this.credentials.clientId,
+      client_secret: this.credentials.clientSecret,
+      code: params.code,
+      redirect_uri: params.redirectUri,
+    });
+    if (!tokenRes.ok) {
+      throw new OAuthExchangeError(this.name, `Token exchange failed (status ${tokenRes.status})`);
+    }
+    const token = tokenResponseSchema.safeParse(tokenRes.body);
+    if (!token.success) {
+      throw new OAuthExchangeError(this.name, 'No access token in response');
+    }
+
+    const authHeaders = {
+      Authorization: `Bearer ${token.data.access_token}`,
+      'User-Agent': USER_AGENT,
+      Accept: 'application/vnd.github+json',
+    };
+
+    const userRes = await this.http.getJson(USER_URL, authHeaders);
+    if (!userRes.ok) {
+      throw new OAuthExchangeError(this.name, `Profile fetch failed (status ${userRes.status})`);
+    }
+    const user = userResponseSchema.safeParse(userRes.body);
+    if (!user.success) {
+      throw new OAuthExchangeError(this.name, 'Unexpected profile shape');
+    }
+
+    const email = await this.resolveEmail(user.data.email ?? null, authHeaders);
+    if (!email) {
+      throw new OAuthExchangeError(this.name, 'No verified primary email available');
+    }
+
+    return {
+      provider: this.name,
+      providerAccountId: String(user.data.id),
+      email,
+      name: user.data.name ?? user.data.login,
+    };
+  }
+
+  /**
+   * GitHub omits the email from `/user` when it is private. Fall back to the
+   * `/user/emails` endpoint and pick the primary, verified address.
+   */
+  private async resolveEmail(
+    publicEmail: string | null,
+    headers: Record<string, string>
+  ): Promise<string | null> {
+    if (publicEmail) {
+      return publicEmail;
+    }
+    const res = await this.http.getJson(EMAILS_URL, headers);
+    if (!res.ok) {
+      return null;
+    }
+    const parsed = z.array(emailEntrySchema).safeParse(res.body);
+    if (!parsed.success) {
+      return null;
+    }
+    const primary = parsed.data.find((e) => e.primary && e.verified);
+    if (primary) {
+      return primary.email;
+    }
+    const anyVerified = parsed.data.find((e) => e.verified);
+    return anyVerified ? anyVerified.email : null;
+  }
+}

--- a/packages/auth/src/oauth/google.provider.ts
+++ b/packages/auth/src/oauth/google.provider.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+import type { OAuthUserProfile } from '../types.js';
+import type { OAuthHttpClient } from './http-client.js';
+import {
+  OAuthExchangeError,
+  type AuthorizationUrlParams,
+  type ExchangeCodeParams,
+  type OAuthProvider,
+  type OAuthProviderCredentials,
+} from './oauth-provider.js';
+
+const AUTHORIZE_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+const SCOPES = ['openid', 'email', 'profile'];
+
+const tokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+});
+
+const userInfoSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  verified_email: z.boolean().nullish(),
+  name: z.string().nullish(),
+});
+
+export class GoogleOAuthProvider implements OAuthProvider {
+  readonly name = 'google' as const;
+
+  constructor(
+    private readonly credentials: OAuthProviderCredentials,
+    private readonly http: OAuthHttpClient
+  ) {}
+
+  getAuthorizationUrl(params: AuthorizationUrlParams): string {
+    const query = new URLSearchParams({
+      client_id: this.credentials.clientId,
+      redirect_uri: params.redirectUri,
+      response_type: 'code',
+      scope: SCOPES.join(' '),
+      state: params.state,
+      access_type: 'online',
+      prompt: 'select_account',
+    });
+    return `${AUTHORIZE_URL}?${query.toString()}`;
+  }
+
+  async exchangeCodeForProfile(params: ExchangeCodeParams): Promise<OAuthUserProfile> {
+    const tokenRes = await this.http.postForm(TOKEN_URL, {
+      client_id: this.credentials.clientId,
+      client_secret: this.credentials.clientSecret,
+      code: params.code,
+      redirect_uri: params.redirectUri,
+      grant_type: 'authorization_code',
+    });
+    if (!tokenRes.ok) {
+      throw new OAuthExchangeError(this.name, `Token exchange failed (status ${tokenRes.status})`);
+    }
+    const token = tokenResponseSchema.safeParse(tokenRes.body);
+    if (!token.success) {
+      throw new OAuthExchangeError(this.name, 'No access token in response');
+    }
+
+    const userRes = await this.http.getJson(USERINFO_URL, {
+      Authorization: `Bearer ${token.data.access_token}`,
+    });
+    if (!userRes.ok) {
+      throw new OAuthExchangeError(this.name, `Profile fetch failed (status ${userRes.status})`);
+    }
+    const user = userInfoSchema.safeParse(userRes.body);
+    if (!user.success) {
+      throw new OAuthExchangeError(this.name, 'Unexpected profile shape');
+    }
+    if (user.data.verified_email === false) {
+      throw new OAuthExchangeError(this.name, 'Google email is not verified');
+    }
+
+    return {
+      provider: this.name,
+      providerAccountId: user.data.id,
+      email: user.data.email,
+      name: user.data.name ?? null,
+    };
+  }
+}

--- a/packages/auth/src/oauth/http-client.ts
+++ b/packages/auth/src/oauth/http-client.ts
@@ -1,0 +1,75 @@
+/**
+ * Minimal HTTP client abstraction for OAuth flows.
+ *
+ * OAuth providers depend on this interface (not on `fetch` directly) so that
+ * token exchange and profile fetches are trivially mockable in unit tests
+ * without spinning up a server or stubbing globals. The default
+ * {@link FetchOAuthHttpClient} is a thin wrapper over the platform `fetch`
+ * (Node 18+ ships it globally).
+ */
+
+export interface OAuthHttpResponse {
+  status: number;
+  ok: boolean;
+  body: unknown;
+}
+
+export interface OAuthHttpClient {
+  /** POST an `application/x-www-form-urlencoded` body and parse JSON back. */
+  postForm(
+    url: string,
+    form: Record<string, string>,
+    headers?: Record<string, string>
+  ): Promise<OAuthHttpResponse>;
+
+  /** GET a JSON resource. */
+  getJson(url: string, headers?: Record<string, string>): Promise<OAuthHttpResponse>;
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.length === 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    // Some providers (e.g. GitHub with the wrong Accept header) return
+    // form-encoded bodies. Surface the raw text so callers can decide.
+    return text;
+  }
+}
+
+export class FetchOAuthHttpClient implements OAuthHttpClient {
+  async postForm(
+    url: string,
+    form: Record<string, string>,
+    headers: Record<string, string> = {}
+  ): Promise<OAuthHttpResponse> {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        ...headers,
+      },
+      body: new URLSearchParams(form).toString(),
+    });
+    return {
+      status: response.status,
+      ok: response.ok,
+      body: await parseBody(response),
+    };
+  }
+
+  async getJson(url: string, headers: Record<string, string> = {}): Promise<OAuthHttpResponse> {
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json', ...headers },
+    });
+    return {
+      status: response.status,
+      ok: response.ok,
+      body: await parseBody(response),
+    };
+  }
+}

--- a/packages/auth/src/oauth/oauth-provider.ts
+++ b/packages/auth/src/oauth/oauth-provider.ts
@@ -1,0 +1,44 @@
+import type { OAuthProviderName, OAuthUserProfile } from '../types.js';
+
+/** Parameters for building a provider authorization-redirect URL. */
+export interface AuthorizationUrlParams {
+  /** Opaque CSRF token; echoed back on the callback and verified one-time. */
+  state: string;
+  /** Absolute callback URL registered with the provider. */
+  redirectUri: string;
+}
+
+/** Parameters for exchanging an authorization code for a user profile. */
+export interface ExchangeCodeParams {
+  code: string;
+  redirectUri: string;
+}
+
+/** OAuth credentials for a single provider. */
+export interface OAuthProviderCredentials {
+  clientId: string;
+  clientSecret: string;
+}
+
+/**
+ * An OAuth 2.0 authorization-code provider that can build a login redirect and
+ * turn a returned `code` into a normalised {@link OAuthUserProfile}.
+ */
+export interface OAuthProvider {
+  readonly name: OAuthProviderName;
+  /** Build the URL to redirect the user-agent to for consent. */
+  getAuthorizationUrl(params: AuthorizationUrlParams): string;
+  /** Exchange an authorization code for the authenticated user's profile. */
+  exchangeCodeForProfile(params: ExchangeCodeParams): Promise<OAuthUserProfile>;
+}
+
+/** Raised when a provider exchange fails (network, bad code, missing email). */
+export class OAuthExchangeError extends Error {
+  constructor(
+    public readonly provider: OAuthProviderName,
+    message: string
+  ) {
+    super(message);
+    this.name = 'OAuthExchangeError';
+  }
+}

--- a/packages/auth/src/oauth/oauth.service.ts
+++ b/packages/auth/src/oauth/oauth.service.ts
@@ -1,0 +1,32 @@
+import type { OAuthProviderName } from '../types.js';
+import type { OAuthProvider } from './oauth-provider.js';
+
+/**
+ * Registry of configured OAuth providers. A provider only appears here when its
+ * client id/secret are configured, so {@link isEnabled} doubles as a
+ * "is this login method available?" check.
+ */
+export class OAuthService {
+  private readonly providers: Map<OAuthProviderName, OAuthProvider>;
+
+  constructor(providers: OAuthProvider[]) {
+    this.providers = new Map(providers.map((p) => [p.name, p]));
+  }
+
+  isEnabled(name: OAuthProviderName): boolean {
+    return this.providers.has(name);
+  }
+
+  listEnabled(): OAuthProviderName[] {
+    return [...this.providers.keys()];
+  }
+
+  /** Look up a configured provider, or throw if it is not enabled. */
+  getProvider(name: OAuthProviderName): OAuthProvider {
+    const provider = this.providers.get(name);
+    if (!provider) {
+      throw new Error(`OAuth provider "${name}" is not configured`);
+    }
+    return provider;
+  }
+}

--- a/packages/auth/src/oauth/oauth.spec.ts
+++ b/packages/auth/src/oauth/oauth.spec.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import type { OAuthHttpClient, OAuthHttpResponse } from './http-client.js';
+import { GitHubOAuthProvider } from './github.provider.js';
+import { GoogleOAuthProvider } from './google.provider.js';
+import { OAuthService } from './oauth.service.js';
+import { OAuthExchangeError } from './oauth-provider.js';
+
+type Route = { match: (url: string) => boolean; response: OAuthHttpResponse };
+
+/** Fake HTTP client that matches requests to canned responses by URL substring. */
+class FakeHttpClient implements OAuthHttpClient {
+  public postCalls: Array<{ url: string; form: Record<string, string> }> = [];
+  public getCalls: Array<{ url: string; headers?: Record<string, string> }> = [];
+
+  constructor(
+    private readonly posts: Route[],
+    private readonly gets: Route[]
+  ) {}
+
+  async postForm(url: string, form: Record<string, string>): Promise<OAuthHttpResponse> {
+    this.postCalls.push({ url, form });
+    const route = this.posts.find((r) => r.match(url));
+    return route ? route.response : notFound();
+  }
+
+  async getJson(url: string, headers?: Record<string, string>): Promise<OAuthHttpResponse> {
+    this.getCalls.push({ url, headers });
+    const route = this.gets.find((r) => r.match(url));
+    return route ? route.response : notFound();
+  }
+}
+
+function ok(body: unknown): OAuthHttpResponse {
+  return { status: 200, ok: true, body };
+}
+function notFound(): OAuthHttpResponse {
+  return { status: 404, ok: false, body: null };
+}
+
+const CREDS = { clientId: 'cid', clientSecret: 'secret' };
+
+describe('GitHubOAuthProvider', () => {
+  it('builds an authorization URL with state and scopes', () => {
+    const provider = new GitHubOAuthProvider(CREDS, new FakeHttpClient([], []));
+    const url = new URL(
+      provider.getAuthorizationUrl({
+        state: 'state-123',
+        redirectUri: 'https://app/cb',
+      })
+    );
+    expect(url.origin + url.pathname).toBe('https://github.com/login/oauth/authorize');
+    expect(url.searchParams.get('client_id')).toBe('cid');
+    expect(url.searchParams.get('state')).toBe('state-123');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://app/cb');
+    expect(url.searchParams.get('scope')).toContain('user:email');
+  });
+
+  it('exchanges a code and returns a normalised profile', async () => {
+    const http = new FakeHttpClient(
+      [
+        {
+          match: (u): boolean => u.includes('access_token'),
+          response: ok({ access_token: 'tok' }),
+        },
+      ],
+      [
+        {
+          match: (u): boolean => u.endsWith('/user'),
+          response: ok({ id: 42, login: 'octocat', name: 'Octo', email: 'octo@gh.com' }),
+        },
+      ]
+    );
+    const provider = new GitHubOAuthProvider(CREDS, http);
+    const profile = await provider.exchangeCodeForProfile({
+      code: 'abc',
+      redirectUri: 'https://app/cb',
+    });
+    expect(profile).toEqual({
+      provider: 'github',
+      providerAccountId: '42',
+      email: 'octo@gh.com',
+      name: 'Octo',
+    });
+    // Sent a User-Agent (GitHub rejects requests without one).
+    expect(http.getCalls[0]?.headers?.['User-Agent']).toBeTruthy();
+  });
+
+  it('falls back to /user/emails when the profile email is private', async () => {
+    const http = new FakeHttpClient(
+      [
+        {
+          match: (u): boolean => u.includes('access_token'),
+          response: ok({ access_token: 'tok' }),
+        },
+      ],
+      [
+        {
+          match: (u): boolean => u.endsWith('/user'),
+          response: ok({ id: 7, login: 'priv', name: null, email: null }),
+        },
+        {
+          match: (u): boolean => u.endsWith('/user/emails'),
+          response: ok([
+            { email: 'secondary@gh.com', primary: false, verified: true },
+            { email: 'primary@gh.com', primary: true, verified: true },
+          ]),
+        },
+      ]
+    );
+    const provider = new GitHubOAuthProvider(CREDS, http);
+    const profile = await provider.exchangeCodeForProfile({
+      code: 'abc',
+      redirectUri: 'https://app/cb',
+    });
+    expect(profile.email).toBe('primary@gh.com');
+    expect(profile.name).toBe('priv'); // falls back to login when name is null
+  });
+
+  it('throws when no verified email can be resolved', async () => {
+    const http = new FakeHttpClient(
+      [
+        {
+          match: (u): boolean => u.includes('access_token'),
+          response: ok({ access_token: 'tok' }),
+        },
+      ],
+      [
+        {
+          match: (u): boolean => u.endsWith('/user'),
+          response: ok({ id: 7, login: 'priv', name: null, email: null }),
+        },
+        {
+          match: (u): boolean => u.endsWith('/user/emails'),
+          response: ok([{ email: 'x@gh.com', primary: true, verified: false }]),
+        },
+      ]
+    );
+    const provider = new GitHubOAuthProvider(CREDS, http);
+    await expect(
+      provider.exchangeCodeForProfile({ code: 'abc', redirectUri: 'https://app/cb' })
+    ).rejects.toBeInstanceOf(OAuthExchangeError);
+  });
+
+  it('throws when the token exchange fails', async () => {
+    const http = new FakeHttpClient(
+      [
+        {
+          match: (): boolean => true,
+          response: { status: 401, ok: false, body: { error: 'bad_verification_code' } },
+        },
+      ],
+      []
+    );
+    const provider = new GitHubOAuthProvider(CREDS, http);
+    await expect(
+      provider.exchangeCodeForProfile({ code: 'bad', redirectUri: 'https://app/cb' })
+    ).rejects.toBeInstanceOf(OAuthExchangeError);
+  });
+});
+
+describe('GoogleOAuthProvider', () => {
+  it('builds an authorization URL', () => {
+    const provider = new GoogleOAuthProvider(CREDS, new FakeHttpClient([], []));
+    const url = new URL(
+      provider.getAuthorizationUrl({ state: 's', redirectUri: 'https://app/cb' })
+    );
+    expect(url.origin + url.pathname).toBe('https://accounts.google.com/o/oauth2/v2/auth');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('scope')).toContain('email');
+  });
+
+  it('exchanges a code and returns a normalised profile', async () => {
+    const http = new FakeHttpClient(
+      [{ match: (u): boolean => u.includes('token'), response: ok({ access_token: 'tok' }) }],
+      [
+        {
+          match: (u): boolean => u.includes('userinfo'),
+          response: ok({ id: 'g-1', email: 'u@gmail.com', verified_email: true, name: 'Goo' }),
+        },
+      ]
+    );
+    const provider = new GoogleOAuthProvider(CREDS, http);
+    const profile = await provider.exchangeCodeForProfile({
+      code: 'abc',
+      redirectUri: 'https://app/cb',
+    });
+    expect(profile).toEqual({
+      provider: 'google',
+      providerAccountId: 'g-1',
+      email: 'u@gmail.com',
+      name: 'Goo',
+    });
+  });
+
+  it('rejects an unverified Google email', async () => {
+    const http = new FakeHttpClient(
+      [{ match: (u): boolean => u.includes('token'), response: ok({ access_token: 'tok' }) }],
+      [
+        {
+          match: (u): boolean => u.includes('userinfo'),
+          response: ok({ id: 'g-1', email: 'u@gmail.com', verified_email: false }),
+        },
+      ]
+    );
+    const provider = new GoogleOAuthProvider(CREDS, http);
+    await expect(
+      provider.exchangeCodeForProfile({ code: 'abc', redirectUri: 'https://app/cb' })
+    ).rejects.toBeInstanceOf(OAuthExchangeError);
+  });
+});
+
+describe('OAuthService', () => {
+  it('reports which providers are enabled', () => {
+    const http = new FakeHttpClient([], []);
+    const svc = new OAuthService([new GitHubOAuthProvider(CREDS, http)]);
+    expect(svc.isEnabled('github')).toBe(true);
+    expect(svc.isEnabled('google')).toBe(false);
+    expect(svc.listEnabled()).toEqual(['github']);
+    expect(svc.getProvider('github').name).toBe('github');
+    expect(() => svc.getProvider('google')).toThrow(/not configured/);
+  });
+});

--- a/packages/auth/src/ratelimit/rate-limit-store.ts
+++ b/packages/auth/src/ratelimit/rate-limit-store.ts
@@ -1,0 +1,22 @@
+/**
+ * Counter store backing the fixed-window rate limiter.
+ *
+ * The package defines the interface; the host application provides a Redis
+ * implementation (atomic `INCR` + first-hit `EXPIRE`). Unit tests use an
+ * in-memory fake driven by an injectable clock.
+ */
+export interface RateLimitIncrementResult {
+  /** Counter value *after* this increment (1 on the first hit of a window). */
+  count: number;
+  /** Seconds remaining until the window — and therefore the counter — resets. */
+  ttlSeconds: number;
+}
+
+export interface RateLimitStore {
+  /**
+   * Atomically increment the counter at `key`. The window TTL must be applied
+   * on the first increment (when the counter becomes 1) and left untouched
+   * thereafter, giving a fixed window anchored at the first request.
+   */
+  increment(key: string, windowSeconds: number): Promise<RateLimitIncrementResult>;
+}

--- a/packages/auth/src/ratelimit/rate-limit.service.spec.ts
+++ b/packages/auth/src/ratelimit/rate-limit.service.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import type { RateLimitStore, RateLimitIncrementResult } from './rate-limit-store.js';
+import { RateLimitService } from './rate-limit.service.js';
+
+/**
+ * In-memory fixed-window store with a manual clock so we can advance time and
+ * observe window resets deterministically.
+ */
+class FakeStore implements RateLimitStore {
+  private counters = new Map<string, { count: number; expiresAt: number }>();
+  constructor(public now = 0) {}
+
+  advance(seconds: number): void {
+    this.now += seconds;
+  }
+
+  async increment(key: string, windowSeconds: number): Promise<RateLimitIncrementResult> {
+    const existing = this.counters.get(key);
+    if (!existing || existing.expiresAt <= this.now) {
+      this.counters.set(key, { count: 1, expiresAt: this.now + windowSeconds });
+      return { count: 1, ttlSeconds: windowSeconds };
+    }
+    existing.count += 1;
+    return { count: existing.count, ttlSeconds: existing.expiresAt - this.now };
+  }
+}
+
+describe('RateLimitService', () => {
+  it('allows requests up to the limit, then blocks', async () => {
+    const store = new FakeStore();
+    const svc = new RateLimitService(store, {
+      defaultRule: { limit: 3, windowSeconds: 60 },
+    });
+
+    const r1 = await svc.consume({ key: 'user-1' });
+    expect(r1).toMatchObject({ allowed: true, limit: 3, remaining: 2 });
+    const r2 = await svc.consume({ key: 'user-1' });
+    expect(r2).toMatchObject({ allowed: true, remaining: 1 });
+    const r3 = await svc.consume({ key: 'user-1' });
+    expect(r3).toMatchObject({ allowed: true, remaining: 0 });
+
+    const r4 = await svc.consume({ key: 'user-1' });
+    expect(r4.allowed).toBe(false);
+    expect(r4.remaining).toBe(0);
+    expect(r4.retryAfterSeconds).toBeGreaterThan(0);
+    expect(r4.retryAfterSeconds).toBeLessThanOrEqual(60);
+  });
+
+  it('resets after the window elapses', async () => {
+    const store = new FakeStore();
+    const svc = new RateLimitService(store, {
+      defaultRule: { limit: 1, windowSeconds: 60 },
+    });
+    expect((await svc.consume({ key: 'u' })).allowed).toBe(true);
+    expect((await svc.consume({ key: 'u' })).allowed).toBe(false);
+
+    store.advance(61);
+    const afterReset = await svc.consume({ key: 'u' });
+    expect(afterReset.allowed).toBe(true);
+    expect(afterReset.remaining).toBe(0);
+  });
+
+  it('keeps separate buckets per identity', async () => {
+    const store = new FakeStore();
+    const svc = new RateLimitService(store, {
+      defaultRule: { limit: 1, windowSeconds: 60 },
+    });
+    expect((await svc.consume({ key: 'a' })).allowed).toBe(true);
+    // Different identity is unaffected.
+    expect((await svc.consume({ key: 'b' })).allowed).toBe(true);
+    // First identity is now blocked.
+    expect((await svc.consume({ key: 'a' })).allowed).toBe(false);
+  });
+
+  it('meters overridden tools against a separate, stricter bucket', async () => {
+    const store = new FakeStore();
+    const svc = new RateLimitService(store, {
+      defaultRule: { limit: 100, windowSeconds: 60 },
+      toolOverrides: { reindex_memories: { limit: 1, windowSeconds: 60 } },
+    });
+
+    // The override bucket is independent of the default bucket.
+    expect((await svc.consume({ key: 'u', tool: 'reindex_memories' })).allowed).toBe(true);
+    expect((await svc.consume({ key: 'u', tool: 'reindex_memories' })).allowed).toBe(false);
+
+    // A non-overridden tool for the same identity still uses the generous default.
+    expect((await svc.consume({ key: 'u', tool: 'recall' })).allowed).toBe(true);
+  });
+
+  it('never reports negative remaining', async () => {
+    const store = new FakeStore();
+    const svc = new RateLimitService(store, {
+      defaultRule: { limit: 1, windowSeconds: 30 },
+    });
+    await svc.consume({ key: 'u' });
+    await svc.consume({ key: 'u' });
+    const blocked = await svc.consume({ key: 'u' });
+    expect(blocked.remaining).toBe(0);
+  });
+});

--- a/packages/auth/src/ratelimit/rate-limit.service.ts
+++ b/packages/auth/src/ratelimit/rate-limit.service.ts
@@ -1,0 +1,83 @@
+import type { RateLimitStore } from './rate-limit-store.js';
+
+/** A single rate-limit rule: at most `limit` requests per `windowSeconds`. */
+export interface RateLimitRule {
+  limit: number;
+  windowSeconds: number;
+}
+
+export interface RateLimitOptions {
+  /** Applied to every request that has no matching per-tool override. */
+  defaultRule: RateLimitRule;
+  /**
+   * Optional stricter rules for specific MCP tools (e.g. `reindex_memories`).
+   * A request to an overridden tool is metered against its *own* counter and
+   * rule, separate from the default identity bucket.
+   */
+  toolOverrides?: Record<string, RateLimitRule>;
+}
+
+export interface ConsumeParams {
+  /** Stable identity for the caller: api-key id, user id, or client IP. */
+  key: string;
+  /** MCP tool being invoked, when known (enables per-tool overrides). */
+  tool?: string;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  /** Requests left in the current window (never negative). */
+  remaining: number;
+  /** Seconds until the window resets. */
+  resetSeconds: number;
+  /** Seconds the caller should wait before retrying (0 when allowed). */
+  retryAfterSeconds: number;
+}
+
+const KEY_PREFIX = 'ratelimit:';
+
+/**
+ * Fixed-window rate limiter. The window is anchored at the first request in
+ * each window (the store applies the TTL on the first increment), so a key that
+ * goes quiet naturally resets when its TTL elapses.
+ */
+export class RateLimitService {
+  private readonly defaultRule: RateLimitRule;
+  private readonly toolOverrides: Record<string, RateLimitRule>;
+
+  constructor(
+    private readonly store: RateLimitStore,
+    options: RateLimitOptions
+  ) {
+    this.defaultRule = options.defaultRule;
+    this.toolOverrides = options.toolOverrides ?? {};
+  }
+
+  async consume(params: ConsumeParams): Promise<RateLimitResult> {
+    const override = params.tool != null ? this.toolOverrides[params.tool] : undefined;
+    const rule = override ?? this.defaultRule;
+
+    // Overridden tools get a dedicated counter so their stricter budget is
+    // tracked separately from the caller's general request budget.
+    const redisKey = override
+      ? `${KEY_PREFIX}${params.key}:tool:${params.tool}`
+      : `${KEY_PREFIX}${params.key}`;
+
+    const { count, ttlSeconds } = await this.store.increment(redisKey, rule.windowSeconds);
+
+    const allowed = count <= rule.limit;
+    const remaining = Math.max(0, rule.limit - count);
+    // Guard against a missing TTL (e.g. key with no expiry): fall back to the
+    // full window so Retry-After is never negative or zero-on-block.
+    const resetSeconds = ttlSeconds > 0 ? ttlSeconds : rule.windowSeconds;
+
+    return {
+      allowed,
+      limit: rule.limit,
+      remaining,
+      resetSeconds,
+      retryAfterSeconds: allowed ? 0 : resetSeconds,
+    };
+  }
+}

--- a/packages/auth/src/session/session-store.ts
+++ b/packages/auth/src/session/session-store.ts
@@ -1,0 +1,17 @@
+/**
+ * Key/value store backing sessions and one-time OAuth state.
+ *
+ * The package defines only the interface; the host application provides a
+ * concrete implementation (Redis in enterprise). Unit tests use an in-memory
+ * fake. Every write carries an explicit TTL so entries cannot leak.
+ */
+export interface SessionStore {
+  set(key: string, value: string, ttlSeconds: number): Promise<void>;
+  get(key: string): Promise<string | null>;
+  delete(key: string): Promise<void>;
+  /**
+   * Atomically read a key and delete it, returning the prior value (or null).
+   * Used for one-time OAuth `state` so a callback cannot be replayed.
+   */
+  getDelete(key: string): Promise<string | null>;
+}

--- a/packages/auth/src/session/session.service.spec.ts
+++ b/packages/auth/src/session/session.service.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import type { SessionStore } from './session-store.js';
+import { SessionService } from './session.service.js';
+
+/** In-memory SessionStore with no TTL expiry (sufficient for lifecycle tests). */
+class FakeStore implements SessionStore {
+  public map = new Map<string, string>();
+  public ttls = new Map<string, number>();
+
+  async set(key: string, value: string, ttlSeconds: number): Promise<void> {
+    this.map.set(key, value);
+    this.ttls.set(key, ttlSeconds);
+  }
+  async get(key: string): Promise<string | null> {
+    return this.map.get(key) ?? null;
+  }
+  async delete(key: string): Promise<void> {
+    this.map.delete(key);
+  }
+  async getDelete(key: string): Promise<string | null> {
+    const v = this.map.get(key) ?? null;
+    this.map.delete(key);
+    return v;
+  }
+}
+
+describe('SessionService', () => {
+  it('creates, reads, and destroys a session', async () => {
+    const store = new FakeStore();
+    const svc = new SessionService(store);
+    const sessionId = await svc.createSession({
+      userId: 'user-1',
+      organizationId: 'org-1',
+      email: 'a@b.com',
+      scopes: ['memories:read'],
+    });
+    expect(sessionId).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const data = await svc.getSession(sessionId);
+    expect(data?.userId).toBe('user-1');
+    expect(data?.organizationId).toBe('org-1');
+    expect(data?.scopes).toEqual(['memories:read']);
+    expect(typeof data?.createdAt).toBe('number');
+
+    await svc.destroySession(sessionId);
+    expect(await svc.getSession(sessionId)).toBeNull();
+  });
+
+  it('applies the configured session TTL', async () => {
+    const store = new FakeStore();
+    const svc = new SessionService(store, { sessionTtlSeconds: 42 });
+    const id = await svc.createSession({
+      userId: 'u',
+      organizationId: null,
+      email: null,
+      scopes: [],
+    });
+    const key = [...store.ttls.keys()].find((k) => k.includes(id));
+    expect(store.ttls.get(key!)).toBe(42);
+  });
+
+  it('returns null for unknown or malformed sessions', async () => {
+    const store = new FakeStore();
+    const svc = new SessionService(store);
+    expect(await svc.getSession('nope')).toBeNull();
+    expect(await svc.getSession('')).toBeNull();
+    await store.set('auth:session:bad', 'not-json', 60);
+    expect(await svc.getSession('bad')).toBeNull();
+  });
+
+  it('issues one-time OAuth state that cannot be replayed', async () => {
+    const store = new FakeStore();
+    const svc = new SessionService(store);
+    const state = await svc.createOAuthState('github');
+
+    const first = await svc.consumeOAuthState(state);
+    expect(first?.provider).toBe('github');
+
+    // Replaying the same state returns null (already consumed).
+    const second = await svc.consumeOAuthState(state);
+    expect(second).toBeNull();
+  });
+
+  it('returns null when consuming unknown state', async () => {
+    const svc = new SessionService(new FakeStore());
+    expect(await svc.consumeOAuthState('unknown')).toBeNull();
+    expect(await svc.consumeOAuthState('')).toBeNull();
+  });
+});

--- a/packages/auth/src/session/session.service.ts
+++ b/packages/auth/src/session/session.service.ts
@@ -1,0 +1,131 @@
+import { randomBytes } from 'node:crypto';
+import { z } from 'zod';
+import type { SessionStore } from './session-store.js';
+
+const SESSION_PREFIX = 'auth:session:';
+const STATE_PREFIX = 'auth:oauthstate:';
+const DEFAULT_SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+const DEFAULT_STATE_TTL_SECONDS = 10 * 60; // 10 minutes
+const ID_BYTES = 32;
+
+export interface SessionData {
+  userId: string;
+  organizationId: string | null;
+  email: string | null;
+  scopes: string[];
+  createdAt: number;
+}
+
+const sessionSchema = z
+  .object({
+    userId: z.string().min(1),
+    organizationId: z.string().nullable(),
+    email: z.string().nullable(),
+    scopes: z.array(z.string()),
+    createdAt: z.number().int(),
+  })
+  .strip();
+
+/** Payload bound to an in-flight OAuth login, recovered on the callback. */
+export interface OAuthStateData {
+  provider: string;
+  createdAt: number;
+}
+
+const stateSchema = z
+  .object({
+    provider: z.string().min(1),
+    createdAt: z.number().int(),
+  })
+  .strip();
+
+export interface SessionServiceOptions {
+  sessionTtlSeconds?: number;
+  stateTtlSeconds?: number;
+}
+
+function newId(): string {
+  return randomBytes(ID_BYTES).toString('base64url');
+}
+
+/**
+ * Manages interactive user sessions and one-time OAuth `state` tokens on top of
+ * a {@link SessionStore}. Session ids and state tokens are 256-bit random,
+ * base64url-encoded values.
+ */
+export class SessionService {
+  private readonly sessionTtl: number;
+  private readonly stateTtl: number;
+
+  constructor(
+    private readonly store: SessionStore,
+    options: SessionServiceOptions = {}
+  ) {
+    this.sessionTtl = options.sessionTtlSeconds ?? DEFAULT_SESSION_TTL_SECONDS;
+    this.stateTtl = options.stateTtlSeconds ?? DEFAULT_STATE_TTL_SECONDS;
+  }
+
+  async createSession(
+    data: Omit<SessionData, 'createdAt'>,
+    createdAt: number = Math.floor(Date.now() / 1000)
+  ): Promise<string> {
+    const sessionId = newId();
+    const payload: SessionData = { ...data, createdAt };
+    await this.store.set(SESSION_PREFIX + sessionId, JSON.stringify(payload), this.sessionTtl);
+    return sessionId;
+  }
+
+  async getSession(sessionId: string): Promise<SessionData | null> {
+    if (!sessionId) {
+      return null;
+    }
+    const raw = await this.store.get(SESSION_PREFIX + sessionId);
+    if (!raw) {
+      return null;
+    }
+    const parsed = sessionSchema.safeParse(safeJsonParse(raw));
+    return parsed.success ? parsed.data : null;
+  }
+
+  async destroySession(sessionId: string): Promise<void> {
+    if (!sessionId) {
+      return;
+    }
+    await this.store.delete(SESSION_PREFIX + sessionId);
+  }
+
+  /** Mint a one-time CSRF `state` token bound to the chosen provider. */
+  async createOAuthState(
+    provider: string,
+    createdAt: number = Math.floor(Date.now() / 1000)
+  ): Promise<string> {
+    const state = newId();
+    const payload: OAuthStateData = { provider, createdAt };
+    await this.store.set(STATE_PREFIX + state, JSON.stringify(payload), this.stateTtl);
+    return state;
+  }
+
+  /**
+   * Consume an OAuth `state` token. Returns its payload and atomically removes
+   * it so the callback cannot be replayed; returns null if unknown/expired.
+   */
+  async consumeOAuthState(state: string): Promise<OAuthStateData | null> {
+    if (!state) {
+      return null;
+    }
+    const raw = await this.store.getDelete(STATE_PREFIX + state);
+    if (!raw) {
+      return null;
+    }
+    const parsed = stateSchema.safeParse(safeJsonParse(raw));
+    return parsed.success ? parsed.data : null;
+  }
+}
+
+function safeJsonParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared authentication types for ENGRAM.
+ *
+ * These describe an authenticated principal independent of *how* it was
+ * authenticated (interactive JWT session vs. programmatic API key). The
+ * resolved {@link AuthIdentity} is what the MCP request pipeline trusts when
+ * deriving the acting tenant — never the `userId` supplied in tool input.
+ */
+
+/** How a principal proved its identity on a request. */
+export type AuthMethod = 'jwt' | 'api-key';
+
+/**
+ * A resolved, trusted principal for a single request.
+ *
+ * `userId` is the tenant boundary: all memory operations are scoped to it.
+ * `organizationId` enables org-level scoping/quotas when present.
+ */
+export interface AuthIdentity {
+  userId: string;
+  organizationId: string | null;
+  email: string | null;
+  scopes: string[];
+  method: AuthMethod;
+  /**
+   * The API key id when authenticated via a key, else null. Lets rate limiting
+   * meter per-key (not just per-user) so two keys for one user have independent
+   * budgets.
+   */
+  apiKeyId: string | null;
+}
+
+/** OAuth providers ENGRAM can authenticate against. */
+export type OAuthProviderName = 'github' | 'google';
+
+/**
+ * Normalised user profile returned by an OAuth provider after a successful
+ * authorization-code exchange. `email` is required because it is the stable
+ * key ENGRAM uses to upsert a {@link AuthIdentity.userId}.
+ */
+export interface OAuthUserProfile {
+  provider: OAuthProviderName;
+  /** Provider-specific stable account id (e.g. GitHub numeric id). */
+  providerAccountId: string;
+  email: string;
+  name: string | null;
+}

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/auth/vitest.config.ts
+++ b/packages/auth/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/packages/config/src/env.schema.spec.ts
+++ b/packages/config/src/env.schema.spec.ts
@@ -27,6 +27,13 @@ describe('envSchema', () => {
         VECTOR_BACKEND: 'qdrant',
         STM_CONSOLIDATION_ACCESS_THRESHOLD: 3,
         STM_CONSOLIDATION_INTERVAL_MS: 300_000,
+        JWT_EXPIRES_IN: '7d',
+        AUTH_REQUIRED: false,
+        RATE_LIMIT_ENABLED: false,
+        RATE_LIMIT_WINDOW_SEC: 60,
+        RATE_LIMIT_USER_RPM: 120,
+        RATE_LIMIT_ORG_RPM: 6000,
+        RATE_LIMIT_IP_RPM: 60,
       });
     });
 
@@ -231,6 +238,90 @@ describe('envSchema', () => {
       };
 
       expect(() => envSchema.parse(config)).toThrow(ZodError);
+    });
+  });
+
+  describe('auth & rate limiting', () => {
+    const base = {
+      DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+      REDIS_URL: 'redis://localhost:6379',
+      QDRANT_URL: 'http://localhost:6333',
+    };
+
+    const secret = 'a-very-long-secret-key-of-at-least-32-characters';
+
+    it('parses AUTH_REQUIRED truthy strings without the z.coerce.boolean footgun', () => {
+      expect(
+        envSchema.parse({ ...base, AUTH_REQUIRED: 'true', JWT_SECRET: secret }).AUTH_REQUIRED
+      ).toBe(true);
+      expect(
+        envSchema.parse({ ...base, AUTH_REQUIRED: '1', JWT_SECRET: secret }).AUTH_REQUIRED
+      ).toBe(true);
+      // The string 'false' must NOT be coerced to true (the z.coerce.boolean footgun).
+      expect(envSchema.parse({ ...base, AUTH_REQUIRED: 'false' }).AUTH_REQUIRED).toBe(false);
+      expect(envSchema.parse({ ...base, AUTH_REQUIRED: '0' }).AUTH_REQUIRED).toBe(false);
+    });
+
+    it('requires a 32+ char JWT_SECRET when AUTH_REQUIRED=true', () => {
+      expect(() => envSchema.parse({ ...base, AUTH_REQUIRED: 'true' })).toThrow(ZodError);
+      expect(() =>
+        envSchema.parse({ ...base, AUTH_REQUIRED: 'true', JWT_SECRET: 'short' })
+      ).toThrow(ZodError);
+      expect(
+        envSchema.parse({
+          ...base,
+          AUTH_REQUIRED: 'true',
+          JWT_SECRET: 'a-very-long-secret-key-of-at-least-32-characters',
+        }).JWT_SECRET
+      ).toHaveLength(48);
+    });
+
+    it('does not require JWT_SECRET when auth is disabled', () => {
+      expect(() => envSchema.parse(base)).not.toThrow();
+      expect(envSchema.parse(base).JWT_SECRET).toBeUndefined();
+    });
+
+    it('coerces rate-limit numbers and rejects non-positive limits', () => {
+      const result = envSchema.parse({
+        ...base,
+        RATE_LIMIT_ENABLED: 'true',
+        RATE_LIMIT_USER_RPM: '300',
+        RATE_LIMIT_WINDOW_SEC: '30',
+      });
+      expect(result.RATE_LIMIT_ENABLED).toBe(true);
+      expect(result.RATE_LIMIT_USER_RPM).toBe(300);
+      expect(result.RATE_LIMIT_WINDOW_SEC).toBe(30);
+      expect(() => envSchema.parse({ ...base, RATE_LIMIT_USER_RPM: '0' })).toThrow(ZodError);
+    });
+
+    it('accepts a well-formed RATE_LIMIT_TOOL_OVERRIDES and rejects a malformed one', () => {
+      expect(
+        envSchema.parse({
+          ...base,
+          RATE_LIMIT_TOOL_OVERRIDES: '{"reindex_memories":{"limit":2,"windowSeconds":3600}}',
+        }).RATE_LIMIT_TOOL_OVERRIDES
+      ).toContain('reindex_memories');
+      // Not JSON.
+      expect(() => envSchema.parse({ ...base, RATE_LIMIT_TOOL_OVERRIDES: 'not-json' })).toThrow(
+        ZodError
+      );
+      // Wrong shape (missing windowSeconds / non-positive).
+      expect(() =>
+        envSchema.parse({
+          ...base,
+          RATE_LIMIT_TOOL_OVERRIDES: '{"t":{"limit":0,"windowSeconds":60}}',
+        })
+      ).toThrow(ZodError);
+    });
+
+    it('validates OAUTH_REDIRECT_BASE_URL as a URL when present', () => {
+      expect(
+        envSchema.parse({ ...base, OAUTH_REDIRECT_BASE_URL: 'https://api.example.com' })
+          .OAUTH_REDIRECT_BASE_URL
+      ).toBe('https://api.example.com');
+      expect(() => envSchema.parse({ ...base, OAUTH_REDIRECT_BASE_URL: 'not-a-url' })).toThrow(
+        ZodError
+      );
     });
   });
 

--- a/packages/config/src/env.schema.ts
+++ b/packages/config/src/env.schema.ts
@@ -2,6 +2,22 @@ import { z } from 'zod';
 import { DeploymentProfile, coerceDeploymentProfile } from './profile';
 
 /**
+ * Boolean flag parsed from an environment string. `z.coerce.boolean()` is
+ * unusable here — it treats the string `'false'` as truthy — so we map the
+ * common truthy spellings explicitly and default everything else to `false`.
+ */
+const booleanFlag = (defaultValue: boolean): z.ZodType<boolean> =>
+  z
+    .preprocess(
+      (value) =>
+        typeof value === 'string'
+          ? ['true', '1', 'yes', 'on'].includes(value.trim().toLowerCase())
+          : value,
+      z.boolean()
+    )
+    .default(defaultValue) as z.ZodType<boolean>;
+
+/**
  * Environment validation schema for ENGRAM.
  *
  * URL requirements are conditional on the active deployment profile so that
@@ -65,6 +81,51 @@ const baseSchema = z.object({
     .enum(['memory', 'lite', 'enterprise'])
     .optional()
     .default(DeploymentProfile.ENTERPRISE),
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Authentication & multi-tenancy (Epic E4)
+  // ──────────────────────────────────────────────────────────────────────────
+  /**
+   * HMAC secret for issuing/verifying session JWTs. Required (≥32 chars) when
+   * `AUTH_REQUIRED=true`; otherwise optional. Never logged.
+   */
+  JWT_SECRET: z.string().optional(),
+  /** JWT lifetime as a duration string (`7d`, `24h`, `30m`, `3600s`) or seconds. */
+  JWT_EXPIRES_IN: z.string().default('7d'),
+  /**
+   * When true, `/mcp` tool calls must present a valid JWT or API key, and the
+   * acting `userId` is derived from that credential — the `userId` in tool input
+   * is ignored. Default false preserves the trusted-caller behaviour. Only
+   * enforced over the streamable-http transport.
+   */
+  AUTH_REQUIRED: booleanFlag(false),
+  /** Base URL used to build OAuth callback URLs, e.g. `https://api.example.com`. */
+  OAUTH_REDIRECT_BASE_URL: z.string().url().optional(),
+  /** GitHub OAuth app credentials. Both must be set to enable GitHub login. */
+  GITHUB_CLIENT_ID: z.string().optional(),
+  GITHUB_CLIENT_SECRET: z.string().optional(),
+  /** Google OAuth app credentials. Both must be set to enable Google login. */
+  GOOGLE_CLIENT_ID: z.string().optional(),
+  GOOGLE_CLIENT_SECRET: z.string().optional(),
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Rate limiting (Epic E4 / #132)
+  // ──────────────────────────────────────────────────────────────────────────
+  /** Master switch for the Redis-backed rate limiter (enterprise only). */
+  RATE_LIMIT_ENABLED: booleanFlag(false),
+  /** Fixed-window length in seconds. Default 60 → the `*_RPM` limits are per minute. */
+  RATE_LIMIT_WINDOW_SEC: z.coerce.number().int().min(1).default(60),
+  /** Max requests per window for an authenticated user. */
+  RATE_LIMIT_USER_RPM: z.coerce.number().int().min(1).default(120),
+  /** Max requests per window aggregated across an organization. */
+  RATE_LIMIT_ORG_RPM: z.coerce.number().int().min(1).default(6000),
+  /** Max requests per window for an unauthenticated client IP. */
+  RATE_LIMIT_IP_RPM: z.coerce.number().int().min(1).default(60),
+  /**
+   * Optional JSON map of per-tool overrides, e.g.
+   * `{"reindex_memories":{"limit":2,"windowSeconds":3600}}`. Parsed by the app.
+   */
+  RATE_LIMIT_TOOL_OVERRIDES: z.string().optional(),
 });
 
 /**
@@ -138,11 +199,65 @@ export const envSchema: z.ZodType<Env> = baseSchema.transform((value, ctx) => {
     value.QDRANT_URL = undefined;
   }
 
+  // Fail fast on a malformed RATE_LIMIT_TOOL_OVERRIDES rather than silently
+  // dropping all per-tool limits at runtime.
+  if (
+    typeof value.RATE_LIMIT_TOOL_OVERRIDES === 'string' &&
+    value.RATE_LIMIT_TOOL_OVERRIDES.trim().length > 0
+  ) {
+    if (!isValidToolOverrides(value.RATE_LIMIT_TOOL_OVERRIDES)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['RATE_LIMIT_TOOL_OVERRIDES'],
+        message:
+          'RATE_LIMIT_TOOL_OVERRIDES must be a JSON object mapping tool name to { "limit": positive int, "windowSeconds": positive int }',
+      });
+      return z.NEVER;
+    }
+  }
+
+  // When auth enforcement is on, a real JWT secret is mandatory.
+  if (value.AUTH_REQUIRED) {
+    if (typeof value.JWT_SECRET !== 'string' || value.JWT_SECRET.length < 32) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['JWT_SECRET'],
+        message: 'JWT_SECRET must be set and at least 32 characters when AUTH_REQUIRED=true',
+      });
+      return z.NEVER;
+    }
+  }
+
   return {
     ...value,
     DEPLOYMENT_PROFILE: profile,
   } as Env;
 });
+
+function isValidToolOverrides(raw: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return false;
+  }
+  return Object.values(parsed).every((rule) => {
+    if (typeof rule !== 'object' || rule === null) return false;
+    const { limit, windowSeconds } = rule as {
+      limit?: unknown;
+      windowSeconds?: unknown;
+    };
+    return (
+      Number.isInteger(limit) &&
+      (limit as number) > 0 &&
+      Number.isInteger(windowSeconds) &&
+      (windowSeconds as number) > 0
+    );
+  });
+}
 
 function isLikelyUrl(value: string): boolean {
   // Permissive URL check that matches `z.string().url()` without requiring
@@ -172,6 +287,20 @@ export type Env = {
   PGVECTOR_HNSW_M?: number;
   PGVECTOR_HNSW_EF_CONSTRUCTION?: number;
   PGVECTOR_HNSW_EF_SEARCH?: number;
+  JWT_SECRET?: string;
+  JWT_EXPIRES_IN: string;
+  AUTH_REQUIRED: boolean;
+  OAUTH_REDIRECT_BASE_URL?: string;
+  GITHUB_CLIENT_ID?: string;
+  GITHUB_CLIENT_SECRET?: string;
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
+  RATE_LIMIT_ENABLED: boolean;
+  RATE_LIMIT_WINDOW_SEC: number;
+  RATE_LIMIT_USER_RPM: number;
+  RATE_LIMIT_ORG_RPM: number;
+  RATE_LIMIT_IP_RPM: number;
+  RATE_LIMIT_TOOL_OVERRIDES?: string;
 };
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,5 +16,5 @@ export { LoggingModule, REDACT_PATHS } from './logging/logging.module';
 export { McpModule } from './mcp/mcp.module';
 export { McpHandler } from './mcp/mcp.handler';
 export type { McpServerConfig, McpServer, ServerInfo } from './mcp/types';
-export { registerTools, type Tool } from './mcp/tools/index';
+export { registerTools, type Tool, type ToolAuthMode, type AuthPolicy } from './mcp/tools/index';
 export { pingTool } from './mcp/tools/ping.tool';

--- a/packages/core/src/mcp/mcp.handler.ts
+++ b/packages/core/src/mcp/mcp.handler.ts
@@ -8,7 +8,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { McpServerConfig, McpServer } from './types.js';
-import { registerTools, type Tool } from './tools/index.js';
+import { registerTools, type Tool, type AuthPolicy } from './tools/index.js';
 
 /**
  * MCP Protocol Handler
@@ -21,6 +21,7 @@ export class McpHandler implements OnModuleDestroy {
   private transport: Transport | null = null;
   private isConnected = false;
   private additionalTools: Tool[] = [];
+  private authPolicy: AuthPolicy = { required: false };
 
   /**
    * Register additional tools before initialization
@@ -29,6 +30,15 @@ export class McpHandler implements OnModuleDestroy {
   registerAdditionalTools(tools: Tool[]): void {
     this.additionalTools = [...this.additionalTools, ...tools];
     this.logger.log(`Registered ${tools.length} additional tools`);
+  }
+
+  /**
+   * Set the authentication policy applied during tool dispatch. When
+   * `required` is true, non-public tools reject unauthenticated requests.
+   */
+  setAuthPolicy(policy: AuthPolicy): void {
+    this.authPolicy = policy;
+    this.logger.log(`MCP auth policy: required=${policy.required}`);
   }
 
   /**
@@ -66,7 +76,7 @@ export class McpHandler implements OnModuleDestroy {
       };
 
       // Register MCP tools (built-in + additional)
-      registerTools(this.server, this.additionalTools);
+      registerTools(this.server, this.additionalTools, this.authPolicy);
 
       this.logger.log('MCP server initialized successfully');
     } catch (error) {
@@ -127,7 +137,7 @@ export class McpHandler implements OnModuleDestroy {
     server.onerror = (error): void => {
       this.logger.error('MCP session server error:', error);
     };
-    registerTools(server, this.additionalTools);
+    registerTools(server, this.additionalTools, this.authPolicy);
     return server;
   }
 

--- a/packages/core/src/mcp/tools/dispatch-auth.spec.ts
+++ b/packages/core/src/mcp/tools/dispatch-auth.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Auth-aware tool dispatch tests: identity injection, admin pass-through,
+ * required-auth enforcement, and scope enforcement.
+ */
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { z } from 'zod';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { registerTools, type AuthPolicy, type Tool } from './index';
+
+type CallRequest = {
+  method: string;
+  params: { name: string; arguments?: unknown };
+};
+type CallExtra = {
+  authInfo?: { scopes?: string[]; extra?: Record<string, unknown> };
+};
+type CallResult = { content: Array<{ text: string }>; isError?: boolean };
+type CallHandler = (request: CallRequest, extra?: CallExtra) => Promise<CallResult>;
+
+const getRequestMethod = (schema: unknown): string | undefined =>
+  (
+    schema as {
+      def?: { shape?: { method?: { def?: { values?: string[] } } } };
+    }
+  )?.def?.shape?.method?.def?.values?.[0];
+
+const identityTool: Tool = {
+  name: 'echo_user',
+  description: 'echoes the acting userId',
+  inputSchema: z.object({ userId: z.string() }).strict(),
+  handler: (input): Promise<unknown> =>
+    Promise.resolve({ echoedUserId: (input as { userId: string }).userId }),
+};
+
+const adminTool: Tool = {
+  name: 'admin_op',
+  description: 'targets an arbitrary userId',
+  inputSchema: z.object({ userId: z.string() }).strict(),
+  handler: (input): Promise<unknown> =>
+    Promise.resolve({ targetUserId: (input as { userId: string }).userId }),
+  auth: 'admin',
+};
+
+const scopedTool: Tool = {
+  name: 'write_thing',
+  description: 'requires the memories:write scope',
+  inputSchema: z.object({ userId: z.string() }).strict(),
+  handler: (input): Promise<unknown> =>
+    Promise.resolve({ ok: (input as { userId: string }).userId }),
+  requiredScope: 'memories:write',
+};
+
+describe('auth-aware tool dispatch', () => {
+  let server: Server;
+
+  beforeEach((): void => {
+    server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: { tools: {} } });
+  });
+
+  const capture = (tools: Tool[], policy: AuthPolicy): CallHandler => {
+    let handler: CallHandler | undefined;
+    vi.spyOn(server, 'setRequestHandler').mockImplementation((schema, fn): void => {
+      if (getRequestMethod(schema) === 'tools/call') {
+        handler = fn as unknown as CallHandler;
+      }
+    });
+    registerTools(server, tools, policy);
+    if (!handler) throw new Error('call handler not registered');
+    return handler;
+  };
+
+  const parse = (result: CallResult): Record<string, unknown> =>
+    JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+
+  it('injects the authenticated userId into identity tools, overriding input', async () => {
+    const handler = capture([identityTool], { required: true });
+    const result = await handler(
+      { method: 'tools/call', params: { name: 'echo_user', arguments: { userId: 'attacker' } } },
+      { authInfo: { extra: { userId: 'real-user' } } }
+    );
+    expect(parse(result).echoedUserId).toBe('real-user');
+  });
+
+  it('does NOT override userId for admin tools', async () => {
+    const handler = capture([adminTool], { required: true });
+    const result = await handler(
+      { method: 'tools/call', params: { name: 'admin_op', arguments: { userId: 'target' } } },
+      { authInfo: { extra: { userId: 'operator' } } }
+    );
+    expect(parse(result).targetUserId).toBe('target');
+  });
+
+  it('rejects protected tools when auth is required and absent', async () => {
+    const handler = capture([identityTool], { required: true });
+    const result = await handler({
+      method: 'tools/call',
+      params: { name: 'echo_user', arguments: { userId: 'x' } },
+    });
+    expect(result).toHaveProperty('isError', true);
+    expect(parse(result).error).toContain('Unauthorized');
+  });
+
+  it('allows public tools without auth even when required', async () => {
+    const handler = capture([], { required: true });
+    const result = await handler({
+      method: 'tools/call',
+      params: { name: 'ping', arguments: {} },
+    });
+    expect(parse(result).status).toBe('pong');
+  });
+
+  it('uses input userId untouched when no identity is present and auth is optional', async () => {
+    const handler = capture([identityTool], { required: false });
+    const result = await handler({
+      method: 'tools/call',
+      params: { name: 'echo_user', arguments: { userId: 'self-declared' } },
+    });
+    expect(parse(result).echoedUserId).toBe('self-declared');
+  });
+
+  it('rejects a tool when the identity lacks the required scope', async () => {
+    const handler = capture([scopedTool], { required: true });
+    const result = await handler(
+      { method: 'tools/call', params: { name: 'write_thing', arguments: {} } },
+      { authInfo: { scopes: ['memories:read'], extra: { userId: 'u' } } }
+    );
+    expect(result).toHaveProperty('isError', true);
+    expect(parse(result).error).toContain('scope');
+  });
+
+  it('allows a tool when the identity holds the required scope', async () => {
+    const handler = capture([scopedTool], { required: true });
+    const result = await handler(
+      { method: 'tools/call', params: { name: 'write_thing', arguments: {} } },
+      { authInfo: { scopes: ['memories:write'], extra: { userId: 'u' } } }
+    );
+    expect(parse(result).ok).toBe('u');
+  });
+
+  it('treats the admin scope as a universal grant', async () => {
+    const handler = capture([scopedTool], { required: true });
+    const result = await handler(
+      { method: 'tools/call', params: { name: 'write_thing', arguments: {} } },
+      { authInfo: { scopes: ['admin'], extra: { userId: 'u' } } }
+    );
+    expect(parse(result).ok).toBe('u');
+  });
+});

--- a/packages/core/src/mcp/tools/index.ts
+++ b/packages/core/src/mcp/tools/index.ts
@@ -10,6 +10,19 @@ import type { McpServer } from '../types.js';
 import { pingTool } from './ping.tool.js';
 
 /**
+ * How an authenticated identity maps onto a tool:
+ *   - `identity` (default): the tool acts on behalf of the caller. When the
+ *     request is authenticated, the verified `userId` is injected into the tool
+ *     input, overriding any client-supplied `userId` (a forged tenant cannot
+ *     read another tenant's data).
+ *   - `admin`: `userId` is a parameter chosen by an operator (e.g. issuing an
+ *     API key *for* a user); it is never overwritten. These tools carry their
+ *     own `adminToken` gate.
+ *   - `public`: callable without authentication (e.g. `ping`).
+ */
+export type ToolAuthMode = 'identity' | 'admin' | 'public';
+
+/**
  * Tool definition interface
  */
 export interface Tool {
@@ -17,6 +30,52 @@ export interface Tool {
   description: string;
   inputSchema: z.ZodSchema;
   handler: (input: unknown) => Promise<unknown>;
+  /** Defaults to `identity`. See {@link ToolAuthMode}. */
+  auth?: ToolAuthMode;
+  /**
+   * Scope an authenticated principal must hold to call this tool (e.g.
+   * `memories:write`). The `admin` scope satisfies any requirement. Only
+   * checked when the request carries an authenticated identity; tools with no
+   * `requiredScope` need only a valid identity. Leaves unauthenticated/legacy
+   * calls (no authInfo) to the `auth` enforcement above.
+   */
+  requiredScope?: string;
+}
+
+/**
+ * Server-wide authentication policy applied during tool dispatch. Supplied by
+ * the host (derived from `AUTH_REQUIRED` + transport). When `required` is true,
+ * non-public tools reject requests that carry no authenticated identity.
+ */
+export interface AuthPolicy {
+  required: boolean;
+}
+
+/** Shape of the per-request auth info forwarded by the transport. */
+type ToolCallExtra =
+  | { authInfo?: { scopes?: unknown; extra?: Record<string, unknown> } }
+  | undefined;
+
+/** Read the verified user id stashed on the transport's auth info, if any. */
+function authenticatedUserId(extra: ToolCallExtra): string | undefined {
+  const value = extra?.authInfo?.extra?.userId;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/** Read the authenticated principal's granted scopes, if any. */
+function authenticatedScopes(extra: ToolCallExtra): string[] {
+  const scopes = extra?.authInfo?.scopes;
+  return Array.isArray(scopes) ? scopes.filter((s): s is string => typeof s === 'string') : [];
+}
+
+/** The `admin` scope is a universal grant. */
+const ADMIN_SCOPE = 'admin';
+
+/** Whether a tool's input schema declares a `userId` we can safely inject. */
+function schemaAcceptsUserId(schema: z.ZodSchema): boolean {
+  return (
+    schema instanceof z.ZodObject && Object.prototype.hasOwnProperty.call(schema.shape, 'userId')
+  );
 }
 
 /**
@@ -72,7 +131,11 @@ function zodToJsonSchema(schema: z.ZodSchema): {
  * @param server - MCP server instance
  * @param additionalTools - Optional array of additional tools to register
  */
-export function registerTools(server: McpServer, additionalTools: Tool[] = []): void {
+export function registerTools(
+  server: McpServer,
+  additionalTools: Tool[] = [],
+  authPolicy: AuthPolicy = { required: false }
+): void {
   const logger = new Logger('McpTools');
 
   // Combine built-in and additional tools
@@ -92,7 +155,7 @@ export function registerTools(server: McpServer, additionalTools: Tool[] = []): 
   });
 
   // Register call_tool handler
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const toolName = request.params.name;
     logger.log(`Handling tools/call request for tool: ${toolName}`);
 
@@ -104,8 +167,41 @@ export function registerTools(server: McpServer, additionalTools: Tool[] = []): 
         throw new Error(`Unknown tool: ${toolName}`);
       }
 
+      const mode: ToolAuthMode = tool.auth ?? 'identity';
+      const userId = authenticatedUserId(extra);
+
+      // Enforcement: protected tools require an authenticated identity when the
+      // server policy demands it. (The HTTP layer rejects these earlier with a
+      // 401; this is the in-dispatch safety net so no protected tool can run
+      // unauthenticated even if the request reaches the handler.)
+      if (authPolicy.required && mode !== 'public' && !extra?.authInfo) {
+        logger.warn(`auth_required_denied tool=${toolName}`);
+        throw new Error('Unauthorized: authentication is required');
+      }
+
+      // Scope check: an authenticated principal must hold the tool's required
+      // scope (or the universal `admin` scope). This makes API-key/JWT scopes
+      // load-bearing — e.g. a `memories:read`-only key cannot call a write or
+      // delete tool. Unauthenticated/legacy calls (no authInfo) are governed by
+      // the auth-required check above, not here.
+      if (extra?.authInfo && mode !== 'public' && tool.requiredScope) {
+        const scopes = authenticatedScopes(extra);
+        if (!scopes.includes(ADMIN_SCOPE) && !scopes.includes(tool.requiredScope)) {
+          logger.warn(`scope_denied tool=${toolName} required=${tool.requiredScope}`);
+          throw new Error(`Forbidden: missing required scope "${tool.requiredScope}"`);
+        }
+      }
+
+      // Build the effective input. For identity tools we trust the verified
+      // userId over anything the client supplied — the tenant boundary is the
+      // token, not the request body.
+      let args: unknown = request.params.arguments ?? {};
+      if (mode === 'identity' && userId && schemaAcceptsUserId(tool.inputSchema)) {
+        args = { ...(args as Record<string, unknown>), userId };
+      }
+
       // Validate input with Zod
-      const validatedInput = tool.inputSchema.parse(request.params.arguments || {});
+      const validatedInput = tool.inputSchema.parse(args);
 
       // Execute tool handler
       const result = await tool.handler(validatedInput);
@@ -150,5 +246,7 @@ export function registerTools(server: McpServer, additionalTools: Tool[] = []): 
     }
   });
 
-  logger.log(`Registered ${allTools.length} MCP tools (${builtInTools.length} built-in, ${additionalTools.length} additional)`);
+  logger.log(
+    `Registered ${allTools.length} MCP tools (${builtInTools.length} built-in, ${additionalTools.length} additional)`
+  );
 }

--- a/packages/core/src/mcp/tools/ping.tool.ts
+++ b/packages/core/src/mcp/tools/ping.tool.ts
@@ -37,4 +37,6 @@ export const pingTool = {
   description: 'Test connectivity to ENGRAM server',
   inputSchema: pingInputSchema,
   handler: pingHandler,
+  // Connectivity check — callable without authentication.
+  auth: 'public' as const,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
 
   apps/mcp-server:
     dependencies:
+      '@engram/auth':
+        specifier: workspace:^
+        version: link:../../packages/auth
       '@engram/config':
         specifier: workspace:^
         version: link:../../packages/config
@@ -351,6 +354,43 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+
+  packages/auth:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^11.1.24
+        version: 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@nestjs/testing':
+        specifier: ^11.1.24
+        version: 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(@nestjs/platform-express@11.1.24)
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.7.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   packages/client:
     dependencies:


### PR DESCRIPTION
Completes **Epic #101 — Auth & Multi-tenancy (Stream E)** by delivering the two open stories and enforcing the epic's Definition of Done.

Closes #128 · Closes #132 · Advances #101

## What's included

### `@engram/auth` (new package) — #128
- **`JwtService`** — HS256 over `node:crypto`. `jose@6` is ESM-only and incompatible with this CJS package, so this is hand-rolled and *structurally* immune to algorithm-confusion (it never reads `alg` from the token; always HMAC-SHA256 + constant-time compare).
- **GitHub / Google OAuth providers** over an injectable, mockable HTTP client.
- **`SessionService`** — Redis-backed sessions + one-time CSRF OAuth `state`.
- **`RateLimitService`** — fixed-window limiter.

### mcp-server wiring
- **`AuthModule`** (profile-gated: DB → JWT/API-key auth; Redis → OAuth, sessions, rate limiting), `/auth/:provider/login` · `/callback` · `/auth/me` · `/auth/logout`, `AuthResolver`, `McpAuthMiddleware`, user upsert.
- **Tenant-isolation enforcement (DoD):** the `/mcp` tool dispatch derives `userId` from the verified token (`extra.authInfo`) and **overrides** any spoofed `userId` in tool input for identity tools; admin tools keep their parameter `userId`. **API-key/JWT scopes are now load-bearing** per tool (`memories:read|write|delete`; `admin` is universal) — a read-only key can no longer write or delete.
- Gated by **`AUTH_REQUIRED`** (default **off**, streamable-http only) → **no schema/migration**, and existing token-less callers are unaffected.

### Rate limiting — #132
Redis-backed, **per-key / per-user / per-org / per-IP** with per-tool overrides; meters **every** call in a JSON-RPC batch; `429` + `Retry-After` + `X-RateLimit-*` headers.

## Verification

| | |
|---|---|
| Unit | `@engram/auth` 30, `@engram/core` 35, `@engram/config` 32, mcp-server 423 |
| **Integration (real Postgres/Redis/Qdrant)** | cross-tenant isolation — a `create_memory` with spoofed `userId: bob` while authenticated as alice lands the row under **alice** (asserted in Postgres); scope denial; `401` |
| **Linchpin** | a real HTTP→middleware→transport→dispatch test proves `req.auth` reaches the handler **per-request** (same session, `alice` then `bob`) |
| Gates | build 16/16 · typecheck 14/14 · lint · docs:check |

An adversarial review surfaced a real scope-enforcement gap and a JSON-RPC-batch rate-limit bypass; both are fixed and covered by tests.

## Test-harness fix (please note)
This PR also repairs the **previously non-functional e2e harness** (`apps/mcp-server/test/jest-e2e.json`): a `TS5011` compile error and the unit `@engram/redis` mock leaking into e2e meant every AppModule-booting e2e test failed to run — and **no CI job runs e2e**, so it went unnoticed. Fixing it is what let the integration tests above actually execute.

## Related
- Filed #189 — a pre-existing `create_memory → recall` "saved but not synchronously indexed" finding surfaced while making the e2e runnable. Out of scope here (memory/vector subsystem, not auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016o3CDWc54PBn5wj3sQkWV9