### PR TITLE
fix(auth): make JWT sessions revocable via jti denylist on logout (#202)

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -17,15 +17,18 @@
  * a large staged set.
  */
 module.exports = {
-  '*.{ts,tsx,js,jsx}': [
-    'eslint --fix --config apps/web/eslint.config.js',
-    'prettier --write',
-  ],
-  '*.{json,md,yml,yaml}': (filenames) =>
-    filenames
-      .filter((filename) => {
-        const basename = (filename.replace(/\\/g, '/').split('/').pop()) || '';
-        return basename !== 'pnpm-lock.yaml';
-      })
-      .map(() => 'prettier --write'),
+  '*.{ts,tsx,js,jsx}': ['eslint --fix --config apps/web/eslint.config.js', 'prettier --write'],
+  '*.{json,md,yml,yaml}': (filenames) => {
+    const files = filenames.filter((filename) => {
+      const basename = filename.replace(/\\/g, '/').split('/').pop() || '';
+      return basename !== 'pnpm-lock.yaml';
+    });
+    // Return ONE prettier invocation carrying the (quoted) filenames. The
+    // function form of a lint-staged task does not auto-append filenames, so
+    // mapping to a bare `prettier --write` would run it with no target and
+    // block forever reading stdin. Skip entirely when nothing remains.
+    return files.length
+      ? [`prettier --write ${files.map((f) => JSON.stringify(f)).join(' ')}`]
+      : [];
+  },
 };

--- a/apps/mcp-server/src/auth/auth-logout.wiring.spec.ts
+++ b/apps/mcp-server/src/auth/auth-logout.wiring.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * Wiring-level test for JWT revocation on logout (#202).
+ *
+ * Exercises the real seams — AuthController → SessionService/JwtService/
+ * JwtRevocationService → AuthResolver → McpAuthMiddleware — over an in-memory
+ * store standing in for Redis. Proves the end-to-end property the security
+ * review demanded: after `POST /auth/logout`, the Bearer JWT issued at login
+ * is rejected by the MCP request pipeline (and `/auth/me`) even though its
+ * signature and expiry are still valid.
+ */
+import { UnauthorizedException } from '@nestjs/common';
+import type { Request, Response } from 'express';
+import {
+  JwtRevocationService,
+  JwtService,
+  SessionService,
+  type OAuthService,
+  type SessionStore,
+} from '@engram/auth';
+import { AuthController } from './auth.controller';
+import { AuthResolver } from './auth-resolver.service';
+import { McpAuthMiddleware } from './mcp-auth.middleware';
+import type { ApiKeysService } from '../api-keys/api-keys.service';
+import type { UserService } from './user.service';
+
+const SECRET = 'wiring-test-secret-at-least-32-characters-long';
+
+/** In-memory SessionStore doubling as the jti denylist store. */
+class FakeStore implements SessionStore {
+  public map = new Map<string, string>();
+  set(key: string, value: string): Promise<void> {
+    this.map.set(key, value);
+    return Promise.resolve();
+  }
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.map.get(key) ?? null);
+  }
+  delete(key: string): Promise<void> {
+    this.map.delete(key);
+    return Promise.resolve();
+  }
+  getDelete(key: string): Promise<string | null> {
+    const v = this.map.get(key) ?? null;
+    this.map.delete(key);
+    return Promise.resolve(v);
+  }
+}
+
+function fakeOAuth(): OAuthService {
+  return {
+    isEnabled: (name: string) => name === 'github',
+    getProvider: () => ({
+      getAuthorizationUrl: () => 'https://github.test/authorize',
+      exchangeCodeForProfile: () =>
+        Promise.resolve({
+          provider: 'github' as const,
+          providerAccountId: '1',
+          email: 'octo@gh.com',
+          name: 'Octo',
+        }),
+    }),
+  } as unknown as OAuthService;
+}
+
+function fakeUsers(): UserService {
+  // Distinct id per login so the "other users" test genuinely spans two users,
+  // not one user twice. First login → user-1 (relied on by single-login tests).
+  let n = 0;
+  return {
+    upsertByEmail: jest.fn(() => {
+      n += 1;
+      return Promise.resolve({
+        id: `user-${n}`,
+        email: 'octo@gh.com',
+        organizationId: null,
+      });
+    }),
+  } as unknown as UserService;
+}
+
+function mockControllerRes(): Response & { cookies: Map<string, string> } {
+  const cookies = new Map<string, string>();
+  return {
+    cookies,
+    cookie: jest.fn((name: string, value: string) => {
+      cookies.set(name, value);
+    }),
+    clearCookie: jest.fn((name: string) => {
+      cookies.delete(name);
+    }),
+    redirect: jest.fn(),
+  } as unknown as Response & { cookies: Map<string, string> };
+}
+
+function mockMwRes(): Response & { statusCode: number; body: unknown } {
+  const res = { statusCode: 200, body: undefined as unknown };
+  const r = res as unknown as Response & typeof res;
+  r.status = jest.fn((code: number) => {
+    res.statusCode = code;
+    return r;
+  }) as never;
+  r.json = jest.fn((b: unknown) => {
+    res.body = b;
+    return r;
+  }) as never;
+  r.set = jest.fn(() => r) as never;
+  return r as never;
+}
+
+function mcpRequest(token: string): Request {
+  return {
+    headers: { authorization: `Bearer ${token}` },
+    body: { method: 'tools/call', params: { name: 'recall' } },
+  } as unknown as Request;
+}
+
+interface Harness {
+  controller: AuthController;
+  middleware: McpAuthMiddleware;
+  sessions: SessionService;
+  revocation: JwtRevocationService;
+  store: FakeStore;
+  login(): Promise<{ token: string; sessionId: string }>;
+}
+
+function buildHarness(): Harness {
+  const store = new FakeStore();
+  const jwt = new JwtService({ secret: SECRET });
+  const sessions = new SessionService(store);
+  const revocation = new JwtRevocationService(store);
+  const apiKeys = {
+    verifyApiKey: jest.fn(() => Promise.resolve(null)),
+  } as unknown as ApiKeysService;
+  const resolver = new AuthResolver(apiKeys, jwt, revocation);
+  const middleware = new McpAuthMiddleware(resolver, true);
+  const controller = new AuthController(
+    fakeOAuth(),
+    sessions,
+    jwt,
+    revocation,
+    fakeUsers(),
+    resolver,
+    'https://api.example.com',
+  );
+
+  const login = async (): Promise<{ token: string; sessionId: string }> => {
+    const state = await sessions.createOAuthState('github');
+    const res = mockControllerRes();
+    const result = (await controller.callback(
+      'github',
+      { code: 'code-1', state },
+      res,
+    )) as { token: string };
+    return {
+      token: result.token,
+      sessionId: res.cookies.get('engram_session')!,
+    };
+  };
+
+  return { controller, middleware, sessions, revocation, store, login };
+}
+
+describe('JWT logout revocation (wiring)', () => {
+  it('rejects a logged-out Bearer token at the MCP middleware (cookie-only logout)', async () => {
+    const h = buildHarness();
+    const { token, sessionId } = await h.login();
+    expect(sessionId).toBeTruthy();
+
+    // Before logout: the token authenticates a protected tools/call.
+    const okRes = mockMwRes();
+    const okNext = jest.fn();
+    await h.middleware.handle(mcpRequest(token), okRes, okNext);
+    expect(okNext).toHaveBeenCalled();
+    expect(okRes.statusCode).toBe(200);
+
+    // Logout presenting only the httpOnly session cookie — no Bearer header.
+    await h.controller.logout(
+      { headers: { cookie: `engram_session=${sessionId}` } } as never,
+      mockControllerRes(),
+    );
+
+    // After logout: the very same Bearer token is rejected with 401.
+    const deniedRes = mockMwRes();
+    const deniedNext = jest.fn();
+    await h.middleware.handle(mcpRequest(token), deniedRes, deniedNext);
+    expect(deniedNext).not.toHaveBeenCalled();
+    expect(deniedRes.statusCode).toBe(401);
+    expect(JSON.stringify(deniedRes.body)).toContain('revoked');
+
+    // And the session itself is gone.
+    expect(await h.sessions.getSession(sessionId)).toBeNull();
+  });
+
+  it('rejects a logged-out Bearer token when logout presented only the token', async () => {
+    const h = buildHarness();
+    const { token } = await h.login();
+
+    await h.controller.logout(
+      { headers: { authorization: `Bearer ${token}` } } as never,
+      mockControllerRes(),
+    );
+
+    const res = mockMwRes();
+    const next = jest.fn();
+    await h.middleware.handle(mcpRequest(token), res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a logged-out token on /auth/me as well', async () => {
+    const h = buildHarness();
+    const { token, sessionId } = await h.login();
+
+    const me = (await h.controller.me({
+      headers: { authorization: `Bearer ${token}` },
+    } as never)) as { user: { userId: string } };
+    expect(me.user.userId).toBe('user-1');
+
+    await h.controller.logout(
+      { headers: { cookie: `engram_session=${sessionId}` } } as never,
+      mockControllerRes(),
+    );
+
+    await expect(
+      h.controller.me({
+        headers: { authorization: `Bearer ${token}` },
+      } as never),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it("leaves other users' tokens valid after one user logs out", async () => {
+    const h = buildHarness();
+    const first = await h.login();
+    const second = await h.login();
+
+    await h.controller.logout(
+      { headers: { cookie: `engram_session=${first.sessionId}` } } as never,
+      mockControllerRes(),
+    );
+
+    // First token dead, second still fine (revocation is per-jti, not global).
+    const deadRes = mockMwRes();
+    await h.middleware.handle(mcpRequest(first.token), deadRes, jest.fn());
+    expect(deadRes.statusCode).toBe(401);
+
+    const aliveRes = mockMwRes();
+    const aliveNext = jest.fn();
+    await h.middleware.handle(mcpRequest(second.token), aliveRes, aliveNext);
+    expect(aliveNext).toHaveBeenCalled();
+    expect(aliveRes.statusCode).toBe(200);
+  });
+
+  it('logout is idempotent — repeating it keeps the token revoked', async () => {
+    const h = buildHarness();
+    const { token, sessionId } = await h.login();
+    const logoutReq = {
+      headers: {
+        cookie: `engram_session=${sessionId}`,
+        authorization: `Bearer ${token}`,
+      },
+    } as never;
+
+    await h.controller.logout(logoutReq, mockControllerRes());
+    await h.controller.logout(logoutReq, mockControllerRes());
+
+    const res = mockMwRes();
+    await h.middleware.handle(mcpRequest(token), res, jest.fn());
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/apps/mcp-server/src/auth/auth-resolver.service.spec.ts
+++ b/apps/mcp-server/src/auth/auth-resolver.service.spec.ts
@@ -1,8 +1,24 @@
-import { JwtService } from '@engram/auth';
+import {
+  JwtRevocationService,
+  JwtService,
+  type JwtDenylistStore,
+} from '@engram/auth';
 import { AuthResolver } from './auth-resolver.service';
 import type { ApiKeysService } from '../api-keys/api-keys.service';
 
 const SECRET = 'unit-test-secret-at-least-32-characters-long';
+
+/** In-memory jti denylist store. */
+class FakeDenylistStore implements JwtDenylistStore {
+  public map = new Map<string, string>();
+  set(key: string, value: string): Promise<void> {
+    this.map.set(key, value);
+    return Promise.resolve();
+  }
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.map.get(key) ?? null);
+  }
+}
 
 type VerifyResult = Awaited<ReturnType<ApiKeysService['verifyApiKey']>>;
 
@@ -126,5 +142,80 @@ describe('AuthResolver', () => {
     );
     const outcome = await resolver.authenticate({ 'x-api-key': 'eng_x' });
     expect(outcome.status).toBe('invalid');
+  });
+
+  describe('jti denylist (revocation)', () => {
+    it('rejects a revoked (logged-out) JWT', async () => {
+      const revocation = new JwtRevocationService(new FakeDenylistStore());
+      const resolver = new AuthResolver(
+        makeApiKeys(() => null),
+        jwt,
+        revocation,
+      );
+      const { token, claims } = jwt.issueWithClaims({ userId: 'user-2' });
+
+      // Valid before revocation…
+      const before = await resolver.authenticate({
+        authorization: `Bearer ${token}`,
+      });
+      expect(before.status).toBe('authenticated');
+
+      // …rejected after.
+      await revocation.revoke(claims);
+      const after = await resolver.authenticate({
+        authorization: `Bearer ${token}`,
+      });
+      expect(after).toEqual({
+        status: 'invalid',
+        reason: 'Token has been revoked',
+      });
+    });
+
+    it('fails closed when the denylist store errors', async () => {
+      const revocation = new JwtRevocationService({
+        set: () => Promise.reject(new Error('redis down')),
+        get: () => Promise.reject(new Error('redis down')),
+      });
+      const resolver = new AuthResolver(
+        makeApiKeys(() => null),
+        jwt,
+        revocation,
+      );
+      const outcome = await resolver.authenticate({
+        authorization: `Bearer ${jwt.issue({ userId: 'user-2' })}`,
+      });
+      expect(outcome).toEqual({
+        status: 'invalid',
+        reason: 'Token revocation check failed',
+      });
+    });
+
+    it('still authenticates without a revocation service (lite profile)', async () => {
+      const resolver = new AuthResolver(
+        makeApiKeys(() => null),
+        jwt,
+        undefined,
+      );
+      const outcome = await resolver.authenticate({
+        authorization: `Bearer ${jwt.issue({ userId: 'user-2' })}`,
+      });
+      expect(outcome.status).toBe('authenticated');
+    });
+
+    it('does not consult the denylist for API keys', async () => {
+      const store = new FakeDenylistStore();
+      const getSpy = jest.spyOn(store, 'get');
+      const revocation = new JwtRevocationService(store);
+      const resolver = new AuthResolver(
+        makeApiKeys(() => sampleKey()),
+        jwt,
+        revocation,
+      );
+      const outcome = await resolver.authenticate({
+        'x-api-key': 'eng_abcdef',
+      });
+      expect(outcome.status).toBe('authenticated');
+      expect(getSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/mcp-server/src/auth/auth-resolver.service.ts
+++ b/apps/mcp-server/src/auth/auth-resolver.service.ts
@@ -1,5 +1,11 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
-import { JwtService, type AuthIdentity } from '@engram/auth';
+import {
+  JwtError,
+  JwtRevocationService,
+  JwtService,
+  type AuthIdentity,
+  type JwtClaims,
+} from '@engram/auth';
 import { ApiKeysService } from '../api-keys/api-keys.service';
 
 export type AuthOutcome =
@@ -26,6 +32,10 @@ function firstHeader(value: string | string[] | undefined): string | undefined {
  * presented but fails verification, and `authenticated` with the resolved
  * {@link AuthIdentity} otherwise. A presented-but-invalid credential is never
  * silently downgraded to anonymous.
+ *
+ * When a {@link JwtRevocationService} is wired (enterprise profile — requires
+ * Redis), verified JWTs are additionally checked against the `jti` denylist so
+ * logged-out tokens are rejected for their remaining lifetime.
  */
 @Injectable()
 export class AuthResolver {
@@ -34,6 +44,7 @@ export class AuthResolver {
   constructor(
     private readonly apiKeys: ApiKeysService,
     @Optional() private readonly jwt?: JwtService,
+    @Optional() private readonly revocation?: JwtRevocationService,
   ) {}
 
   async authenticate(headers: RequestHeaders): Promise<AuthOutcome> {
@@ -88,28 +99,46 @@ export class AuthResolver {
     };
   }
 
-  private authenticateJwt(token: string): AuthOutcome {
+  private async authenticateJwt(token: string): Promise<AuthOutcome> {
     if (!this.jwt) {
       return { status: 'invalid', reason: 'JWT auth is not configured' };
     }
+    let claims: JwtClaims;
     try {
-      const claims = this.jwt.verify(token);
-      return {
-        status: 'authenticated',
-        identity: {
-          userId: claims.sub,
-          organizationId: claims.org,
-          email: claims.email,
-          scopes: claims.scopes,
-          method: 'jwt',
-          apiKeyId: null,
-        },
-      };
+      claims = this.jwt.verify(token);
     } catch (error) {
       return {
         status: 'invalid',
         reason: error instanceof Error ? error.message : 'Invalid token',
       };
     }
+
+    // Revocation (jti denylist) check — present only when Redis is wired
+    // (enterprise). Fail-closed: a denylist store error rejects the token
+    // rather than accepting a possibly-revoked one, matching the API-key
+    // posture above where a verification error never authenticates.
+    if (this.revocation) {
+      try {
+        await this.revocation.assertNotRevoked(claims.jti);
+      } catch (error) {
+        if (error instanceof JwtError) {
+          return { status: 'invalid', reason: error.message };
+        }
+        this.logger.warn(`JWT revocation check error: ${String(error)}`);
+        return { status: 'invalid', reason: 'Token revocation check failed' };
+      }
+    }
+
+    return {
+      status: 'authenticated',
+      identity: {
+        userId: claims.sub,
+        organizationId: claims.org,
+        email: claims.email,
+        scopes: claims.scopes,
+        method: 'jwt',
+        apiKeyId: null,
+      },
+    };
   }
 }

--- a/apps/mcp-server/src/auth/auth.controller.spec.ts
+++ b/apps/mcp-server/src/auth/auth.controller.spec.ts
@@ -12,6 +12,8 @@ function build(
     consumeState?: () => unknown;
     exchange?: () => unknown;
     authenticate?: () => unknown;
+    getSession?: () => unknown;
+    verify?: () => unknown;
   } = {},
 ): {
   controller: AuthController;
@@ -20,9 +22,15 @@ function build(
     createOAuthState: jest.Mock;
     consumeOAuthState: jest.Mock;
     createSession: jest.Mock;
+    getSession: jest.Mock;
     destroySession: jest.Mock;
   };
-  jwt: { issue: jest.Mock; tokenLifetimeSeconds: number };
+  jwt: {
+    issueWithClaims: jest.Mock;
+    verify: jest.Mock;
+    tokenLifetimeSeconds: number;
+  };
+  revocation: { revoke: jest.Mock };
   users: { upsertByEmail: jest.Mock };
   resolver: { authenticate: jest.Mock };
 } {
@@ -57,9 +65,36 @@ function build(
           Promise.resolve({ provider: 'github', createdAt: 1 })),
     ),
     createSession: jest.fn(() => Promise.resolve('sess-1')),
+    getSession: jest.fn(
+      overrides.getSession ??
+        ((): Promise<unknown> =>
+          Promise.resolve({
+            userId: 'user-1',
+            organizationId: null,
+            email: 'octo@gh.com',
+            scopes: [],
+            createdAt: 100,
+            jti: 'session-jti',
+            jwtExp: 4100,
+          })),
+    ),
     destroySession: jest.fn(() => Promise.resolve(undefined)),
   };
-  const jwt = { issue: jest.fn(() => 'jwt-token'), tokenLifetimeSeconds: 3600 };
+  const jwt = {
+    issueWithClaims: jest.fn(() => ({
+      token: 'jwt-token',
+      claims: { jti: 'minted-jti', exp: 3700, iat: 100, sub: 'user-1' },
+    })),
+    verify: jest.fn(
+      overrides.verify ??
+        ((): { jti: string; exp: number } => ({
+          jti: 'bearer-jti',
+          exp: 5000,
+        })),
+    ),
+    tokenLifetimeSeconds: 3600,
+  };
+  const revocation = { revoke: jest.fn(() => Promise.resolve(true)) };
   const users = {
     upsertByEmail: jest.fn(() =>
       Promise.resolve({
@@ -86,11 +121,12 @@ function build(
     oauth as never,
     sessions as never,
     jwt as never,
+    revocation as never,
     users as never,
     resolver as never,
     'https://api.example.com',
   );
-  return { controller, oauth, sessions, jwt, users, resolver };
+  return { controller, oauth, sessions, jwt, revocation, users, resolver };
 }
 
 function mockRes(): Response {
@@ -132,8 +168,12 @@ describe('AuthController', () => {
       )) as { token: string; sessionId?: string };
       expect(sessions.consumeOAuthState).toHaveBeenCalledWith('state-1');
       expect(users.upsertByEmail).toHaveBeenCalledWith('octo@gh.com');
-      expect(jwt.issue).toHaveBeenCalled();
+      expect(jwt.issueWithClaims).toHaveBeenCalled();
       expect(result.token).toBe('jwt-token');
+      // The minted jti/exp are bound to the session for revocation on logout.
+      expect(sessions.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({ jti: 'minted-jti', jwtExp: 3700 }),
+      );
       // The session id must NOT be echoed in the body — cookie only.
       expect(result.sessionId).toBeUndefined();
       expect(res.cookie).toHaveBeenCalledWith(
@@ -210,11 +250,159 @@ describe('AuthController', () => {
       expect(res.clearCookie).toHaveBeenCalledWith('engram_session');
     });
 
+    it('revokes the jti paired with the session on logout', async () => {
+      const { controller, revocation } = build();
+      await controller.logout(
+        { headers: { cookie: 'engram_session=sess-1' } } as never,
+        mockRes(),
+      );
+      expect(revocation.revoke).toHaveBeenCalledWith({
+        jti: 'session-jti',
+        exp: 4100,
+      });
+    });
+
+    it('falls back to createdAt + lifetime for legacy sessions without jwtExp', async () => {
+      const { controller, revocation } = build({
+        getSession: () =>
+          Promise.resolve({
+            userId: 'user-1',
+            organizationId: null,
+            email: null,
+            scopes: [],
+            createdAt: 100,
+            jti: 'legacy-jti',
+          }),
+      });
+      await controller.logout(
+        { headers: { cookie: 'engram_session=sess-1' } } as never,
+        mockRes(),
+      );
+      // exp = createdAt (100) + tokenLifetimeSeconds (3600)
+      expect(revocation.revoke).toHaveBeenCalledWith({
+        jti: 'legacy-jti',
+        exp: 3700,
+      });
+    });
+
+    it('revokes a Bearer JWT presented on the logout request', async () => {
+      const { controller, jwt, revocation } = build({
+        getSession: () => Promise.resolve(null),
+      });
+      await controller.logout(
+        {
+          headers: {
+            cookie: 'engram_session=sess-1',
+            authorization: 'Bearer some.jwt.token',
+          },
+        } as never,
+        mockRes(),
+      );
+      expect(jwt.verify).toHaveBeenCalledWith('some.jwt.token');
+      expect(revocation.revoke).toHaveBeenCalledWith({
+        jti: 'bearer-jti',
+        exp: 5000,
+      });
+    });
+
+    it('revokes both the session jti and a distinct Bearer jti presented together', async () => {
+      // Cookie names session-jti; the Authorization header carries a different
+      // token (bearer-jti). Both must be denylisted — guards against a
+      // regression that makes the Bearer branch an `else` of the session branch.
+      const { controller, revocation } = build();
+      await controller.logout(
+        {
+          headers: {
+            cookie: 'engram_session=sess-1',
+            authorization: 'Bearer some.jwt.token',
+          },
+        } as never,
+        mockRes(),
+      );
+      expect(revocation.revoke).toHaveBeenCalledWith({
+        jti: 'session-jti',
+        exp: 4100,
+      });
+      expect(revocation.revoke).toHaveBeenCalledWith({
+        jti: 'bearer-jti',
+        exp: 5000,
+      });
+      expect(revocation.revoke).toHaveBeenCalledTimes(2);
+    });
+
+    it('propagates a denylist store error on the session path (no false 204)', async () => {
+      // The logout contract: a 204 must never falsely promise revocation. When
+      // the denylist write fails, the handler rejects (→ 500) rather than
+      // resolving, and — because revoke precedes destroy/clear — the session is
+      // left intact so the client retries rather than believing it logged out.
+      const { controller, revocation, sessions } = build();
+      revocation.revoke.mockRejectedValue(new Error('redis down'));
+      const res = mockRes();
+      await expect(
+        controller.logout(
+          { headers: { cookie: 'engram_session=sess-1' } } as never,
+          res,
+        ),
+      ).rejects.toThrow('redis down');
+      expect(sessions.destroySession).not.toHaveBeenCalled();
+      expect(res.clearCookie).not.toHaveBeenCalled();
+    });
+
+    it('propagates a denylist store error on the Bearer path (no false 204)', async () => {
+      const { controller, revocation } = build({
+        getSession: () => Promise.resolve(null),
+      });
+      revocation.revoke.mockRejectedValue(new Error('redis down'));
+      const res = mockRes();
+      await expect(
+        controller.logout(
+          { headers: { authorization: 'Bearer some.jwt.token' } } as never,
+          res,
+        ),
+      ).rejects.toThrow('redis down');
+      expect(res.clearCookie).not.toHaveBeenCalled();
+    });
+
+    it('ignores an invalid Bearer token on logout (idempotent 204)', async () => {
+      const { controller, revocation, sessions } = build({
+        getSession: () => Promise.resolve(null),
+        verify: () => {
+          throw new Error('bad token');
+        },
+      });
+      const res = mockRes();
+      await controller.logout(
+        {
+          headers: {
+            cookie: 'engram_session=sess-1',
+            authorization: 'Bearer garbage',
+          },
+        } as never,
+        res,
+      );
+      expect(revocation.revoke).not.toHaveBeenCalled();
+      expect(sessions.destroySession).toHaveBeenCalledWith('sess-1');
+      expect(res.clearCookie).toHaveBeenCalledWith('engram_session');
+    });
+
+    it('does not treat an eng_ API key Bearer as a JWT on logout', async () => {
+      const { controller, jwt, revocation } = build({
+        getSession: () => Promise.resolve(null),
+      });
+      await controller.logout(
+        { headers: { authorization: 'Bearer eng_secretkey123' } } as never,
+        mockRes(),
+      );
+      expect(jwt.verify).not.toHaveBeenCalled();
+      expect(revocation.revoke).not.toHaveBeenCalled();
+    });
+
     it('is a no-op destroy when no session cookie is present', async () => {
-      const { controller, sessions } = build();
+      const { controller, sessions, revocation } = build();
       const res = mockRes();
       await controller.logout({ headers: {} } as never, res);
       expect(sessions.destroySession).not.toHaveBeenCalled();
+      expect(revocation.revoke).not.toHaveBeenCalled();
       expect(res.clearCookie).toHaveBeenCalledWith('engram_session');
     });
   });

--- a/apps/mcp-server/src/auth/auth.controller.ts
+++ b/apps/mcp-server/src/auth/auth.controller.ts
@@ -16,9 +16,11 @@ import {
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import {
+  JwtRevocationService,
   JwtService,
   OAuthService,
   SessionService,
+  type JwtClaims,
   type OAuthProviderName,
   type OAuthUserProfile,
 } from '@engram/auth';
@@ -55,6 +57,20 @@ function readSessionCookie(req: Request): string | undefined {
   return undefined;
 }
 
+/**
+ * Read a JWT presented as `Authorization: Bearer <token>`, if any. `eng_`
+ * API keys are not JWTs and are ignored here — they have their own
+ * `revokedAt`-based revocation.
+ */
+function readBearerJwt(req: Request): string | undefined {
+  const header = req.headers.authorization;
+  if (typeof header !== 'string') return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  const token = match?.[1]?.trim();
+  if (!token || token.startsWith('eng_')) return undefined;
+  return token;
+}
+
 const callbackQuerySchema = z.object({
   code: z.string().min(1),
   state: z.string().min(1),
@@ -70,6 +86,7 @@ function isProviderName(value: string): value is OAuthProviderName {
  *   - `GET  /auth/:provider/callback` → exchange code, upsert user, issue JWT + session
  *   - `GET  /auth/me`                 → resolve the caller's identity
  *   - `POST /auth/logout`             → destroy the session named by its cookie
+ *                                       and revoke the paired JWT (jti denylist)
  */
 @Controller('auth')
 export class AuthController {
@@ -79,6 +96,7 @@ export class AuthController {
     private readonly oauth: OAuthService,
     private readonly sessions: SessionService,
     private readonly jwt: JwtService,
+    private readonly revocation: JwtRevocationService,
     private readonly users: UserService,
     private readonly resolver: AuthResolver,
     @Inject(OAUTH_REDIRECT_BASE_URL) private readonly redirectBase: string,
@@ -141,17 +159,21 @@ export class AuthController {
     }
 
     const user = await this.users.upsertByEmail(profile.email);
-    const token = this.jwt.issue({
+    const { token, claims } = this.jwt.issueWithClaims({
       userId: user.id,
       email: user.email,
       organizationId: user.organizationId,
       scopes: SESSION_SCOPES,
     });
+    // Bind the minted jti/exp to the session so logout can revoke the paired
+    // Bearer token even when only the httpOnly cookie is presented.
     const sessionId = await this.sessions.createSession({
       userId: user.id,
       organizationId: user.organizationId,
       email: user.email,
       scopes: SESSION_SCOPES,
+      jti: claims.jti,
+      jwtExp: claims.exp,
     });
 
     res.cookie(SESSION_COOKIE, sessionId, {
@@ -186,6 +208,13 @@ export class AuthController {
     return { user: outcome.identity };
   }
 
+  /**
+   * Logout invalidates *both* halves of the interactive credential pair:
+   * the Redis session named by the cookie, and the JWT via the `jti`
+   * denylist (entry TTL = remaining token lifetime). The JWT is found from
+   * the session record (which stores the paired `jti`/`exp`) and/or the
+   * `Authorization: Bearer` header on the logout request itself.
+   */
   @Post('logout')
   @HttpCode(204)
   async logout(
@@ -194,8 +223,40 @@ export class AuthController {
   ): Promise<void> {
     const sessionId = readSessionCookie(req);
     if (sessionId) {
+      const session = await this.sessions.getSession(sessionId);
+      // Sessions minted before jti-binding shipped carry no `jti`; a cookie-only
+      // logout of such a legacy session cannot denylist the paired JWT (its id
+      // was never stored), so that token stays valid until `exp`. This residual
+      // window self-heals within one token lifetime of deploy — every new login
+      // binds jti/jwtExp — and an API client that resends its Bearer on logout
+      // is still covered by the header path below.
+      if (session?.jti) {
+        await this.revocation.revoke({
+          jti: session.jti,
+          // Older sessions predate jwtExp; fall back to a safe upper bound
+          // (session creation + configured lifetime ≥ the token's real exp).
+          exp:
+            session.jwtExp ?? session.createdAt + this.jwt.tokenLifetimeSeconds,
+        });
+      }
       await this.sessions.destroySession(sessionId);
     }
+
+    const bearer = readBearerJwt(req);
+    if (bearer) {
+      let claims: JwtClaims | undefined;
+      try {
+        claims = this.jwt.verify(bearer);
+      } catch {
+        // Invalid/expired/foreign token — nothing to revoke; logout stays
+        // idempotent. Denylist *store* errors below still propagate (a 204
+        // must not falsely promise the token was revoked).
+      }
+      if (claims) {
+        await this.revocation.revoke(claims);
+      }
+    }
+
     res.clearCookie(SESSION_COOKIE);
   }
 }

--- a/apps/mcp-server/src/auth/auth.module.ts
+++ b/apps/mcp-server/src/auth/auth.module.ts
@@ -4,7 +4,12 @@ import {
   type Provider,
   type Type,
 } from '@nestjs/common';
-import { JwtService, OAuthService, SessionService } from '@engram/auth';
+import {
+  JwtRevocationService,
+  JwtService,
+  OAuthService,
+  SessionService,
+} from '@engram/auth';
 import { RedisModule } from '@engram/redis';
 import type { ProfileCapabilities } from '@engram/config';
 import { ApiKeysModule } from '../api-keys/api-keys.module';
@@ -102,7 +107,17 @@ export class AuthModule {
       }
 
       // OAuth login endpoints require both sessions (Redis) and JWT issuance.
+      // The jti denylist (JWT revocation on logout) shares the Redis session
+      // store; without Redis (lite profile) JWTs are not revocable and the
+      // AuthResolver skips the denylist check.
       if (jwtConfig) {
+        providers.push({
+          provide: JwtRevocationService,
+          useFactory: (store: RedisSessionStore): JwtRevocationService =>
+            new JwtRevocationService(store),
+          inject: [RedisSessionStore],
+        });
+        exports.push(JwtRevocationService);
         controllers.push(AuthController);
       }
     }

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -14,6 +14,7 @@ host app (`apps/mcp-server/src/auth`).
 | Building block                                | Responsibility                                                                |
 | --------------------------------------------- | ----------------------------------------------------------------------------- |
 | `JwtService`                                  | Issue/verify HS256 JWTs (`node:crypto`, no external deps).                    |
+| `JwtRevocationService`                        | `jti` denylist over a `JwtDenylistStore` — makes issued JWTs revocable.       |
 | `OAuthService`                                | Registry of configured OAuth providers.                                       |
 | `GitHubOAuthProvider` / `GoogleOAuthProvider` | Authorization-URL build + code→profile exchange.                              |
 | `SessionService`                              | Redis-backed sessions + one-time OAuth `state` (CSRF), over a `SessionStore`. |
@@ -26,9 +27,14 @@ host app (`apps/mcp-server/src/auth`).
   Verification never reads the algorithm from the token to choose a strategy —
   it always computes an HMAC-SHA256 and compares in constant time — so it is
   structurally immune to algorithm-confusion (`none`/`RS256`) attacks.
-- **Stores are interfaces.** `SessionStore` and `RateLimitStore` are implemented
-  by the host (Redis in enterprise); the package ships only the logic, so unit
-  tests run with in-memory fakes and no external services.
+- **Stores are interfaces.** `SessionStore`, `RateLimitStore`, and
+  `JwtDenylistStore` are implemented by the host (Redis in enterprise); the
+  package ships only the logic, so unit tests run with in-memory fakes and no
+  external services.
+- **JWTs are revocable via a `jti` denylist.** Logout writes the token's `jti`
+  with a TTL equal to its remaining lifetime; the auth path checks the denylist
+  after signature/expiry verification. Revocation checks fail closed: a store
+  error rejects the token rather than accepting a possibly-revoked one.
 - **OAuth HTTP is injected** (`OAuthHttpClient`) so token exchange and profile
   fetches are mockable without network access. `FetchOAuthHttpClient` is the
   default platform-`fetch` implementation.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -16,6 +16,7 @@ export {
   type JwtIssueInput,
   type JwtServiceOptions,
 } from './jwt/jwt.service.js';
+export { JwtRevocationService, type JwtDenylistStore } from './jwt/jwt-revocation.service.js';
 
 export { OAuthService } from './oauth/oauth.service.js';
 export {

--- a/packages/auth/src/jwt/jwt-revocation.service.spec.ts
+++ b/packages/auth/src/jwt/jwt-revocation.service.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { JwtService, JwtError } from './jwt.service.js';
+import { JwtRevocationService, type JwtDenylistStore } from './jwt-revocation.service.js';
+
+const SECRET = 'test-secret-must-be-at-least-32-characters-long';
+
+/** In-memory denylist store recording values and TTLs (no expiry simulation). */
+class FakeStore implements JwtDenylistStore {
+  public map = new Map<string, string>();
+  public ttls = new Map<string, number>();
+
+  async set(key: string, value: string, ttlSeconds: number): Promise<void> {
+    this.map.set(key, value);
+    this.ttls.set(key, ttlSeconds);
+  }
+  async get(key: string): Promise<string | null> {
+    return this.map.get(key) ?? null;
+  }
+}
+
+class BrokenStore implements JwtDenylistStore {
+  set(): Promise<void> {
+    return Promise.reject(new Error('redis down'));
+  }
+  get(): Promise<string | null> {
+    return Promise.reject(new Error('redis down'));
+  }
+}
+
+describe('JwtRevocationService', () => {
+  it('denylists a jti with TTL equal to the remaining token lifetime', async () => {
+    const store = new FakeStore();
+    const svc = new JwtRevocationService(store);
+    const revoked = await svc.revoke({ jti: 'tok-1', exp: 1_000_000 }, 999_400);
+    expect(revoked).toBe(true);
+
+    const key = [...store.map.keys()][0]!;
+    expect(key).toContain('tok-1');
+    // exp - at = 1_000_000 - 999_400
+    expect(store.ttls.get(key)).toBe(600);
+    expect(await svc.isRevoked('tok-1')).toBe(true);
+  });
+
+  it('reports non-revoked jtis as valid', async () => {
+    const svc = new JwtRevocationService(new FakeStore());
+    expect(await svc.isRevoked('never-revoked')).toBe(false);
+    await expect(svc.assertNotRevoked('never-revoked')).resolves.toBeUndefined();
+  });
+
+  it('skips the write for an already-expired token', async () => {
+    const store = new FakeStore();
+    const svc = new JwtRevocationService(store);
+    // exp == at (expired this second) and exp < at both skip.
+    expect(await svc.revoke({ jti: 'old', exp: 500 }, 500)).toBe(false);
+    expect(await svc.revoke({ jti: 'older', exp: 400 }, 500)).toBe(false);
+    expect(store.map.size).toBe(0);
+  });
+
+  it('skips the write for an empty jti and fails closed when checking one', async () => {
+    const store = new FakeStore();
+    const svc = new JwtRevocationService(store);
+    expect(await svc.revoke({ jti: '', exp: 10_000 }, 1)).toBe(false);
+    expect(store.map.size).toBe(0);
+    expect(await svc.isRevoked('')).toBe(true);
+  });
+
+  it('assertNotRevoked throws a typed JwtError for a denylisted jti', async () => {
+    const svc = new JwtRevocationService(new FakeStore());
+    await svc.revoke({ jti: 'gone', exp: Math.floor(Date.now() / 1000) + 3600 });
+    await expect(svc.assertNotRevoked('gone')).rejects.toThrowError(
+      expect.objectContaining({ code: 'revoked' })
+    );
+    await expect(svc.assertNotRevoked('gone')).rejects.toBeInstanceOf(JwtError);
+  });
+
+  it('propagates store errors so auth callers can fail closed', async () => {
+    const svc = new JwtRevocationService(new BrokenStore());
+    await expect(svc.isRevoked('any')).rejects.toThrow('redis down');
+    await expect(svc.assertNotRevoked('any')).rejects.toThrow('redis down');
+    await expect(svc.revoke({ jti: 'any', exp: 9_999_999_999 })).rejects.toThrow('redis down');
+  });
+
+  it('revokes real issued tokens end-to-end with JwtService claims', async () => {
+    const jwt = new JwtService({ secret: SECRET, expiresInSeconds: 100 });
+    const svc = new JwtRevocationService(new FakeStore());
+
+    const issuedAt = 2_000_000;
+    const { token, claims } = jwt.issueWithClaims({ userId: 'user-1' }, issuedAt);
+    expect(await svc.isRevoked(claims.jti)).toBe(false);
+
+    expect(await svc.revoke(claims, issuedAt + 40)).toBe(true);
+    expect(await svc.isRevoked(claims.jti)).toBe(true);
+
+    // The token still *verifies* (signature/exp are intact) — revocation is a
+    // separate check layered on top by the auth path.
+    expect(jwt.verify(token, issuedAt + 50).jti).toBe(claims.jti);
+  });
+});

--- a/packages/auth/src/jwt/jwt-revocation.service.ts
+++ b/packages/auth/src/jwt/jwt-revocation.service.ts
@@ -1,0 +1,74 @@
+/**
+ * JWT revocation via a `jti` denylist.
+ *
+ * JWTs are stateless: once issued, an HS256 token verifies until `exp`
+ * (7 days by default) no matter what happens server-side. This service makes
+ * individual tokens revocable by recording their `jti` in a denylist store
+ * (Redis in the host app) with a TTL equal to the token's *remaining*
+ * lifetime — the entry expires exactly when the token itself would, so the
+ * denylist never grows beyond the set of still-live revoked tokens.
+ *
+ * Failure posture: `isRevoked`/`assertNotRevoked` deliberately let store
+ * errors propagate. Callers on the authentication path (e.g. the host app's
+ * `AuthResolver`) treat any error as *invalid* — fail-closed — matching the
+ * API-key posture where a verification error never authenticates. A store
+ * outage therefore degrades JWT auth rather than silently accepting a
+ * possibly-revoked token.
+ */
+
+import { JwtError, type JwtClaims } from './jwt.service.js';
+
+const DENYLIST_PREFIX = 'auth:jwt:denylist:';
+
+/**
+ * Key/value store backing the `jti` denylist. Structurally a subset of
+ * `SessionStore`, so the host's Redis session store satisfies it as-is.
+ * Every write carries an explicit TTL so entries cannot leak.
+ */
+export interface JwtDenylistStore {
+  set(key: string, value: string, ttlSeconds: number): Promise<void>;
+  get(key: string): Promise<string | null>;
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export class JwtRevocationService {
+  constructor(private readonly store: JwtDenylistStore) {}
+
+  /**
+   * Revoke a token by denylisting its `jti` for the token's remaining
+   * lifetime (`exp - atSeconds`). Returns `false` without writing when the
+   * token is already expired (nothing left to revoke) or carries no `jti`.
+   */
+  async revoke(
+    claims: Pick<JwtClaims, 'jti' | 'exp'>,
+    atSeconds: number = nowSeconds()
+  ): Promise<boolean> {
+    const remainingSeconds = claims.exp - atSeconds;
+    if (!claims.jti || remainingSeconds <= 0) {
+      return false;
+    }
+    await this.store.set(DENYLIST_PREFIX + claims.jti, String(atSeconds), remainingSeconds);
+    return true;
+  }
+
+  /**
+   * Whether a `jti` has been revoked. An empty `jti` reports revoked
+   * (fail-closed); store errors propagate to the caller.
+   */
+  async isRevoked(jti: string): Promise<boolean> {
+    if (!jti) {
+      return true;
+    }
+    return (await this.store.get(DENYLIST_PREFIX + jti)) !== null;
+  }
+
+  /** Throw {@link JwtError} (`code: 'revoked'`) when the `jti` is denylisted. */
+  async assertNotRevoked(jti: string): Promise<void> {
+    if (await this.isRevoked(jti)) {
+      throw new JwtError('revoked', 'Token has been revoked');
+    }
+  }
+}

--- a/packages/auth/src/jwt/jwt.service.spec.ts
+++ b/packages/auth/src/jwt/jwt.service.spec.ts
@@ -31,6 +31,24 @@ describe('JwtService', () => {
     expect(claims.jti).toBeTruthy();
   });
 
+  it('issueWithClaims returns the exact claims embedded in the token', () => {
+    const svc = new JwtService({ secret: SECRET, expiresInSeconds: 100 });
+    const issuedAt = 1_000_000;
+    const { token, claims } = svc.issueWithClaims({ userId: 'user-1' }, issuedAt);
+    expect(claims.iat).toBe(issuedAt);
+    expect(claims.exp).toBe(issuedAt + 100);
+    expect(claims.jti).toBeTruthy();
+    // Verifying the token yields the same claims (same jti — no re-mint).
+    expect(svc.verify(token, issuedAt + 1)).toEqual(claims);
+  });
+
+  it('mints a unique jti per token', () => {
+    const svc = new JwtService({ secret: SECRET });
+    const a = svc.issueWithClaims({ userId: 'user-1' }).claims.jti;
+    const b = svc.issueWithClaims({ userId: 'user-1' }).claims.jti;
+    expect(a).not.toBe(b);
+  });
+
   it('defaults optional claims to null/empty', () => {
     const svc = new JwtService({ secret: SECRET });
     const claims = svc.verify(svc.issue({ userId: 'user-2' }));

--- a/packages/auth/src/jwt/jwt.service.ts
+++ b/packages/auth/src/jwt/jwt.service.ts
@@ -29,7 +29,8 @@ export type JwtErrorCode =
   | 'expired'
   | 'not-active'
   | 'issuer'
-  | 'claims';
+  | 'claims'
+  | 'revoked';
 
 /** Typed error thrown by {@link JwtService.verify}. */
 export class JwtError extends Error {
@@ -125,6 +126,18 @@ export class JwtService {
 
   /** Issue a signed token for the given principal. */
   issue(input: JwtIssueInput, issuedAt: number = nowSeconds()): string {
+    return this.issueWithClaims(input, issuedAt).token;
+  }
+
+  /**
+   * Issue a signed token and also return its claims, so callers can bind the
+   * minted `jti`/`exp` to server-side state (e.g. a session, for revocation on
+   * logout) without re-verifying the token they just produced.
+   */
+  issueWithClaims(
+    input: JwtIssueInput,
+    issuedAt: number = nowSeconds()
+  ): { token: string; claims: JwtClaims } {
     const header = { alg: ALG, typ: TOKEN_TYPE };
     const claims: JwtClaims = {
       sub: input.userId,
@@ -140,7 +153,7 @@ export class JwtService {
     const payloadPart = base64urlEncode(JSON.stringify(claims));
     const signingInput = `${headerPart}.${payloadPart}`;
     const signature = this.sign(signingInput);
-    return `${signingInput}.${signature}`;
+    return { token: `${signingInput}.${signature}`, claims };
   }
 
   /**

--- a/packages/auth/src/session/session.service.spec.ts
+++ b/packages/auth/src/session/session.service.spec.ts
@@ -59,6 +59,42 @@ describe('SessionService', () => {
     expect(store.ttls.get(key!)).toBe(42);
   });
 
+  it('round-trips the paired JWT jti/exp when provided', async () => {
+    const store = new FakeStore();
+    const svc = new SessionService(store);
+    const id = await svc.createSession({
+      userId: 'user-1',
+      organizationId: null,
+      email: null,
+      scopes: [],
+      jti: 'jwt-id-1',
+      jwtExp: 1_234_567,
+    });
+    const data = await svc.getSession(id);
+    expect(data?.jti).toBe('jwt-id-1');
+    expect(data?.jwtExp).toBe(1_234_567);
+  });
+
+  it('still parses pre-existing sessions without jti/jwtExp', async () => {
+    const store = new FakeStore();
+    const svc = new SessionService(store);
+    await store.set(
+      'auth:session:legacy',
+      JSON.stringify({
+        userId: 'user-1',
+        organizationId: null,
+        email: null,
+        scopes: [],
+        createdAt: 1,
+      }),
+      60
+    );
+    const data = await svc.getSession('legacy');
+    expect(data?.userId).toBe('user-1');
+    expect(data?.jti).toBeUndefined();
+    expect(data?.jwtExp).toBeUndefined();
+  });
+
   it('returns null for unknown or malformed sessions', async () => {
     const store = new FakeStore();
     const svc = new SessionService(store);

--- a/packages/auth/src/session/session.service.ts
+++ b/packages/auth/src/session/session.service.ts
@@ -14,6 +14,14 @@ export interface SessionData {
   email: string | null;
   scopes: string[];
   createdAt: number;
+  /**
+   * `jti` of the JWT minted alongside this session, when one was. Lets logout
+   * revoke the paired Bearer token even when only the session cookie is
+   * presented. Optional for backwards compatibility with pre-existing sessions.
+   */
+  jti?: string;
+  /** `exp` (seconds since epoch) of the paired JWT, for denylist TTL math. */
+  jwtExp?: number;
 }
 
 const sessionSchema = z
@@ -23,6 +31,8 @@ const sessionSchema = z
     email: z.string().nullable(),
     scopes: z.array(z.string()),
     createdAt: z.number().int(),
+    jti: z.string().min(1).optional(),
+    jwtExp: z.number().int().optional(),
   })
   .strip();
 


### PR DESCRIPTION
## Summary

Closes #202 (security review, auth finding #1).

OAuth login issued a stateless 7-day HS256 JWT alongside a Redis session cookie, but `logout` only destroyed the cookie session — the JWT stayed valid until `exp`, so a leaked or logged-out Bearer token could not be revoked. A `jti` was minted but never consumed.

This PR makes issued JWTs revocable via a Redis `jti` denylist.

## What changed

**`@engram/auth`**
- **`JwtRevocationService`** (new) — `revoke` / `isRevoked` / `assertNotRevoked` over a `JwtDenylistStore`. Each denylist entry's TTL equals the token's **remaining lifetime** (`exp - now`), so it expires exactly when the token would and the list never grows past still-live revoked tokens. Fail-closed: an empty `jti` reports revoked and store errors propagate, so callers on the auth path reject rather than accept a possibly-revoked token.
- **`JwtService.issueWithClaims`** (new) — returns the minted claims so the OAuth callback can bind `jti`/`exp` onto the session without re-verifying the token it just produced. `issue()` is unchanged (delegates to it).
- **`SessionData`** — gains optional `jti` / `jwtExp` (backwards compatible with pre-existing sessions).

**`apps/mcp-server`**
- **`AuthResolver.authenticateJwt`** — after signature/expiry verification, consults the denylist when a `JwtRevocationService` is wired (`@Optional`).
- **`AuthController`** — the OAuth callback binds the minted `jti`/`exp` to the session; `logout` revokes the token via **both** the session record and an `Authorization: Bearer` header on the request (idempotent, `204`).
- **`AuthModule`** — wires `JwtRevocationService` over the Redis session store in the **enterprise** profile only. Without Redis (lite) JWTs are not revocable and the denylist check is skipped.

## Security properties (verified by review)

- Only two `jwt.verify()` sites exist: the auth path (gated, immediately followed by `assertNotRevoked`) and logout (revoke-only). No path authenticates a JWT without consulting the denylist.
- Fail-closed under denylist store errors on the auth path; logout propagates a store error rather than returning a false `204`.
- Denylist keys (`auth:jwt:denylist:`) are disjoint from session/state namespaces; server-generated UUID `jti`s — no cross-user poisoning.

## Tests

Service-level (vitest) and wiring-level (jest), per repo convention:
- `JwtRevocationService`: TTL math, already-expired/empty-`jti` skips, fail-closed store errors, end-to-end with real `JwtService` claims.
- `AuthResolver`: revoked token rejected, fail-closed on store error, lite profile (no revocation) still authenticates, API keys don't consult the denylist.
- `AuthController`: session-jti and Bearer-jti both revoked (incl. distinct-jti dual path), store-error propagation (no false `204`), `eng_` API key not treated as a JWT, legacy `jwtExp` fallback.
- **`auth-logout.wiring.spec.ts`** (new): end-to-end through `AuthController → SessionService/JwtService/JwtRevocationService → AuthResolver → McpAuthMiddleware` — a logged-out Bearer token is rejected at the MCP pipeline and `/auth/me`, per-`jti` isolation, idempotent logout.

All green: `@engram/auth` 41, mcp-server auth 99, mcp-server full unit suite 505; typecheck + lint clean.

## Known limitation

Sessions created **before** this change carry no `jti`, so a cookie-only logout of such a legacy session cannot denylist its paired token (the id was never stored). This residual window self-heals within one token lifetime of deploy — every new login binds `jti`/`jwtExp` — and an API client that resends its Bearer on logout is covered by the header path. Documented inline at the logout guard.

## Incidental

Includes a separate `chore(tooling)` commit fixing a `.lintstagedrc.js` bug (the `*.{json,md,yml,yaml}` handler ran `prettier --write` with no filename, hanging every commit that staged a json/md/yml/yaml file). This was a prerequisite for the pre-commit hook to run to completion on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
