### PR TITLE
fix(mcp): opt-in admin delegation for cross-tenant console access (#200)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,8 +105,12 @@ LOG_LEVEL=debug
 # the live health view. Omit it and the console still works read-only over
 # Postgres (keyword search, no writes).
 # ENGRAM_MCP_URL=http://localhost:3000
-# Service API key (memories:read/write/delete scopes) used for MCP writes/recall
-# when the MCP server has AUTH_REQUIRED=true. Mint one with create_api_key.
+# Service API key used for MCP writes/recall when the MCP server has
+# AUTH_REQUIRED=true. Mint one with create_api_key. To manage EVERY data owner
+# from the console the key must carry the `admin` scope (delegated mode); a
+# key with only memories:read/write/delete is pinned to its own tenant, so
+# writes and semantic search work for that single owner only (the console's
+# Settings page surfaces this limitation).
 # ENGRAM_API_KEY=eng_...
 
 # NextAuth.js v5 (Auth.js). AUTH_SECRET is required at runtime — generate with

--- a/apps/mcp-server/src/api-keys/api-keys.controller.spec.ts
+++ b/apps/mcp-server/src/api-keys/api-keys.controller.spec.ts
@@ -76,6 +76,18 @@ describe('ApiKeysController', () => {
         expect(typeof tool.handler).toBe('function');
       }
     });
+
+    it('never marks the identity-mode key-management tools delegable (#200)', () => {
+      // Delegation is opt-in; these destructive credential tools must stay
+      // pinned to the caller's own tenant so an admin key cannot list or revoke
+      // another tenant's API keys by passing a foreign userId.
+      const tools = controller.getMcpTools();
+      for (const name of ['list_api_keys', 'revoke_api_key']) {
+        const tool = tools.find((t) => t.name === name);
+        expect(tool).toBeDefined();
+        expect(tool?.delegable).not.toBe(true);
+      }
+    });
   });
 
   describe('createApiKey', () => {

--- a/apps/mcp-server/src/memory/mcp-delegation-wiring.spec.ts
+++ b/apps/mcp-server/src/memory/mcp-delegation-wiring.spec.ts
@@ -60,8 +60,9 @@ describe('MCP delegation wiring — real memory tools (#200)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    process.env.MCP_ADMIN_TOKEN = 'test-admin-token-12345';
-
+    // No MCP_ADMIN_TOKEN is set here: this spec only exercises identity-mode
+    // tools (recall/update_memory/delete_memory), which never read it — so we
+    // avoid mutating (and leaking) shared process.env across jest files.
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MemoryController],
       providers: [

--- a/apps/mcp-server/src/memory/mcp-delegation-wiring.spec.ts
+++ b/apps/mcp-server/src/memory/mcp-delegation-wiring.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Wiring test for issue #200: binds the delegation security contract to the
+ * REAL identity-mode memory tools (`recall`/`update_memory`/`delete_memory`),
+ * not a synthetic echo tool. The core dispatch tests prove the mechanism; this
+ * proves the mechanism is wired to the tools that matter. It guards against a
+ * refactor that would silently regress tenant isolation with every other test
+ * still green — e.g. setting `auth: 'admin'` on recall, dropping `delegable`,
+ * or nesting/renaming `userId` in a DTO so the dispatch stops injecting it.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { registerTools, type Tool } from '@engram/core';
+import { MemoryController } from './memory.controller';
+import { MemoryService } from './memory.service';
+import { ReindexQueueService } from './reindex-queue.service';
+import { ConsolidationService } from './consolidation.service';
+
+// Two distinct, valid CUIDs (userIdSchema accepts cuid()/cuid2()); arbitrary
+// strings like 'other-tenant' would fail the real recall schema's validation.
+const KEY_TENANT = 'cjld2cjxh0000qzrmn831i7rn';
+const OTHER_TENANT = 'cjld2cyuq0000t3rmniod1foy';
+
+type CallRequest = {
+  method: string;
+  params: { name: string; arguments?: unknown };
+};
+type CallExtra = {
+  authInfo?: { scopes?: string[]; extra?: Record<string, unknown> };
+};
+type CallResult = { content: Array<{ text: string }>; isError?: boolean };
+type CallHandler = (
+  request: CallRequest,
+  extra?: CallExtra,
+) => Promise<CallResult>;
+
+const getRequestMethod = (schema: unknown): string | undefined =>
+  (schema as { def?: { shape?: { method?: { def?: { values?: string[] } } } } })
+    ?.def?.shape?.method?.def?.values?.[0];
+
+describe('MCP delegation wiring — real memory tools (#200)', () => {
+  let controller: MemoryController;
+
+  const mockMemoryService = {
+    createMemory: jest.fn(),
+    getMemory: jest.fn(),
+    listMemories: jest.fn(),
+    updateMemory: jest.fn(),
+    deleteMemory: jest.fn(),
+    promoteMemory: jest.fn(),
+    recall: jest.fn(),
+    reindex: jest.fn(),
+  };
+  const mockReindexQueueService = {
+    enqueue: jest.fn(),
+    get: jest.fn(),
+    cancel: jest.fn(),
+    retry: jest.fn(),
+  };
+  const mockConsolidationService = { run: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    process.env.MCP_ADMIN_TOKEN = 'test-admin-token-12345';
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MemoryController],
+      providers: [
+        { provide: MemoryService, useValue: mockMemoryService },
+        { provide: ReindexQueueService, useValue: mockReindexQueueService },
+        { provide: ConsolidationService, useValue: mockConsolidationService },
+      ],
+    }).compile();
+
+    controller = module.get<MemoryController>(MemoryController);
+  });
+
+  const tool = (name: string): Tool => {
+    const found = controller.getMcpTools().find((t) => t.name === name);
+    if (!found) throw new Error(`tool ${name} not registered`);
+    return found;
+  };
+
+  describe('metadata contract', () => {
+    it.each(['recall', 'update_memory', 'delete_memory'])(
+      '%s is identity-mode and opts into delegation',
+      (name) => {
+        const t = tool(name);
+        // Identity mode (the default): the tenant boundary is the token, not the
+        // request body. If this ever became 'admin', a client-supplied userId
+        // would pass through untouched for EVERY principal — a cross-tenant leak.
+        expect(t.auth ?? 'identity').toBe('identity');
+        // Opted into delegation so an admin-scoped operator console can act on
+        // behalf of any data owner. Dropping this silently re-pins the console.
+        expect(t.delegable).toBe(true);
+      },
+    );
+  });
+
+  describe('end-to-end delegation through registerTools', () => {
+    const capture = (t: Tool): CallHandler => {
+      const server = new Server(
+        { name: 'wiring', version: '0.0.0' },
+        { capabilities: { tools: {} } },
+      );
+      let captured: CallHandler | undefined;
+      jest
+        .spyOn(server, 'setRequestHandler')
+        .mockImplementation((schema, fn): void => {
+          if (getRequestMethod(schema) === 'tools/call') {
+            captured = fn as unknown as CallHandler;
+          }
+        });
+      registerTools(server, [t], { required: true });
+      if (!captured) throw new Error('tools/call handler was not registered');
+      return captured;
+    };
+
+    it('honours an admin-scoped key delegating recall to another tenant', async () => {
+      mockMemoryService.recall.mockResolvedValue([]);
+      const call = capture(tool('recall'));
+      await call(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'recall',
+            arguments: { userId: OTHER_TENANT, query: 'hi' },
+          },
+        },
+        { authInfo: { scopes: ['admin'], extra: { userId: KEY_TENANT } } },
+      );
+      expect(mockMemoryService.recall).toHaveBeenCalledWith(
+        OTHER_TENANT,
+        'hi',
+        expect.anything(),
+      );
+    });
+
+    it('pins a non-admin key back to its own tenant on recall', async () => {
+      // This is the load-bearing assertion: it only holds if the dispatch both
+      // DETECTS recall's userId schema and OVERWRITES the forged tenant. A
+      // refactor that broke either would surface the client's OTHER_TENANT here.
+      mockMemoryService.recall.mockResolvedValue([]);
+      const call = capture(tool('recall'));
+      await call(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'recall',
+            arguments: { userId: OTHER_TENANT, query: 'hi' },
+          },
+        },
+        {
+          authInfo: {
+            scopes: ['memories:read'],
+            extra: { userId: KEY_TENANT },
+          },
+        },
+      );
+      expect(mockMemoryService.recall).toHaveBeenCalledWith(
+        KEY_TENANT,
+        'hi',
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -1138,6 +1138,9 @@ export class MemoryController {
         name: 'update_memory',
         description: 'Update existing memory',
         inputSchema: updateMemoryToolSchema,
+        // Delegable: an admin-scoped key (the operator console) may edit any
+        // data owner's memory by passing an explicit userId (#200).
+        delegable: true,
         handler: this.updateMemory.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -1146,6 +1149,9 @@ export class MemoryController {
         name: 'delete_memory',
         description: 'Delete memory by ID',
         inputSchema: getMemoryToolSchema, // Reuse get_memory schema
+        // Delegable: an admin-scoped key (the operator console) may delete any
+        // data owner's memory by passing an explicit userId (#200).
+        delegable: true,
         handler: this.deleteMemory.bind(this) as (
           input: unknown,
         ) => Promise<unknown>,
@@ -1163,6 +1169,9 @@ export class MemoryController {
         description:
           'Semantically recall the most relevant long-term memories for a natural-language query',
         inputSchema: recallToolSchema,
+        // Delegable: an admin-scoped key (the operator console) may run semantic
+        // search on behalf of any data owner by passing an explicit userId (#200).
+        delegable: true,
         handler: this.recall.bind(this) as (input: unknown) => Promise<unknown>,
       },
       {

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -24,6 +24,16 @@ The dashboard talks to the ENGRAM backend through a single, mockable seam,
   endpoint, so the derived vector index stays in sync (a raw Prisma write would
   desync Qdrant/pgvector). Configure `ENGRAM_MCP_URL` to enable these; without
   it the console runs read-only with keyword search.
+
+  When the MCP server enforces auth (`AUTH_REQUIRED=true`), set
+  `ENGRAM_API_KEY`. The key's scopes decide how far the console reaches: an
+  **admin-scoped key** may act on behalf of any data owner (the MCP dispatcher
+  honours the console-supplied `userId` — delegated mode, audited server-side),
+  while a non-admin key is pinned to its own tenant, so writes and semantic
+  search only work for that single owner. `meta.capabilities` reports the
+  detected mode (`delegation`: `admin` / `tenant-limited` / `unrestricted` /
+  `unknown`) and the Settings page shows a warning when the console is
+  tenant-limited.
 - **Health & metrics — the MCP server HTTP endpoints** (`/health`,
   `/health/metrics`).
 

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -101,6 +101,20 @@ export default function SettingsPage() {
                   label="Semantic search (recall)"
                 />
                 <Capability ok={capabilities.data.writes} label="Edit & delete memories" />
+                {capabilities.data.mcpConfigured && (
+                  <Capability
+                    ok={
+                      capabilities.data.delegation === 'admin' ||
+                      capabilities.data.delegation === 'unrestricted'
+                    }
+                    label="Cross-tenant writes & search"
+                  />
+                )}
+                {capabilities.data.limitation && (
+                  <p className="pt-1 text-xs text-[var(--warning)]">
+                    {capabilities.data.limitation}
+                  </p>
+                )}
                 {!capabilities.data.mcpConfigured && (
                   <p className="pt-1 text-xs text-muted-foreground">
                     Set <code className="font-mono">ENGRAM_MCP_URL</code> to enable semantic search

--- a/apps/web/server/backend/prisma-backend.test.ts
+++ b/apps/web/server/backend/prisma-backend.test.ts
@@ -52,20 +52,23 @@ function mockFetch(responses: Record<string, { ok?: boolean; json?: unknown; tex
 }
 
 describe('PrismaEngramBackend.capabilities', () => {
-  it('reports disabled writes when no MCP client', () => {
+  it('reports disabled writes when no MCP client', async () => {
     const backend = new PrismaEngramBackend({
       prisma: makePrisma(),
       mcpUrl: null,
       mcpApiKey: null,
     });
-    expect(backend.capabilities()).toEqual({
+    await expect(backend.capabilities()).resolves.toEqual({
       writes: false,
       semanticSearch: false,
       mcpConfigured: false,
+      delegation: 'unknown',
+      keyTenant: null,
+      limitation: null,
     });
   });
 
-  it('reports enabled capabilities when an MCP client is present', () => {
+  it('reports enabled capabilities when an MCP client is present', async () => {
     const mcp = { call: vi.fn() } as unknown as McpToolClient;
     const backend = new PrismaEngramBackend({
       prisma: makePrisma(),
@@ -73,7 +76,130 @@ describe('PrismaEngramBackend.capabilities', () => {
       mcpApiKey: null,
       mcpClient: mcp,
     });
-    expect(backend.capabilities().writes).toBe(true);
+    await expect(backend.capabilities()).resolves.toMatchObject({ writes: true });
+  });
+
+  it('reports unrestricted delegation with a precondition caveat when no API key is configured', async () => {
+    const mcp = { call: vi.fn() } as unknown as McpToolClient;
+    const backend = new PrismaEngramBackend({
+      prisma: makePrisma(),
+      mcpUrl: 'http://localhost:3000',
+      mcpApiKey: null,
+      mcpClient: mcp,
+    });
+    const caps = await backend.capabilities();
+    expect(caps.delegation).toBe('unrestricted');
+    expect(caps.keyTenant).toBeNull();
+    // The keyless-but-configured case only works against an auth-disabled
+    // server; the console cannot verify that, so it surfaces the caveat rather
+    // than a bare green light.
+    expect(caps.limitation).toContain('ENGRAM_API_KEY');
+    expect(caps.limitation).toContain('auth disabled');
+  });
+
+  it('reports admin delegation when the key holds the admin scope', async () => {
+    const fetchImpl = mockFetch({
+      '/auth/me': { json: { user: { userId: 'svc', scopes: ['admin'] } } },
+    });
+    const mcp = { call: vi.fn() } as unknown as McpToolClient;
+    const backend = new PrismaEngramBackend({
+      prisma: makePrisma(),
+      mcpUrl: 'http://localhost:3000',
+      mcpApiKey: 'eng_admin',
+      mcpClient: mcp,
+      fetchImpl,
+    });
+    await expect(backend.capabilities()).resolves.toMatchObject({
+      delegation: 'admin',
+      keyTenant: 'svc',
+      limitation: null,
+    });
+  });
+
+  it('reports tenant-limited delegation with a warning for a non-admin key', async () => {
+    const fetchImpl = mockFetch({
+      '/auth/me': {
+        json: {
+          user: { userId: 'svc', scopes: ['memories:read', 'memories:write', 'memories:delete'] },
+        },
+      },
+    });
+    const mcp = { call: vi.fn() } as unknown as McpToolClient;
+    const backend = new PrismaEngramBackend({
+      prisma: makePrisma(),
+      mcpUrl: 'http://localhost:3000',
+      mcpApiKey: 'eng_service',
+      mcpClient: mcp,
+      fetchImpl,
+    });
+    const caps = await backend.capabilities();
+    expect(caps.delegation).toBe('tenant-limited');
+    expect(caps.keyTenant).toBe('svc');
+    expect(caps.limitation).toContain('limited to the API key');
+    expect(caps.limitation).toContain('"svc"');
+  });
+
+  it('reports unknown delegation with a warning when /auth/me is unreachable', async () => {
+    const fetchImpl = mockFetch({}); // every path 404s
+    const mcp = { call: vi.fn() } as unknown as McpToolClient;
+    const backend = new PrismaEngramBackend({
+      prisma: makePrisma(),
+      mcpUrl: 'http://localhost:3000',
+      mcpApiKey: 'eng_service',
+      mcpClient: mcp,
+      fetchImpl,
+    });
+    const caps = await backend.capabilities();
+    expect(caps.delegation).toBe('unknown');
+    expect(caps.limitation).toContain('Could not verify');
+  });
+
+  it('caches a successful delegation probe but retries after unknown', async () => {
+    const okFetch = mockFetch({
+      '/auth/me': { json: { user: { userId: 'svc', scopes: ['admin'] } } },
+    });
+    const cachedBackend = new PrismaEngramBackend({
+      prisma: makePrisma(),
+      mcpUrl: 'http://localhost:3000',
+      mcpApiKey: 'eng_admin',
+      mcpClient: { call: vi.fn() } as unknown as McpToolClient,
+      fetchImpl: okFetch,
+    });
+    await cachedBackend.capabilities();
+    await cachedBackend.capabilities();
+    expect(okFetch).toHaveBeenCalledTimes(1);
+
+    const failFetch = mockFetch({});
+    const retryBackend = new PrismaEngramBackend({
+      prisma: makePrisma(),
+      mcpUrl: 'http://localhost:3000',
+      mcpApiKey: 'eng_admin',
+      mcpClient: { call: vi.fn() } as unknown as McpToolClient,
+      fetchImpl: failFetch,
+    });
+    await retryBackend.capabilities();
+    await retryBackend.capabilities();
+    expect(failFetch).toHaveBeenCalledTimes(2); // 'unknown' is never cached
+  });
+
+  it('re-probes once the delegation cache TTL has elapsed', async () => {
+    const okFetch = mockFetch({
+      '/auth/me': { json: { user: { userId: 'svc', scopes: ['admin'] } } },
+    });
+    const backend = new PrismaEngramBackend({
+      prisma: makePrisma(),
+      mcpUrl: 'http://localhost:3000',
+      mcpApiKey: 'eng_admin',
+      mcpClient: { call: vi.fn() } as unknown as McpToolClient,
+      fetchImpl: okFetch,
+      // TTL 0 means a cached result is always considered stale, so every
+      // capabilities() call must re-probe — proving the TTL check is load-bearing
+      // (a cache-that-never-expires bug would serve the first result and fail).
+      delegationCacheTtlMs: 0,
+    });
+    await backend.capabilities();
+    await backend.capabilities();
+    expect(okFetch).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/apps/web/server/backend/prisma-backend.ts
+++ b/apps/web/server/backend/prisma-backend.ts
@@ -12,6 +12,7 @@ import {
   type ListMemoriesResult,
   type MemoryDTO,
   type MemoryOwner,
+  type McpDelegationMode,
   type MemoryStats,
   type MemoryType,
   type MetricSnapshot,
@@ -91,6 +92,15 @@ interface PrismaBackendOptions {
   /** Injectable MCP client + fetch for testing; defaults derive from mcpUrl. */
   mcpClient?: McpToolClient | null;
   fetchImpl?: typeof fetch;
+  /** How long a resolved API-key delegation probe stays cached (ms). */
+  delegationCacheTtlMs?: number;
+}
+
+/** Resolved API-key access facts surfaced through `capabilities()`. */
+interface DelegationInfo {
+  mode: McpDelegationMode;
+  keyTenant: string | null;
+  limitation: string | null;
 }
 
 export class PrismaEngramBackend implements EngramBackend {
@@ -100,6 +110,8 @@ export class PrismaEngramBackend implements EngramBackend {
   private readonly mcp: McpToolClient | null;
   private readonly httpTimeoutMs: number;
   private readonly fetchImpl: typeof fetch;
+  private readonly delegationCacheTtlMs: number;
+  private delegationCache: { resolvedAt: number; info: DelegationInfo } | null = null;
 
   constructor(options: PrismaBackendOptions) {
     this.prisma = options.prisma;
@@ -112,11 +124,97 @@ export class PrismaEngramBackend implements EngramBackend {
         ? new McpToolClient({ baseUrl: options.mcpUrl, apiKey: options.mcpApiKey })
         : null);
     this.fetchImpl = options.fetchImpl ?? ((...args) => fetch(...args));
+    this.delegationCacheTtlMs = options.delegationCacheTtlMs ?? 60_000;
   }
 
-  capabilities(): BackendCapabilities {
+  async capabilities(): Promise<BackendCapabilities> {
     const configured = this.mcp !== null;
-    return { writes: configured, semanticSearch: configured, mcpConfigured: configured };
+    const delegation = configured
+      ? await this.resolveDelegation()
+      : { mode: 'unknown' as const, keyTenant: null, limitation: null };
+    return {
+      writes: configured,
+      semanticSearch: configured,
+      mcpConfigured: configured,
+      delegation: delegation.mode,
+      keyTenant: delegation.keyTenant,
+      limitation: delegation.limitation,
+    };
+  }
+
+  /**
+   * Work out whether the configured MCP credential can act on behalf of any
+   * data owner. The MCP server pins identity-mode tools (`recall`,
+   * `update_memory`, `delete_memory`) to the API key's own tenant unless the
+   * key holds the `admin` scope, so a non-admin key silently limits the whole
+   * console to a single owner — surface that instead of letting searches come
+   * back empty and writes fail as "not found".
+   *
+   * The key's scopes are resolved via `GET /auth/me` and cached briefly so
+   * `capabilities()` stays cheap.
+   */
+  private async resolveDelegation(): Promise<DelegationInfo> {
+    if (!this.mcpApiKey) {
+      // No credential is attached: the server sees anonymous calls and uses the
+      // request's userId as-is. That only works when the MCP server runs with
+      // auth disabled; if it enforces auth (AUTH_REQUIRED=true) every write and
+      // recall is rejected. We cannot tell the two apart from here (an anonymous
+      // /auth/me 401s either way), so surface the precondition instead of an
+      // unconditional green light.
+      return {
+        mode: 'unrestricted',
+        keyTenant: null,
+        limitation:
+          'No ENGRAM_API_KEY is set — cross-tenant writes and semantic search work only if the ENGRAM server runs with auth disabled. If it enforces auth, writes and recall will fail; set an admin-scoped ENGRAM_API_KEY to manage data owners securely.',
+      };
+    }
+
+    const cached = this.delegationCache;
+    if (cached && Date.now() - cached.resolvedAt < this.delegationCacheTtlMs) {
+      return cached.info;
+    }
+
+    const info = await this.probeDelegation();
+    // Never cache 'unknown' — a briefly unreachable server should not stick.
+    if (info.mode !== 'unknown') {
+      this.delegationCache = { resolvedAt: Date.now(), info };
+    }
+    return info;
+  }
+
+  private async probeDelegation(): Promise<DelegationInfo> {
+    const unknown: DelegationInfo = {
+      mode: 'unknown',
+      keyTenant: null,
+      limitation:
+        "Could not verify the ENGRAM_API_KEY scopes — cross-tenant writes and semantic search may be limited to the key's own tenant.",
+    };
+
+    const res = await this.fetchMcp('/auth/me');
+    if (!res || !res.ok) return unknown;
+
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      return unknown;
+    }
+    const user = (body as { user?: { userId?: unknown; scopes?: unknown } } | null)?.user;
+    const keyTenant = typeof user?.userId === 'string' ? user.userId : null;
+    const scopes = Array.isArray(user?.scopes)
+      ? user.scopes.filter((s): s is string => typeof s === 'string')
+      : [];
+
+    if (scopes.includes('admin')) {
+      return { mode: 'admin', keyTenant, limitation: null };
+    }
+    return {
+      mode: 'tenant-limited',
+      keyTenant,
+      limitation: `Writes and semantic search are limited to the API key's own tenant${
+        keyTenant ? ` ("${keyTenant}")` : ''
+      }. Use an admin-scoped ENGRAM_API_KEY to manage other data owners.`,
+    };
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/web/server/backend/types.ts
+++ b/apps/web/server/backend/types.ts
@@ -172,15 +172,40 @@ export interface MemoryOwner {
   lastActivityAt: string | null;
 }
 
+/**
+ * How the configured MCP credential maps dashboard requests onto data owners:
+ *  - `admin`: the API key holds the `admin` scope — the MCP server honours the
+ *    dashboard-supplied `userId` on the delegable memory tools
+ *    (`recall`/`update_memory`/`delete_memory`), so cross-tenant writes and
+ *    semantic search work for every owner in the scope switcher.
+ *  - `tenant-limited`: a non-admin key — the MCP server rewrites `userId` to
+ *    the key's own tenant, so writes/search only work for that single owner.
+ *  - `unrestricted`: no API key is sent; the server accepts the supplied
+ *    `userId` as-is (only viable against a server with auth disabled).
+ *  - `unknown`: no MCP server configured, or the key's scopes could not be
+ *    resolved (server unreachable or the credential was rejected).
+ */
+export type McpDelegationMode = 'admin' | 'tenant-limited' | 'unrestricted' | 'unknown';
+
 export interface BackendCapabilities {
   /** True when an MCP server is configured for writes + recall. */
   writes: boolean;
   semanticSearch: boolean;
   mcpConfigured: boolean;
+  /** See {@link McpDelegationMode}. */
+  delegation: McpDelegationMode;
+  /**
+   * The data owner the configured API key is bound to, when resolved (`admin`
+   * and `tenant-limited` modes); null otherwise. Exposed for programmatic tRPC
+   * consumers and diagnostics — the Settings UI surfaces it via `limitation`.
+   */
+  keyTenant: string | null;
+  /** Operator-facing warning when cross-tenant writes/search will not work. */
+  limitation: string | null;
 }
 
 export interface EngramBackend {
-  capabilities(): BackendCapabilities;
+  capabilities(): Promise<BackendCapabilities>;
 
   listMemories(params: ListMemoriesParams): Promise<ListMemoriesResult>;
   getMemory(userId: string, memoryId: string): Promise<MemoryDTO | null>;

--- a/apps/web/server/trpc/routers/routers.test.ts
+++ b/apps/web/server/trpc/routers/routers.test.ts
@@ -7,9 +7,14 @@ import { createCaller } from '../root';
 
 function makeBackend(overrides: Partial<EngramBackend> = {}): EngramBackend {
   return {
-    capabilities: vi
-      .fn()
-      .mockReturnValue({ writes: true, semanticSearch: true, mcpConfigured: true }),
+    capabilities: vi.fn().mockResolvedValue({
+      writes: true,
+      semanticSearch: true,
+      mcpConfigured: true,
+      delegation: 'admin',
+      keyTenant: null,
+      limitation: null,
+    }),
     listMemories: vi
       .fn()
       .mockResolvedValue({ items: [], totalCount: 0, nextCursor: null, hasMore: false }),
@@ -104,9 +109,34 @@ describe('health + analytics + meta routers', () => {
     await expect(api.health.status()).resolves.toMatchObject({ status: 'ok' });
   });
 
-  it('returns capabilities', async () => {
+  it('returns capabilities including the delegation mode', async () => {
     const api = caller(makeBackend());
-    await expect(api.meta.capabilities()).resolves.toMatchObject({ writes: true });
+    await expect(api.meta.capabilities()).resolves.toMatchObject({
+      writes: true,
+      delegation: 'admin',
+      limitation: null,
+    });
+  });
+
+  it('surfaces the tenant-limited warning for a non-admin key', async () => {
+    const api = caller(
+      makeBackend({
+        capabilities: vi.fn().mockResolvedValue({
+          writes: true,
+          semanticSearch: true,
+          mcpConfigured: true,
+          delegation: 'tenant-limited',
+          keyTenant: 'svc',
+          limitation:
+            'Writes and semantic search are limited to the API key\'s own tenant ("svc").',
+        }),
+      })
+    );
+    await expect(api.meta.capabilities()).resolves.toMatchObject({
+      delegation: 'tenant-limited',
+      keyTenant: 'svc',
+      limitation: expect.stringContaining('limited') as unknown,
+    });
   });
 
   it('delegates analytics activity with default window', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,5 +16,12 @@ export { LoggingModule, REDACT_PATHS } from './logging/logging.module';
 export { McpModule } from './mcp/mcp.module';
 export { McpHandler } from './mcp/mcp.handler';
 export type { McpServerConfig, McpServer, ServerInfo } from './mcp/types';
-export { registerTools, type Tool, type ToolAuthMode, type AuthPolicy } from './mcp/tools/index';
+export {
+  registerTools,
+  resolveActingUserId,
+  type ActingUserDecision,
+  type Tool,
+  type ToolAuthMode,
+  type AuthPolicy,
+} from './mcp/tools/index';
 export { pingTool } from './mcp/tools/ping.tool';

--- a/packages/core/src/mcp/mcp.handler.spec.ts
+++ b/packages/core/src/mcp/mcp.handler.spec.ts
@@ -4,7 +4,10 @@
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { z } from 'zod';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { McpHandler } from './mcp.handler';
+import type { Tool } from './tools/index';
 
 describe('McpHandler', () => {
   let handler: McpHandler;
@@ -97,6 +100,81 @@ describe('McpHandler', () => {
       expect(handler.getServer()).toBeDefined();
 
       consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('tool dispatch wiring (createConfiguredServer)', () => {
+    type CallRequest = { method: string; params: { name: string; arguments?: unknown } };
+    type CallExtra = { authInfo?: { scopes?: string[]; extra?: Record<string, unknown> } };
+    type CallResult = { content: Array<{ text: string }>; isError?: boolean };
+    type CallHandler = (request: CallRequest, extra?: CallExtra) => Promise<CallResult>;
+
+    const getRequestMethod = (schema: unknown): string | undefined =>
+      (schema as { def?: { shape?: { method?: { def?: { values?: string[] } } } } })?.def?.shape
+        ?.method?.def?.values?.[0];
+
+    const echoTool: Tool = {
+      name: 'echo_user',
+      description: 'echoes the acting userId',
+      inputSchema: z.object({ userId: z.string() }).strict(),
+      // Opts into delegation so the admin-scope end-to-end case can target another tenant.
+      delegable: true,
+      handler: (input): Promise<unknown> =>
+        Promise.resolve({ echoedUserId: (input as { userId: string }).userId }),
+    };
+
+    /**
+     * Wire an identity tool through the handler exactly the way the HTTP
+     * transport does (registerAdditionalTools → setAuthPolicy →
+     * createConfiguredServer) and capture the registered tools/call handler.
+     */
+    const captureCallHandler = (): CallHandler => {
+      let captured: CallHandler | undefined;
+      const spy = vi
+        .spyOn(Server.prototype, 'setRequestHandler')
+        .mockImplementation((schema, fn): void => {
+          if (getRequestMethod(schema) === 'tools/call') {
+            captured = fn as unknown as CallHandler;
+          }
+        });
+      handler.registerAdditionalTools([echoTool]);
+      handler.setAuthPolicy({ required: true });
+      handler.createConfiguredServer({ name: 'wiring-test', version: '0.0.0' });
+      spy.mockRestore();
+      if (!captured) throw new Error('tools/call handler was not registered');
+      return captured;
+    };
+
+    const parse = (result: CallResult): Record<string, unknown> =>
+      JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+
+    it('honours a delegated userId from an admin-scoped key end-to-end', async () => {
+      const call = captureCallHandler();
+      const result = await call(
+        {
+          method: 'tools/call',
+          params: { name: 'echo_user', arguments: { userId: 'other-tenant' } },
+        },
+        { authInfo: { scopes: ['admin'], extra: { userId: 'key-tenant' } } }
+      );
+      expect(parse(result).echoedUserId).toBe('other-tenant');
+    });
+
+    it('pins a non-admin key back to its own tenant end-to-end', async () => {
+      const call = captureCallHandler();
+      const result = await call(
+        {
+          method: 'tools/call',
+          params: { name: 'echo_user', arguments: { userId: 'other-tenant' } },
+        },
+        {
+          authInfo: {
+            scopes: ['memories:read', 'memories:write', 'memories:delete'],
+            extra: { userId: 'key-tenant' },
+          },
+        }
+      );
+      expect(parse(result).echoedUserId).toBe('key-tenant');
     });
   });
 

--- a/packages/core/src/mcp/tools/dispatch-auth.spec.ts
+++ b/packages/core/src/mcp/tools/dispatch-auth.spec.ts
@@ -1,11 +1,13 @@
 /**
  * Auth-aware tool dispatch tests: identity injection, admin pass-through,
- * required-auth enforcement, and scope enforcement.
+ * delegated (admin-scope) userId pass-through, required-auth enforcement, and
+ * scope enforcement.
  */
 import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { Logger } from '@nestjs/common';
 import { z } from 'zod';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { registerTools, type AuthPolicy, type Tool } from './index';
+import { registerTools, resolveActingUserId, type AuthPolicy, type Tool } from './index';
 
 type CallRequest = {
   method: string;
@@ -28,6 +30,18 @@ const identityTool: Tool = {
   name: 'echo_user',
   description: 'echoes the acting userId',
   inputSchema: z.object({ userId: z.string() }).strict(),
+  // Opts into delegation, so an admin-scoped principal may target another tenant.
+  delegable: true,
+  handler: (input): Promise<unknown> =>
+    Promise.resolve({ echoedUserId: (input as { userId: string }).userId }),
+};
+
+// Identity tool that does NOT opt into delegation: every caller, admin included,
+// is pinned to the verified tenant (the default posture for identity tools).
+const pinnedTool: Tool = {
+  name: 'pinned_echo',
+  description: 'echoes the acting userId but is not delegable',
+  inputSchema: z.object({ userId: z.string() }).strict(),
   handler: (input): Promise<unknown> =>
     Promise.resolve({ echoedUserId: (input as { userId: string }).userId }),
 };
@@ -45,9 +59,11 @@ const scopedTool: Tool = {
   name: 'write_thing',
   description: 'requires the memories:write scope',
   inputSchema: z.object({ userId: z.string() }).strict(),
+  requiredScope: 'memories:write',
+  // Delegable so we can prove delegation composes with scope enforcement.
+  delegable: true,
   handler: (input): Promise<unknown> =>
     Promise.resolve({ ok: (input as { userId: string }).userId }),
-  requiredScope: 'memories:write',
 };
 
 describe('auth-aware tool dispatch', () => {
@@ -144,5 +160,203 @@ describe('auth-aware tool dispatch', () => {
       { authInfo: { scopes: ['admin'], extra: { userId: 'u' } } }
     );
     expect(parse(result).ok).toBe('u');
+  });
+
+  describe('delegated (admin-scope) userId pass-through on identity tools', () => {
+    it('honours an explicit foreign userId from an admin-scoped principal', async () => {
+      const handler = capture([identityTool], { required: true });
+      const result = await handler(
+        {
+          method: 'tools/call',
+          params: { name: 'echo_user', arguments: { userId: 'other-tenant' } },
+        },
+        { authInfo: { scopes: ['admin'], extra: { userId: 'service-key-tenant' } } }
+      );
+      expect(parse(result).echoedUserId).toBe('other-tenant');
+    });
+
+    it('still overwrites a foreign userId supplied by a NON-admin principal', async () => {
+      const handler = capture([identityTool], { required: true });
+      const result = await handler(
+        {
+          method: 'tools/call',
+          params: { name: 'echo_user', arguments: { userId: 'other-tenant' } },
+        },
+        {
+          authInfo: {
+            scopes: ['memories:read', 'memories:write', 'memories:delete'],
+            extra: { userId: 'service-key-tenant' },
+          },
+        }
+      );
+      expect(parse(result).echoedUserId).toBe('service-key-tenant');
+    });
+
+    it('falls back to the admin principal’s own tenant when no userId is supplied', async () => {
+      const handler = capture([identityTool], { required: true });
+      const result = await handler(
+        { method: 'tools/call', params: { name: 'echo_user', arguments: {} } },
+        { authInfo: { scopes: ['admin'], extra: { userId: 'service-key-tenant' } } }
+      );
+      expect(parse(result).echoedUserId).toBe('service-key-tenant');
+    });
+
+    it('delegation also applies to scoped identity tools when admin satisfies the scope', async () => {
+      const handler = capture([scopedTool], { required: true });
+      const result = await handler(
+        {
+          method: 'tools/call',
+          params: { name: 'write_thing', arguments: { userId: 'other-tenant' } },
+        },
+        { authInfo: { scopes: ['admin'], extra: { userId: 'service-key-tenant' } } }
+      );
+      expect(parse(result).ok).toBe('other-tenant');
+    });
+
+    it('pins an admin foreign userId on an identity tool that is NOT delegable', async () => {
+      const handler = capture([pinnedTool], { required: true });
+      const result = await handler(
+        {
+          method: 'tools/call',
+          params: { name: 'pinned_echo', arguments: { userId: 'other-tenant' } },
+        },
+        { authInfo: { scopes: ['admin'], extra: { userId: 'service-key-tenant' } } }
+      );
+      // Delegation is opt-in per tool; without `delegable` even admin is pinned.
+      expect(parse(result).echoedUserId).toBe('service-key-tenant');
+    });
+
+    it('does not grant delegation when scopes arrive as a non-array value', async () => {
+      const handler = capture([identityTool], { required: true });
+      const result = await handler(
+        {
+          method: 'tools/call',
+          params: { name: 'echo_user', arguments: { userId: 'other-tenant' } },
+        },
+        {
+          // A malformed transport could hand us `scopes: 'admin'` (a bare string
+          // whose .includes('admin') is true) — it must NOT be read as admin.
+          authInfo: {
+            scopes: 'admin' as unknown as string[],
+            extra: { userId: 'service-key-tenant' },
+          },
+        }
+      );
+      expect(parse(result).echoedUserId).toBe('service-key-tenant');
+    });
+
+    it('audit-logs a delegated call (with apiKeyId) and stays silent for a pinned one', async () => {
+      const logSpy = vi.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+      try {
+        const handler = capture([identityTool], { required: true });
+
+        await handler(
+          {
+            method: 'tools/call',
+            params: { name: 'echo_user', arguments: { userId: 'other-tenant' } },
+          },
+          {
+            authInfo: {
+              scopes: ['admin'],
+              extra: { userId: 'service-key-tenant', apiKeyId: 'key_123' },
+            },
+          }
+        );
+        const delegatedLog = logSpy.mock.calls
+          .map((c) => String(c[0]))
+          .find((m) => m.includes('delegated_user_id'));
+        expect(delegatedLog).toBeDefined();
+        expect(delegatedLog).toContain('actor=service-key-tenant');
+        expect(delegatedLog).toContain('target=other-tenant');
+        expect(delegatedLog).toContain('apiKeyId=key_123');
+
+        logSpy.mockClear();
+        await handler(
+          {
+            method: 'tools/call',
+            params: { name: 'echo_user', arguments: { userId: 'other-tenant' } },
+          },
+          {
+            authInfo: {
+              scopes: ['memories:read'],
+              extra: { userId: 'service-key-tenant' },
+            },
+          }
+        );
+        expect(
+          logSpy.mock.calls.map((c) => String(c[0])).some((m) => m.includes('delegated_user_id'))
+        ).toBe(false);
+      } finally {
+        logSpy.mockRestore();
+      }
+    });
+  });
+});
+
+describe('resolveActingUserId', () => {
+  // The 4th arg is `toolAllowsDelegation` (from Tool.delegable); pass true to
+  // model a delegable tool, false to model the default pinned posture.
+  it('lets an admin-scoped principal target another tenant on a delegable tool', () => {
+    expect(resolveActingUserId('key-tenant', 'other', ['admin'], true)).toEqual({
+      effectiveUserId: 'other',
+      delegated: true,
+    });
+  });
+
+  it('pins even an admin principal when the tool is NOT delegable', () => {
+    expect(resolveActingUserId('key-tenant', 'other', ['admin'], false)).toEqual({
+      effectiveUserId: 'key-tenant',
+      delegated: false,
+    });
+  });
+
+  it('pins a non-admin principal back to its own tenant', () => {
+    expect(resolveActingUserId('key-tenant', 'other', ['memories:write'], true)).toEqual({
+      effectiveUserId: 'key-tenant',
+      delegated: false,
+    });
+  });
+
+  it('uses the verified tenant when no userId was requested', () => {
+    expect(resolveActingUserId('key-tenant', undefined, ['admin'], true)).toEqual({
+      effectiveUserId: 'key-tenant',
+      delegated: false,
+    });
+  });
+
+  it('treats an empty, whitespace-only, or non-string requested userId as absent', () => {
+    expect(resolveActingUserId('key-tenant', '', ['admin'], true).effectiveUserId).toBe(
+      'key-tenant'
+    );
+    expect(resolveActingUserId('key-tenant', '   ', ['admin'], true)).toEqual({
+      effectiveUserId: 'key-tenant',
+      delegated: false,
+    });
+    expect(resolveActingUserId('key-tenant', 42, ['admin'], true).effectiveUserId).toBe(
+      'key-tenant'
+    );
+  });
+
+  it('is not marked delegated when an admin targets its own tenant', () => {
+    expect(resolveActingUserId('key-tenant', 'key-tenant', ['admin'], true)).toEqual({
+      effectiveUserId: 'key-tenant',
+      delegated: false,
+    });
+  });
+
+  it('ignores requested userId entirely when scopes are empty', () => {
+    expect(resolveActingUserId('key-tenant', 'other', [], true)).toEqual({
+      effectiveUserId: 'key-tenant',
+      delegated: false,
+    });
+  });
+
+  it('requires the exact "admin" scope — near-miss scopes never delegate', () => {
+    for (const near of ['administrator', 'admin:read', 'superadmin', 'x-admin', 'Admin']) {
+      expect(resolveActingUserId('key-tenant', 'other', [near], true)).toEqual({
+        effectiveUserId: 'key-tenant',
+        delegated: false,
+      });
+    }
   });
 });

--- a/packages/core/src/mcp/tools/dispatch-auth.spec.ts
+++ b/packages/core/src/mcp/tools/dispatch-auth.spec.ts
@@ -344,6 +344,20 @@ describe('resolveActingUserId', () => {
     });
   });
 
+  it('normalises a whitespace-padded requested userId to its trimmed value', () => {
+    // A padded copy of the own tenant must not be treated as a foreign target.
+    expect(resolveActingUserId('key-tenant', '  key-tenant  ', ['admin'], true)).toEqual({
+      effectiveUserId: 'key-tenant',
+      delegated: false,
+    });
+    // A padded foreign tenant delegates to the trimmed id, which is what
+    // downstream schema validation and lookups actually receive.
+    expect(resolveActingUserId('key-tenant', '  other  ', ['admin'], true)).toEqual({
+      effectiveUserId: 'other',
+      delegated: true,
+    });
+  });
+
   it('ignores requested userId entirely when scopes are empty', () => {
     expect(resolveActingUserId('key-tenant', 'other', [], true)).toEqual({
       effectiveUserId: 'key-tenant',

--- a/packages/core/src/mcp/tools/index.ts
+++ b/packages/core/src/mcp/tools/index.ts
@@ -14,7 +14,12 @@ import { pingTool } from './ping.tool.js';
  *   - `identity` (default): the tool acts on behalf of the caller. When the
  *     request is authenticated, the verified `userId` is injected into the tool
  *     input, overriding any client-supplied `userId` (a forged tenant cannot
- *     read another tenant's data).
+ *     read another tenant's data). Exception: on a tool that opts in with
+ *     `delegable: true`, a principal holding the `admin` scope may *delegate* —
+ *     explicitly pass another tenant's `userId` and have it honoured (see
+ *     {@link resolveActingUserId}); such calls are audited. Identity tools that
+ *     do not set `delegable` pin every caller, admin included, to their own
+ *     tenant.
  *   - `admin`: `userId` is a parameter chosen by an operator (e.g. issuing an
  *     API key *for* a user); it is never overwritten. These tools carry their
  *     own `adminToken` gate.
@@ -40,6 +45,19 @@ export interface Tool {
    * calls (no authInfo) to the `auth` enforcement above.
    */
   requiredScope?: string;
+  /**
+   * Opt this identity-mode tool into *delegation*: when set, a principal holding
+   * the `admin` scope may explicitly pass another tenant's `userId` and have it
+   * honoured instead of being pinned to its own tenant (the multi-tenant
+   * operator-console case; delegated calls are audited). Defaults to false, so
+   * identity tools pin every caller — admins included — to the verified tenant
+   * unless they opt in. Ignored for `admin`/`public` tools. Set true only on
+   * tools that genuinely need cross-tenant operation (e.g. the memory data tools
+   * `recall`/`update_memory`/`delete_memory`); leave destructive
+   * account/credential tools pinned so an admin key cannot act on other tenants'
+   * credentials by accident.
+   */
+  delegable?: boolean;
 }
 
 /**
@@ -76,6 +94,47 @@ function schemaAcceptsUserId(schema: z.ZodSchema): boolean {
   return (
     schema instanceof z.ZodObject && Object.prototype.hasOwnProperty.call(schema.shape, 'userId')
   );
+}
+
+/** Outcome of {@link resolveActingUserId} for an identity-mode tool call. */
+export interface ActingUserDecision {
+  /** The tenant the tool call will act on. */
+  effectiveUserId: string;
+  /** True when an admin-scoped principal explicitly targeted another tenant. */
+  delegated: boolean;
+}
+
+/**
+ * Decide which tenant an identity-mode tool acts on. The verified identity
+ * always wins for ordinary principals — the tenant boundary is the token, not
+ * the request body. The one exception is *delegation*, which requires BOTH
+ * conditions: the tool opts in (`toolAllowsDelegation`, from `Tool.delegable`)
+ * AND the principal holds the `admin` scope. Such a principal may then
+ * explicitly name another tenant in `userId` and have it honoured (the
+ * multi-tenant operator-console case). Everyone else — non-admins, and admins
+ * calling a non-delegable tool — is pinned back to their own tenant, preserving
+ * the pre-existing overwrite behavior. Keeping both gates here means the full
+ * cross-tenant decision lives in one auditable, unit-tested function.
+ */
+export function resolveActingUserId(
+  verifiedUserId: string,
+  requestedUserId: unknown,
+  scopes: readonly string[],
+  toolAllowsDelegation: boolean
+): ActingUserDecision {
+  const requested =
+    typeof requestedUserId === 'string' && requestedUserId.trim().length > 0
+      ? requestedUserId
+      : undefined;
+  if (
+    toolAllowsDelegation &&
+    requested &&
+    requested !== verifiedUserId &&
+    scopes.includes(ADMIN_SCOPE)
+  ) {
+    return { effectiveUserId: requested, delegated: true };
+  }
+  return { effectiveUserId: verifiedUserId, delegated: false };
 }
 
 /**
@@ -194,10 +253,27 @@ export function registerTools(
 
       // Build the effective input. For identity tools we trust the verified
       // userId over anything the client supplied — the tenant boundary is the
-      // token, not the request body.
+      // token, not the request body. The one exception is a tool that opts into
+      // delegation (`delegable`) called by an admin-scoped principal: it may act
+      // on behalf of another tenant (e.g. the multi-tenant operator console).
+      // Delegated calls are audited.
       let args: unknown = request.params.arguments ?? {};
       if (mode === 'identity' && userId && schemaAcceptsUserId(tool.inputSchema)) {
-        args = { ...(args as Record<string, unknown>), userId };
+        const record = args as Record<string, unknown>;
+        const decision = resolveActingUserId(
+          userId,
+          record.userId,
+          authenticatedScopes(extra),
+          tool.delegable === true
+        );
+        if (decision.delegated) {
+          const apiKeyId = extra?.authInfo?.extra?.apiKeyId;
+          logger.log(
+            `delegated_user_id tool=${toolName} actor=${userId} target=${decision.effectiveUserId}` +
+              (typeof apiKeyId === 'string' ? ` apiKeyId=${apiKeyId}` : '')
+          );
+        }
+        args = { ...record, userId: decision.effectiveUserId };
       }
 
       // Validate input with Zod

--- a/packages/core/src/mcp/tools/index.ts
+++ b/packages/core/src/mcp/tools/index.ts
@@ -122,9 +122,12 @@ export function resolveActingUserId(
   scopes: readonly string[],
   toolAllowsDelegation: boolean
 ): ActingUserDecision {
+  // Normalise: use the trimmed value so a whitespace-only id counts as absent
+  // and a padded id ("  x  ") is compared/acted on as its real value ("x")
+  // rather than being treated as a distinct tenant that then fails validation.
   const requested =
     typeof requestedUserId === 'string' && requestedUserId.trim().length > 0
-      ? requestedUserId
+      ? requestedUserId.trim()
       : undefined;
   if (
     toolAllowsDelegation &&


### PR DESCRIPTION
Fixes #200.

## Problem
The web operator console is multi-tenant (the scope switcher selects any data owner), but under MCP auth the dispatch overwrote the client-supplied `userId` with the API key's own tenant for every identity tool (`recall`, `update_memory`, `delete_memory`). So cross-tenant semantic search returned empty (still reported `semantic: true`) and cross-tenant edits/deletes failed as "not found" — pushing deployers to run the server with `AUTH_REQUIRED=false` and downgrade security.

## Fix
**Core dispatch — opt-in delegation.** New `delegable` flag on `Tool`. A principal holding the `admin` scope may pass an explicit `userId` on a *delegable* tool and have it honoured; everyone else — non-admins, and admins on non-delegable tools — is still pinned to the verified tenant. The whole decision lives in one auditable `resolveActingUserId(verified, requested, scopes, delegable)`. Delegated calls are audit-logged (actor, target, `apiKeyId`).

Only the three memory tools the console uses cross-tenant opt in (`recall`/`update_memory`/`delete_memory`). Destructive key-management tools (`list_api_keys`/`revoke_api_key`) stay pinned, so an admin key cannot list or revoke another tenant's credentials.

> **Design note (please confirm):** this is deliberately *narrower* than the ticket's literal "keys with `admin` scope may pass an explicit `userId`" — delegation is gated on **both** the `admin` scope **and** per-tool opt-in (least privilege). Reverting to generic admin delegation is a one-line change if preferred.

**Web console.** `capabilities()` probes `GET /auth/me` for the key's scopes and reports a delegation mode (`admin` / `tenant-limited` / `unrestricted` / `unknown`), the bound tenant, and an operator-facing limitation; the Settings page warns when the console is tenant-limited or keyless-but-configured. The defensive Postgres re-filter in `searchMemories` is kept — a non-admin key fails closed to empty, never leaking another tenant's hits.

## Tests
- **Wiring test** binding the contract to the *real* memory tools: they are identity-mode + `delegable`, and delegate/pin correctly end-to-end through `registerTools` (the load-bearing non-admin-pin case exercises the real `recall` schema).
- Locking tests: near-miss admin scopes (`administrator`, `admin:read`, …), non-array scopes, whitespace `userId`, the delegation audit log, delegation cache TTL expiry, and key-management tools staying non-delegable.

## Verification
`test` + `typecheck` + `lint` green across `@engram/core` (52), `web` (65), and `mcp-server` (502).

🤖 Generated with [Claude Code](https://claude.com/claude-code)