### PR TITLE
fix(health): probe Qdrant only when it is the active backend (#193)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,13 +179,22 @@ jobs:
 
       - name: Smoke-test image (memory profile)
         run: |
-          docker run --rm \
+          docker run -d \
             -e DEPLOYMENT_PROFILE=memory \
             -e MCP_TRANSPORT=streamable-http \
             -e EMBEDDING_PROVIDER=local \
             -p 13000:3000 \
             --name engram-ci-smoke \
-            engram-mcp-server:ci-${{ github.sha }} &
-          sleep 10
-          curl --retry 5 --retry-delay 2 -sf http://localhost:13000/health
-          docker stop engram-ci-smoke || true
+            engram-mcp-server:ci-${{ github.sha }}
+          # Poll instead of a fixed sleep: curl's --retry does not cover
+          # connection resets (exit 56) from docker-proxy while the app boots.
+          ok=""
+          for _ in $(seq 1 30); do
+            if curl -sf http://localhost:13000/health; then ok=1; break; fi
+            sleep 2
+          done
+          echo
+          echo "--- container logs ---"
+          docker logs engram-ci-smoke
+          docker rm -f engram-ci-smoke || true
+          test -n "$ok"

--- a/apps/mcp-server/src/health/health.controller.spec.ts
+++ b/apps/mcp-server/src/health/health.controller.spec.ts
@@ -244,13 +244,36 @@ describe('HealthController profile-aware vector wiring', () => {
     expect(metrics).toContain('engram_pgvector_ready 0');
   });
 
-  it('ENTERPRISE + pgvector probes both Qdrant and pgvector (no regression)', async () => {
-    process.env.VECTOR_BACKEND = 'pgvector';
+  it('ENTERPRISE with no VECTOR_BACKEND defaults to qdrant and probes it', async () => {
+    delete process.env.VECTOR_BACKEND;
     const { controller, probes } = makeController(DeploymentProfile.ENTERPRISE);
 
     await controller.check();
 
     expect(probes.qdrant).toHaveBeenCalledWith('qdrant');
+    expect(probes.pgvector).not.toHaveBeenCalled();
+  });
+
+  it('ENTERPRISE + pgvector probes pgvector only, never Qdrant (#193)', async () => {
+    process.env.VECTOR_BACKEND = 'pgvector';
+    const { controller, probes } = makeController(DeploymentProfile.ENTERPRISE);
+
+    await controller.check();
+
+    expect(probes.qdrant).not.toHaveBeenCalled();
+    expect(probes.pgvector).toHaveBeenCalledWith('pgvector');
+  });
+
+  it('ENTERPRISE + pgvector stays healthy when Qdrant is down (#193)', async () => {
+    process.env.VECTOR_BACKEND = 'pgvector';
+    const { controller, probes } = makeController(DeploymentProfile.ENTERPRISE);
+    probes.qdrant.mockRejectedValue(new Error('qdrant unreachable'));
+
+    // check() awaits every composed indicator, so a probed-but-down Qdrant
+    // would reject here. Readiness must compose the same indicator set.
+    await expect(controller.check()).resolves.toEqual({ status: 'ok' });
+    await expect(controller.readiness()).resolves.toEqual({ status: 'ok' });
+    expect(probes.qdrant).not.toHaveBeenCalled();
     expect(probes.pgvector).toHaveBeenCalledWith('pgvector');
   });
 

--- a/apps/mcp-server/src/health/health.controller.ts
+++ b/apps/mcp-server/src/health/health.controller.ts
@@ -10,6 +10,7 @@ import {
   resolveCapabilities,
   coerceDeploymentProfile,
   usesPgVector,
+  usesQdrant,
   DEFAULT_VECTOR_BACKEND,
   type ProfileCapabilities,
   DeploymentProfile,
@@ -77,7 +78,9 @@ export class HealthController {
         );
       }
     }
-    if (capabilities.requiresQdrant) {
+    // Qdrant is probed only when it is the active backend on a Qdrant-bearing
+    // profile — symmetric with the pgvector gate below (#193).
+    if (usesQdrant(capabilities, process.env.VECTOR_BACKEND)) {
       const qdrant = this.qdrantHealth;
       if (qdrant) {
         indicators.push(

--- a/apps/mcp-server/src/health/health.module.spec.ts
+++ b/apps/mcp-server/src/health/health.module.spec.ts
@@ -14,7 +14,8 @@ import { MemoryStoreHealthIndicator } from './memory-store.health';
  * compiling the Nest graph, so they assert which indicators a profile/backend
  * combination provides without standing up Postgres/Qdrant/Redis. This is the
  * regression guard for #187: pgvector wiring must follow the active backend,
- * not `requiresQdrant`.
+ * not `requiresQdrant` — and, since #193, the guard for the symmetric rule:
+ * Qdrant wiring must also follow the active backend, not the raw profile flag.
  */
 describe('HealthModule.forRoot wiring', () => {
   const ORIGINAL_BACKEND = process.env.VECTOR_BACKEND;
@@ -83,14 +84,22 @@ describe('HealthModule.forRoot wiring', () => {
     expect(imports).not.toContain(VectorStoreModule);
   });
 
-  it('ENTERPRISE + pgvector provides both indicators (no regression)', () => {
+  it('ENTERPRISE with no VECTOR_BACKEND defaults to qdrant and wires the Qdrant indicator', () => {
+    const { providers, imports } = build(DeploymentProfile.ENTERPRISE);
+    expect(providers).toContain(QdrantHealthIndicator);
+    expect(providers).not.toContain(PgVectorHealthIndicator);
+    expect(imports).toContain(QdrantModule);
+    expect(imports).not.toContain(VectorStoreModule);
+  });
+
+  it('ENTERPRISE + pgvector provides only the pgvector indicator, never Qdrant (#193)', () => {
     const { providers, imports } = build(
       DeploymentProfile.ENTERPRISE,
       'pgvector',
     );
-    expect(providers).toContain(QdrantHealthIndicator);
+    expect(providers).not.toContain(QdrantHealthIndicator);
     expect(providers).toContain(PgVectorHealthIndicator);
-    expect(imports).toContain(QdrantModule);
+    expect(imports).not.toContain(QdrantModule);
     expect(imports).toContain(VectorStoreModule);
   });
 });

--- a/apps/mcp-server/src/health/health.module.ts
+++ b/apps/mcp-server/src/health/health.module.ts
@@ -4,7 +4,11 @@ import { HttpModule } from '@nestjs/axios';
 import { EmbeddingsModule } from '@engram/embeddings';
 import { RedisModule } from '@engram/redis';
 import { QdrantModule, VectorStoreModule } from '@engram/vector-store';
-import { usesPgVector, type ProfileCapabilities } from '@engram/config';
+import {
+  usesPgVector,
+  usesQdrant,
+  type ProfileCapabilities,
+} from '@engram/config';
 import { HealthController } from './health.controller';
 import { PrismaHealthIndicator } from './prisma.health';
 import { RedisHealthIndicator } from './redis.health';
@@ -40,8 +44,10 @@ export class HealthModule {
       imports.push(RedisModule.forRoot());
       providers.push(RedisHealthIndicator);
     }
-    if (capabilities.requiresQdrant) {
-      // Qdrant is a remote service wired only when the profile deploys it.
+    if (usesQdrant(capabilities, process.env.VECTOR_BACKEND)) {
+      // Qdrant is a remote service wired only when the profile deploys it AND
+      // it is the active vector backend. A Qdrant-bearing profile running
+      // VECTOR_BACKEND=pgvector must not gate readiness on Qdrant (#193).
       imports.push(QdrantModule);
       providers.push(QdrantHealthIndicator);
     }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,6 +9,7 @@ export {
   resolveCapabilities,
   coerceDeploymentProfile,
   usesPgVector,
+  usesQdrant,
   DEFAULT_VECTOR_BACKEND,
   type ProfileCapabilities,
 } from './profile';

--- a/packages/config/src/profile.spec.ts
+++ b/packages/config/src/profile.spec.ts
@@ -4,6 +4,7 @@ import {
   resolveCapabilities,
   coerceDeploymentProfile,
   usesPgVector,
+  usesQdrant,
   DEFAULT_VECTOR_BACKEND,
   type ProfileCapabilities,
 } from './profile';
@@ -103,5 +104,49 @@ describe('usesPgVector', () => {
   it('normalises backend casing', () => {
     expect(usesPgVector(lite, 'PgVector')).toBe(true);
     expect(usesPgVector(lite, 'PGVECTOR')).toBe(true);
+  });
+});
+
+describe('usesQdrant', () => {
+  const memory = resolveCapabilities(DeploymentProfile.MEMORY);
+  const lite = resolveCapabilities(DeploymentProfile.LITE);
+  const enterprise = resolveCapabilities(DeploymentProfile.ENTERPRISE);
+
+  it('defaults to the qdrant backend, which selects Qdrant on Qdrant-bearing profiles', () => {
+    expect(DEFAULT_VECTOR_BACKEND).toBe('qdrant');
+    expect(usesQdrant(enterprise, undefined)).toBe(true);
+    expect(usesQdrant(enterprise, null)).toBe(true);
+  });
+
+  it('is true only when a Qdrant-bearing profile also selects the qdrant backend', () => {
+    expect(usesQdrant(enterprise, 'qdrant')).toBe(true);
+  });
+
+  it('is false when the backend is pgvector even on a Qdrant-bearing profile', () => {
+    // The headline fix: ENTERPRISE deploys Qdrant, but with
+    // VECTOR_BACKEND=pgvector the active vector store is pgvector, so Qdrant
+    // must not gate readiness.
+    expect(usesQdrant(enterprise, 'pgvector')).toBe(false);
+  });
+
+  it('is false for profiles that do not deploy Qdrant regardless of backend', () => {
+    expect(usesQdrant(lite, 'qdrant')).toBe(false);
+    expect(usesQdrant(lite, 'pgvector')).toBe(false);
+    expect(usesQdrant(lite, undefined)).toBe(false);
+    expect(usesQdrant(memory, 'qdrant')).toBe(false);
+    expect(usesQdrant(memory, undefined)).toBe(false);
+  });
+
+  it('normalises backend casing', () => {
+    expect(usesQdrant(enterprise, 'Qdrant')).toBe(true);
+    expect(usesQdrant(enterprise, 'QDRANT')).toBe(true);
+  });
+
+  it('is mutually exclusive with usesPgVector for any backend value', () => {
+    for (const caps of [memory, lite, enterprise]) {
+      for (const backend of [undefined, null, 'qdrant', 'pgvector', 'PGVECTOR']) {
+        expect(usesQdrant(caps, backend) && usesPgVector(caps, backend)).toBe(false);
+      }
+    }
   });
 });

--- a/packages/config/src/profile.ts
+++ b/packages/config/src/profile.ts
@@ -138,3 +138,23 @@ export function usesPgVector(
   const normalized = (backend ?? DEFAULT_VECTOR_BACKEND).toLowerCase();
   return capabilities.requiresDatabase && normalized === 'pgvector';
 }
+
+/**
+ * Decide whether the Qdrant backend is active for a given profile.
+ *
+ * Mirrors {@link usesPgVector}: Qdrant is probed only on profiles that deploy
+ * the Qdrant service (`requiresQdrant`) *and* when `VECTOR_BACKEND` actually
+ * selects it. A Qdrant-bearing profile (ENTERPRISE) that runs with
+ * `VECTOR_BACKEND=pgvector` should not require a healthy Qdrant to be ready —
+ * the active vector store is pgvector.
+ *
+ * This exists so the Qdrant health wiring no longer conflates "this profile
+ * deploys the Qdrant service" with "Qdrant is the active vector backend".
+ */
+export function usesQdrant(
+  capabilities: ProfileCapabilities,
+  backend: string | null | undefined
+): boolean {
+  const normalized = (backend ?? DEFAULT_VECTOR_BACKEND).toLowerCase();
+  return capabilities.requiresQdrant && normalized === 'qdrant';
+}


### PR DESCRIPTION
## Summary

The Qdrant health indicator was gated on the profile-static `capabilities.requiresQdrant` flag, while pgvector health (since #187/#191) follows the active `VECTOR_BACKEND`. As a result, an ENTERPRISE deployment running `VECTOR_BACKEND=pgvector` with the Qdrant container stopped returned `503` from `/health` and `/health/ready` even though its active vector store was fully healthy.

This PR makes the Qdrant probe backend-aware, symmetric with pgvector:

- **`packages/config/src/profile.ts`** — new `usesQdrant(capabilities, backend)` predicate mirroring `usesPgVector()`: `caps.requiresQdrant && (backend ?? DEFAULT_VECTOR_BACKEND).toLowerCase() === 'qdrant'`. Exported from `@engram/config`.
- **`apps/mcp-server/src/health/health.module.ts`** — `forRoot()` wires `QdrantModule` + `QdrantHealthIndicator` under `usesQdrant(...)` instead of the raw `requiresQdrant` flag.
- **`apps/mcp-server/src/health/health.controller.ts`** — `buildIndicators()` composes the Qdrant indicator under the same predicate.

## Behaviour after fix

| Profile | Backend | Qdrant probed | pgvector probed |
|---|---|---|---|
| ENTERPRISE | qdrant | yes | no |
| ENTERPRISE | pgvector | **no** (changed) | yes |
| LITE | pgvector | no | yes |

Note: ENTERPRISE + pgvector is a deliberate behaviour change — Qdrant is no longer probed, so `/health` and `/health/ready` return `200` when pgvector is healthy even with Qdrant down.

## Open question resolution

The informational gauge for a deployed-but-idle Qdrant in ENTERPRISE + pgvector (e.g. `engram_qdrant_reachable`) was **dropped from health; can be added later if operationally needed**.

## Tests

- `packages/config/src/profile.spec.ts` — `usesQdrant` unit suite mirroring the `usesPgVector` tests from #191 (default backend, per-profile matrix, casing normalisation, mutual exclusivity with `usesPgVector`).
- `apps/mcp-server/src/health/health.module.spec.ts` — wiring matrix updated: ENTERPRISE + pgvector no longer wires `QdrantModule`/`QdrantHealthIndicator`; new default-backend case.
- `apps/mcp-server/src/health/health.controller.spec.ts` — indicator-composition matrix updated: ENTERPRISE + pgvector probes pgvector only; new test proving `/health` and `/health/ready` stay `ok` with Qdrant rejecting; new default-backend case.

Quality gates: `pnpm build`, `pnpm lint`, `pnpm typecheck`, `pnpm test` all pass.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)