### PR TITLE
chore(mcp-server): harden typed lint in bootstrap/health, drop stale eslint disables (#96)

### DIFF
--- a/apps/mcp-server/eslint.config.mjs
+++ b/apps/mcp-server/eslint.config.mjs
@@ -12,6 +12,10 @@ export default tseslint.config(
   ...tseslint.configs.recommendedTypeChecked,
   eslintPluginPrettierRecommended,
   {
+    // Fail (not just warn) on stale suppressions so they cannot drift (#96).
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
     languageOptions: {
       globals: {
         ...globals.node,

--- a/apps/mcp-server/src/migration/postgres-checkpoint.backend.spec.ts
+++ b/apps/mcp-server/src/migration/postgres-checkpoint.backend.spec.ts
@@ -1,5 +1,24 @@
+import type { PrismaService } from '@engram/database';
 import { PostgresCheckpointBackend } from './postgres-checkpoint.backend';
 import type { MigrationCheckpoint } from './migration.types';
+
+/** Shape of the transaction client handed to the `$transaction` callback. */
+interface TxStub {
+  migrationCheckpoint: {
+    findUnique: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+  };
+}
+
+/** Typed stand-in for the slice of PrismaService the backend touches. */
+interface PrismaStub {
+  $transaction: jest.Mock;
+  migrationCheckpoint: {
+    findUnique: jest.Mock;
+    delete: jest.Mock;
+  };
+}
 
 function makeCheckpoint(
   overrides: Partial<MigrationCheckpoint> = {},
@@ -39,10 +58,8 @@ function makeRow(cp: MigrationCheckpoint): Record<string, unknown> {
 }
 
 describe('PostgresCheckpointBackend', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let tx: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let prisma: any;
+  let tx: TxStub;
+  let prisma: PrismaStub;
   let backend: PostgresCheckpointBackend;
 
   beforeEach(() => {
@@ -55,13 +72,13 @@ describe('PostgresCheckpointBackend', () => {
     };
     prisma = {
       // Simulate Prisma's $transaction by invoking the callback with tx.
-      $transaction: jest.fn((cb: (t: typeof tx) => Promise<unknown>) => cb(tx)),
+      $transaction: jest.fn((cb: (t: TxStub) => Promise<unknown>) => cb(tx)),
       migrationCheckpoint: {
         findUnique: jest.fn(),
         delete: jest.fn(),
       },
     };
-    backend = new PostgresCheckpointBackend(prisma);
+    backend = new PostgresCheckpointBackend(prisma as unknown as PrismaService);
   });
 
   describe('save()', () => {


### PR DESCRIPTION
## Summary
Brings `pnpm --filter mcp-server lint` to 0 errors / 0 warnings with no unused eslint-disable directives, per issue triage (verified after a clean `pnpm build` + `pnpm db:generate` so cross-package type-resolution noise is excluded).

The files named in the issue (`src/main.ts`, `src/health/qdrant.health.ts`, `test/memory-system.e2e-spec.ts`) had already been cleaned by prior PRs; after a clean build the only remaining warnings were in `src/migration/postgres-checkpoint.backend.spec.ts`.

## Changes
- **`apps/mcp-server/src/migration/postgres-checkpoint.backend.spec.ts`**
  - Replaced the `any`-typed `tx` / `prisma` mocks with typed `TxStub` / `PrismaStub` contracts (same pattern as `user.service.spec.ts`), fixing the `@typescript-eslint/no-unsafe-argument` warning at the `PostgresCheckpointBackend` constructor call.
  - Removed two unused `eslint-disable-next-line @typescript-eslint/no-explicit-any` directives (the rule is `off` in this config, so they were stale).
- **`apps/mcp-server/eslint.config.mjs`**
  - Set `linterOptions.reportUnusedDisableDirectives: 'error'` (scoped to mcp-server) so stale suppressions fail lint instead of drifting as warnings.

No runtime behavior changed — edits are confined to a spec file and lint config.

## Verification
- `pnpm --filter mcp-server lint` — 0 errors, 0 warnings (was 3 warnings after clean build)
- `pnpm build` — 16/16 tasks pass
- `pnpm lint` (whole repo) — 17/17 tasks pass
- `pnpm typecheck` — 15/15 tasks pass
- `pnpm --filter mcp-server test` — 488 passed, 2 skipped, 0 failed

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)