### PR TITLE
fix(mcp): advertise correct JSON Schemas in tools/list (#205)

### DIFF
--- a/apps/mcp-server/src/__tests__/tools-list-schema.spec.ts
+++ b/apps/mcp-server/src/__tests__/tools-list-schema.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * Wiring test for the JSON Schemas advertised via the MCP `tools/list`
+ * response (issue #205).
+ *
+ * The full production tool set (memory tools + API-key tools + the built-in
+ * ping tool) is registered through the real `registerTools` dispatcher from
+ * `@engram/core`, and the captured `tools/list` handler is invoked exactly as
+ * an MCP client would. For EVERY advertised tool we assert:
+ *
+ *   1. the schema is object-typed draft-07 with `additionalProperties: false`
+ *      (all tool schemas are `z.object(...).strict()`),
+ *   2. `properties` contains an entry for every key of the Zod input schema
+ *      (the old hand-rolled converter dropped enums, arrays, records, and
+ *      defaulted fields), and
+ *   3. `required` lists exactly the keys that reject an absent value — so a
+ *      `.optional().default(...)` field (ZodDefault) must NOT be required.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { z } from 'zod';
+import { registerTools, pingTool, type Tool } from '@engram/core';
+import { MemoryController } from '../memory/memory.controller';
+import { MemoryService } from '../memory/memory.service';
+import { ReindexQueueService } from '../memory/reindex-queue.service';
+import { ConsolidationService } from '../memory/consolidation.service';
+import { ApiKeysController } from '../api-keys/api-keys.controller';
+import { ApiKeysService } from '../api-keys/api-keys.service';
+
+interface AdvertisedTool {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: string;
+    properties?: Record<string, Record<string, unknown>>;
+    required?: string[];
+    additionalProperties?: boolean;
+    [key: string]: unknown;
+  };
+}
+
+describe('tools/list advertised JSON Schemas (wiring, issue #205)', () => {
+  let registeredTools: Tool[];
+  let advertisedTools: AdvertisedTool[];
+
+  /** Extract the request method literal from an SDK zod request schema. */
+  const getRequestMethod = (schema: unknown): string | undefined => {
+    return (
+      schema as {
+        def?: { shape?: { method?: { def?: { values?: string[] } } } };
+      }
+    )?.def?.shape?.method?.def?.values?.[0];
+  };
+
+  beforeAll(async () => {
+    // Enterprise profile (the default) exposes every tool.
+    delete process.env.DEPLOYMENT_PROFILE;
+    process.env.MCP_ADMIN_TOKEN = 'test-admin-token-12345';
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MemoryController, ApiKeysController],
+      providers: [
+        {
+          provide: MemoryService,
+          useValue: {},
+        },
+        {
+          provide: ReindexQueueService,
+          useValue: {},
+        },
+        {
+          provide: ConsolidationService,
+          useValue: {},
+        },
+        {
+          provide: ApiKeysService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    const memoryController = module.get<MemoryController>(MemoryController);
+    const apiKeysController = module.get<ApiKeysController>(ApiKeysController);
+
+    // The exact tool set main.ts registers, plus the built-in ping tool the
+    // core registry always adds.
+    const additionalTools = [
+      ...memoryController.getMcpTools(),
+      ...apiKeysController.getMcpTools(),
+    ];
+    registeredTools = [pingTool, ...additionalTools];
+
+    // Register through the real dispatcher and capture the tools/list handler.
+    const server = new Server(
+      { name: 'test', version: '1.0.0' },
+      { capabilities: { tools: {} } },
+    );
+    let listToolsHandler:
+      | ((request: unknown) => Promise<{ tools: AdvertisedTool[] }>)
+      | undefined;
+
+    jest
+      .spyOn(server, 'setRequestHandler')
+      .mockImplementation((schema: unknown, handler: unknown) => {
+        if (getRequestMethod(schema) === 'tools/list') {
+          listToolsHandler = handler as (
+            request: unknown,
+          ) => Promise<{ tools: AdvertisedTool[] }>;
+        }
+      });
+
+    registerTools(server, additionalTools);
+
+    if (!listToolsHandler) {
+      throw new Error('tools/list handler was not registered');
+    }
+    const result = await listToolsHandler({ method: 'tools/list' });
+    advertisedTools = result.tools;
+  });
+
+  afterAll(() => {
+    delete process.env.MCP_ADMIN_TOKEN;
+  });
+
+  const advertised = (name: string): AdvertisedTool => {
+    const tool = advertisedTools.find((t) => t.name === name);
+    if (!tool) {
+      throw new Error(`Tool ${name} was not advertised via tools/list`);
+    }
+    return tool;
+  };
+
+  /** Keys of a Zod object schema that reject an absent (undefined) value. */
+  const trulyRequiredKeys = (schema: z.ZodObject): string[] => {
+    return Object.entries(schema.shape)
+      .filter(([, field]) => !(field as z.ZodType).safeParse(undefined).success)
+      .map(([key]) => key)
+      .sort();
+  };
+
+  it('advertises every registered tool', () => {
+    expect(advertisedTools.map((t) => t.name).sort()).toEqual(
+      registeredTools.map((t) => t.name).sort(),
+    );
+    // Enterprise profile: 1 built-in + 20 memory + 3 api-key tools.
+    expect(advertisedTools).toHaveLength(24);
+  });
+
+  it('every advertised schema is a strict draft-07 object schema', () => {
+    for (const tool of advertisedTools) {
+      expect(tool.inputSchema.type).toBe('object');
+      expect(tool.inputSchema.additionalProperties).toBe(false);
+      expect(tool.inputSchema.$schema).toBe(
+        'http://json-schema.org/draft-07/schema#',
+      );
+    }
+  });
+
+  it('every advertised schema has a property entry for each Zod input key', () => {
+    for (const tool of registeredTools) {
+      expect(tool.inputSchema).toBeInstanceOf(z.ZodObject);
+      const shape = (tool.inputSchema as z.ZodObject).shape;
+      const properties = advertised(tool.name).inputSchema.properties ?? {};
+
+      expect(Object.keys(properties).sort()).toEqual(Object.keys(shape).sort());
+    }
+  });
+
+  it('every advertised schema lists exactly the truly-required keys as required', () => {
+    for (const tool of registeredTools) {
+      const schema = tool.inputSchema as z.ZodObject;
+      const required = advertised(tool.name).inputSchema.required ?? [];
+
+      expect([...required].sort()).toEqual(trulyRequiredKeys(schema));
+    }
+  });
+
+  describe('create_memory regression (issue #205)', () => {
+    it('advertises the enum field `type` in properties and required', () => {
+      const schema = advertised('create_memory').inputSchema;
+
+      expect(schema.properties?.type).toMatchObject({
+        type: 'string',
+        enum: ['short-term', 'long-term'],
+      });
+      expect(schema.required).toContain('type');
+    });
+
+    it('advertises the ZodDefault field `tags` in properties but NOT in required', () => {
+      const schema = advertised('create_memory').inputSchema;
+
+      expect(schema.properties?.tags).toMatchObject({
+        type: 'array',
+        default: [],
+        items: { type: 'string' },
+      });
+      expect(schema.required).not.toContain('tags');
+    });
+
+    it('requires exactly userId, content, and type', () => {
+      const schema = advertised('create_memory').inputSchema;
+
+      expect([...(schema.required ?? [])].sort()).toEqual([
+        'content',
+        'type',
+        'userId',
+      ]);
+    });
+  });
+
+  it('recall advertises its defaulted limit and optional filters correctly', () => {
+    const schema = advertised('recall').inputSchema;
+
+    expect(schema.properties?.limit).toMatchObject({
+      type: 'integer',
+      default: 10,
+    });
+    expect([...(schema.required ?? [])].sort()).toEqual(['query', 'userId']);
+  });
+});

--- a/apps/mcp-server/src/__tests__/tools-list-schema.spec.ts
+++ b/apps/mcp-server/src/__tests__/tools-list-schema.spec.ts
@@ -41,6 +41,8 @@ interface AdvertisedTool {
 describe('tools/list advertised JSON Schemas (wiring, issue #205)', () => {
   let registeredTools: Tool[];
   let advertisedTools: AdvertisedTool[];
+  let originalDeploymentProfile: string | undefined;
+  let originalAdminToken: string | undefined;
 
   /** Extract the request method literal from an SDK zod request schema. */
   const getRequestMethod = (schema: unknown): string | undefined => {
@@ -52,6 +54,11 @@ describe('tools/list advertised JSON Schemas (wiring, issue #205)', () => {
   };
 
   beforeAll(async () => {
+    // Snapshot the pre-existing values so this suite's env mutations can't
+    // leak into other test files run in the same Jest worker process.
+    originalDeploymentProfile = process.env.DEPLOYMENT_PROFILE;
+    originalAdminToken = process.env.MCP_ADMIN_TOKEN;
+
     // Enterprise profile (the default) exposes every tool.
     delete process.env.DEPLOYMENT_PROFILE;
     process.env.MCP_ADMIN_TOKEN = 'test-admin-token-12345';
@@ -118,7 +125,17 @@ describe('tools/list advertised JSON Schemas (wiring, issue #205)', () => {
   });
 
   afterAll(() => {
-    delete process.env.MCP_ADMIN_TOKEN;
+    if (originalDeploymentProfile === undefined) {
+      delete process.env.DEPLOYMENT_PROFILE;
+    } else {
+      process.env.DEPLOYMENT_PROFILE = originalDeploymentProfile;
+    }
+
+    if (originalAdminToken === undefined) {
+      delete process.env.MCP_ADMIN_TOKEN;
+    } else {
+      process.env.MCP_ADMIN_TOKEN = originalAdminToken;
+    }
   });
 
   const advertised = (name: string): AdvertisedTool => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,5 +16,12 @@ export { LoggingModule, REDACT_PATHS } from './logging/logging.module';
 export { McpModule } from './mcp/mcp.module';
 export { McpHandler } from './mcp/mcp.handler';
 export type { McpServerConfig, McpServer, ServerInfo } from './mcp/types';
-export { registerTools, type Tool, type ToolAuthMode, type AuthPolicy } from './mcp/tools/index';
+export {
+  registerTools,
+  zodToJsonSchema,
+  type Tool,
+  type ToolAuthMode,
+  type AuthPolicy,
+  type ToolInputJsonSchema,
+} from './mcp/tools/index';
 export { pingTool } from './mcp/tools/ping.tool';

--- a/packages/core/src/mcp/tools/index.spec.ts
+++ b/packages/core/src/mcp/tools/index.spec.ts
@@ -5,7 +5,8 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { registerTools } from './index';
+import { z } from 'zod';
+import { registerTools, zodToJsonSchema, type Tool } from './index';
 
 describe('MCP Tools Registry', () => {
   let server: Server;
@@ -171,5 +172,225 @@ describe('MCP Tools Registry', () => {
         expect(result).toHaveProperty('isError', true);
       }
     });
+  });
+});
+
+describe('zodToJsonSchema', () => {
+  it('emits draft-07 object schemas', () => {
+    const result = zodToJsonSchema(z.object({ name: z.string() }).strict());
+
+    expect(result['$schema']).toBe('http://json-schema.org/draft-07/schema#');
+    expect(result.type).toBe('object');
+  });
+
+  it('emits properties for string, number, and boolean fields', () => {
+    const result = zodToJsonSchema(
+      z.object({ a: z.string(), b: z.number(), c: z.boolean() }).strict()
+    );
+
+    expect(result['properties']).toMatchObject({
+      a: { type: 'string' },
+      b: { type: 'number' },
+      c: { type: 'boolean' },
+    });
+    expect(result['required']).toEqual(['a', 'b', 'c']);
+  });
+
+  it('emits a property entry for enum fields', () => {
+    const result = zodToJsonSchema(
+      z.object({ type: z.enum(['short-term', 'long-term']) }).strict()
+    );
+
+    const properties = result['properties'] as Record<string, Record<string, unknown>>;
+    expect(properties['type']).toMatchObject({
+      type: 'string',
+      enum: ['short-term', 'long-term'],
+    });
+    expect(result['required']).toEqual(['type']);
+  });
+
+  it('emits a property entry for array fields with item schemas', () => {
+    const result = zodToJsonSchema(
+      z.object({ tags: z.array(z.string().min(1).max(100)).max(50) }).strict()
+    );
+
+    const properties = result['properties'] as Record<string, Record<string, unknown>>;
+    expect(properties['tags']).toMatchObject({
+      type: 'array',
+      maxItems: 50,
+      items: { type: 'string', minLength: 1, maxLength: 100 },
+    });
+    expect(result['required']).toEqual(['tags']);
+  });
+
+  it('emits a property entry for nested object and record fields', () => {
+    const result = zodToJsonSchema(
+      z
+        .object({
+          nested: z.object({ inner: z.string() }).strict(),
+          metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict()
+    );
+
+    const properties = result['properties'] as Record<string, Record<string, unknown>>;
+    expect(properties['nested']).toMatchObject({
+      type: 'object',
+      properties: { inner: { type: 'string' } },
+      required: ['inner'],
+    });
+    expect(properties['metadata']).toMatchObject({ type: 'object' });
+    expect(result['required']).toEqual(['nested']);
+  });
+
+  it('does not list optional fields as required', () => {
+    const result = zodToJsonSchema(
+      z.object({ id: z.string(), scope: z.string().optional() }).strict()
+    );
+
+    const properties = result['properties'] as Record<string, unknown>;
+    expect(properties['scope']).toMatchObject({ type: 'string' });
+    expect(result['required']).toEqual(['id']);
+  });
+
+  // Regression for issue #205: `.optional().default(...)` is a ZodDefault, which
+  // the old converter marked as REQUIRED while omitting it from `properties`.
+  it('keeps ZodDefault fields in properties (with default) and out of required', () => {
+    const result = zodToJsonSchema(
+      z
+        .object({
+          id: z.string(),
+          tags: z.array(z.string()).max(50).optional().default([]),
+          limit: z.coerce.number().int().min(1).max(50).optional().default(10),
+        })
+        .strict()
+    );
+
+    const properties = result['properties'] as Record<string, Record<string, unknown>>;
+    expect(properties['tags']).toMatchObject({ type: 'array', default: [] });
+    expect(properties['limit']).toMatchObject({ type: 'integer', default: 10 });
+    expect(result['required']).toEqual(['id']);
+  });
+
+  it('keeps nullable fields required while allowing null', () => {
+    const result = zodToJsonSchema(z.object({ ref: z.string().nullable() }).strict());
+
+    const properties = result['properties'] as Record<string, Record<string, unknown>>;
+    expect(properties['ref']).toMatchObject({
+      anyOf: [{ type: 'string' }, { type: 'null' }],
+    });
+    expect(result['required']).toEqual(['ref']);
+  });
+
+  it('marks strict object schemas with additionalProperties: false', () => {
+    const result = zodToJsonSchema(z.object({ a: z.string() }).strict());
+
+    expect(result['additionalProperties']).toBe(false);
+  });
+
+  it('converts refined object schemas (refinements are validation-only)', () => {
+    const result = zodToJsonSchema(
+      z
+        .object({ from: z.coerce.date().optional(), to: z.coerce.date().optional() })
+        .strict()
+        .refine((v) => !v.from || !v.to || v.from <= v.to)
+    );
+
+    expect(result.type).toBe('object');
+    const properties = result['properties'] as Record<string, unknown>;
+    expect(Object.keys(properties)).toEqual(['from', 'to']);
+    expect(result['required']).toBeUndefined();
+  });
+
+  it('falls back to a plain object schema for non-object inputs', () => {
+    expect(zodToJsonSchema(z.string())).toEqual({ type: 'object' });
+  });
+});
+
+describe('tools/list advertised schemas (wiring)', () => {
+  // Mirrors the shape of create_memory's input schema, including the
+  // enum + `.optional().default([])` fields from issue #205.
+  const createMemoryLikeSchema = z
+    .object({
+      userId: z.string().min(1),
+      content: z.string().min(1).max(10240),
+      type: z.enum(['short-term', 'long-term']),
+      scope: z.string().min(1).max(256).optional(),
+      metadata: z.record(z.string(), z.unknown()).optional(),
+      tags: z.array(z.string().min(1).max(100)).max(50).optional().default([]),
+      ttl: z.coerce.number().int().min(60).max(604800).optional(),
+    })
+    .strict();
+
+  const createMemoryLikeTool: Tool = {
+    name: 'create_memory_like',
+    description: 'Tool with an enum and a defaulted array field',
+    inputSchema: createMemoryLikeSchema,
+    handler: async () => ({ ok: true }),
+  };
+
+  const listToolsVia = async (tools: Tool[]): Promise<any[]> => {
+    const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: { tools: {} } });
+    let listToolsHandler: ((request: any) => Promise<any>) | undefined;
+
+    vi.spyOn(server, 'setRequestHandler').mockImplementation((schema: any, handler: any) => {
+      const method = (schema as { def?: { shape?: { method?: { def?: { values?: string[] } } } } })
+        ?.def?.shape?.method?.def?.values?.[0];
+      if (method === 'tools/list') {
+        listToolsHandler = handler;
+      }
+    });
+
+    registerTools(server, tools);
+
+    expect(listToolsHandler).toBeDefined();
+    const result = await listToolsHandler!({ method: 'tools/list' });
+    return result.tools;
+  };
+
+  it('advertises every Zod key in properties and only truly-required keys in required', async () => {
+    const tools = await listToolsVia([createMemoryLikeTool]);
+    const advertised = tools.find((tool) => tool.name === 'create_memory_like');
+
+    expect(advertised).toBeDefined();
+    expect(advertised.inputSchema.type).toBe('object');
+
+    // Every key of the Zod object shape must have a property entry.
+    expect(Object.keys(advertised.inputSchema.properties).sort()).toEqual(
+      Object.keys(createMemoryLikeSchema.shape).sort()
+    );
+
+    // `required` must list exactly the keys that reject an absent value.
+    const expectedRequired = Object.entries(createMemoryLikeSchema.shape)
+      .filter(([, field]) => !(field as z.ZodType).safeParse(undefined).success)
+      .map(([key]) => key)
+      .sort();
+    expect([...advertised.inputSchema.required].sort()).toEqual(expectedRequired);
+    expect(expectedRequired).toEqual(['content', 'type', 'userId']);
+  });
+
+  it('advertises the enum field and the defaulted array field correctly (issue #205)', async () => {
+    const tools = await listToolsVia([createMemoryLikeTool]);
+    const advertised = tools.find((tool) => tool.name === 'create_memory_like');
+
+    expect(advertised.inputSchema.properties.type).toMatchObject({
+      type: 'string',
+      enum: ['short-term', 'long-term'],
+    });
+    expect(advertised.inputSchema.properties.tags).toMatchObject({
+      type: 'array',
+      default: [],
+    });
+    expect(advertised.inputSchema.required).not.toContain('tags');
+    expect(advertised.inputSchema.required).toContain('type');
+  });
+
+  it('advertises strict schemas with additionalProperties: false end-to-end', async () => {
+    const tools = await listToolsVia([createMemoryLikeTool]);
+
+    for (const tool of tools) {
+      expect(tool.inputSchema.type).toBe('object');
+      expect(tool.inputSchema.additionalProperties).toBe(false);
+    }
   });
 });

--- a/packages/core/src/mcp/tools/index.ts
+++ b/packages/core/src/mcp/tools/index.ts
@@ -84,46 +84,45 @@ function schemaAcceptsUserId(schema: z.ZodSchema): boolean {
 const builtInTools: Tool[] = [pingTool];
 
 /**
- * Convert Zod schema to JSON Schema format for MCP
+ * JSON Schema advertised for a tool's input via `tools/list`. MCP requires
+ * the top level to be an object schema (`"type": "object"`); everything else
+ * (properties, required, additionalProperties, $schema, …) is draft-07.
  */
-function zodToJsonSchema(schema: z.ZodSchema): {
-  type: 'object';
-  properties?: Record<string, unknown>;
-  required?: string[];
-} {
-  // For now, handle simple object schemas
-  // This is a basic implementation - can be extended later
-  if (schema instanceof z.ZodObject) {
-    const shape = schema.shape;
-    const properties: Record<string, unknown> = {};
-    const required: string[] = [];
+export type ToolInputJsonSchema = { type: 'object' } & Record<string, unknown>;
 
-    for (const [key, value] of Object.entries(shape)) {
-      if (value instanceof z.ZodString) {
-        properties[key] = { type: 'string' };
-      } else if (value instanceof z.ZodNumber) {
-        properties[key] = { type: 'number' };
-      } else if (value instanceof z.ZodBoolean) {
-        properties[key] = { type: 'boolean' };
-      }
+/**
+ * Convert a tool's Zod input schema to the JSON Schema (draft-07) shape
+ * advertised to MCP clients via `tools/list`.
+ *
+ * Uses Zod v4's native `z.toJSONSchema()` so every construct tools actually
+ * use — enums, arrays, nested objects/records, `.default()`, `.nullable()`,
+ * `.optional()`, coerced numbers — produces a correct `properties` entry and
+ * an accurate `required` list. (The previous hand-rolled converter only
+ * emitted string/number/boolean properties and marked `ZodDefault` fields as
+ * required while omitting them from `properties`.)
+ */
+export function zodToJsonSchema(schema: z.ZodSchema): ToolInputJsonSchema {
+  const jsonSchema = z.toJSONSchema(schema, {
+    // MCP clients broadly understand draft-07.
+    target: 'draft-7',
+    // Describe what the *client sends*: a field with `.default()` is always
+    // present in the parsed output but optional on input, so it must appear
+    // in `properties` (with its default) and must NOT be listed in `required`.
+    io: 'input',
+    // Inputs with no JSON representation (e.g. `z.coerce.date()`) degrade to
+    // an unconstrained `{}` property instead of throwing; server-side Zod
+    // validation still enforces the real constraints on every call.
+    unrepresentable: 'any',
+  }) as Record<string, unknown>;
 
-      // Check if field is required (not optional)
-      if (!(value instanceof z.ZodOptional)) {
-        required.push(key);
-      }
-    }
-
-    return {
-      type: 'object',
-      properties: Object.keys(properties).length > 0 ? properties : undefined,
-      required: required.length > 0 ? required : undefined,
-    };
+  if (jsonSchema['type'] !== 'object') {
+    // MCP tool input schemas must be object-typed at the top level. All tools
+    // use `z.object(...).strict()`, so this is a defensive fallback for
+    // non-object schemas rather than advertising an invalid shape.
+    return { type: 'object' };
   }
 
-  // Default for empty schemas
-  return {
-    type: 'object',
-  };
+  return jsonSchema as ToolInputJsonSchema;
 }
 
 /**


### PR DESCRIPTION
## Problem

Found in the 2026-07-02 security review (MCP-tools finding #6). The hand-rolled `zodToJsonSchema` in `packages/core/src/mcp/tools/index.ts` only emitted `properties` entries for `ZodString`/`ZodNumber`/`ZodBoolean`, and computed `required` as `!(value instanceof z.ZodOptional)`. Consequences in the advertised `tools/list` response:

- Enums, arrays, records, and nested objects had **no property entry** at all.
- `.optional().default(...)` fields (`ZodDefault`) were marked **required** while absent from `properties` — e.g. `create_memory` advertised `type` and `tags` as required without describing either.

Spec-compliant MCP clients relying on `tools/list` could reject valid calls or send wrong shapes. Server-side Zod validation was never affected — this is a correctness fix for the advertised schemas only.

## Fix

- Replaced the hand-rolled converter with **Zod v4's native `z.toJSONSchema()`** (the repo is on `zod@4.4.3`; the `zod-to-json-schema` package suggested in the issue targets Zod v3 internals and does not apply), configured with:
  - `target: 'draft-7'` — draft-07, broadly MCP-client compatible;
  - `io: 'input'` — describes what the **client sends**, so defaulted fields appear in `properties` (with their `default`) and are correctly excluded from `required`;
  - `unrepresentable: 'any'` — JSON-unrepresentable inputs (e.g. `z.coerce.date()`) degrade to a permissive property instead of throwing; runtime Zod validation still enforces the real constraints.
- Non-object schemas defensively fall back to `{ type: 'object' }` (MCP requires object-typed tool input schemas).
- `.strict()` schemas now advertise `additionalProperties: false`; enums, arrays, records, nested objects, nullable, and coerced numbers all produce correct entries.
- Exported `zodToJsonSchema` / `ToolInputJsonSchema` from `@engram/core` for reuse and testing.

## Tests

**Service/unit level** (`packages/core/src/mcp/tools/index.spec.ts`, vitest — 49 passing):
- Converter unit tests: string/number/boolean parity, enum, array (with item constraints), nested object + record, optional, nullable, coerced numbers, strict `additionalProperties`, refined schemas, non-object fallback, draft-07 marker.
- **ZodDefault regression test**: `.optional().default(...)` fields stay in `properties` (with `default`) and out of `required`.
- Wiring tests through `registerTools`: the captured `tools/list` handler advertises a property entry for every Zod key and an exact `required` list for a `create_memory`-shaped tool.

**Wiring/parent level** (`apps/mcp-server/src/__tests__/tools-list-schema.spec.ts`, jest — 8 passing):
- Registers the **full production tool set** (20 memory tools + 3 API-key tools + built-in ping) through the real `@engram/core` registry and invokes the captured `tools/list` handler end-to-end.
- For **every** advertised tool: object-typed strict draft-07 schema, a property entry for each Zod input key, and `required` equal to exactly the keys that reject an absent value.
- `create_memory` regression: `type` advertised as a required enum; `tags` advertised with `default: []` and **not** required; `required` is exactly `userId`/`content`/`type`. Plus `recall`'s defaulted `limit`.

Quality gates: `pnpm build`, `pnpm --filter @engram/core build|lint|test`, `pnpm --filter mcp-server build|lint|test` (499 passed, 2 skipped), `pnpm typecheck` — all green.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)