### PR TITLE
fix(auth): copy scopes into issued JWT claims to avoid caller aliasing

### DIFF
--- a/packages/auth/src/jwt/jwt.service.spec.ts
+++ b/packages/auth/src/jwt/jwt.service.spec.ts
@@ -49,6 +49,18 @@ describe('JwtService', () => {
     expect(a).not.toBe(b);
   });
 
+  it('returns claims.scopes as an independent snapshot of the input array', () => {
+    const svc = new JwtService({ secret: SECRET, expiresInSeconds: 100 });
+    const input = ['memories:read'];
+    const { token, claims } = svc.issueWithClaims({ userId: 'user-1', scopes: input }, 1_000_000);
+    // Mutating the caller's array must not leak into the returned claims…
+    input.push('memories:write');
+    expect(claims.scopes).toEqual(['memories:read']);
+    expect(claims.scopes).not.toBe(input);
+    // …and the returned claims still match the (already serialized) token.
+    expect(svc.verify(token, 1_000_001).scopes).toEqual(['memories:read']);
+  });
+
   it('defaults optional claims to null/empty', () => {
     const svc = new JwtService({ secret: SECRET });
     const claims = svc.verify(svc.issue({ userId: 'user-2' }));

--- a/packages/auth/src/jwt/jwt.service.ts
+++ b/packages/auth/src/jwt/jwt.service.ts
@@ -143,7 +143,11 @@ export class JwtService {
       sub: input.userId,
       email: input.email ?? null,
       org: input.organizationId ?? null,
-      scopes: input.scopes ?? [],
+      // Copy the caller's array so the returned claims are an independent
+      // snapshot: issueWithClaims now exposes `claims`, and the sole caller
+      // passes a shared module constant (SESSION_SCOPES) — aliasing it would
+      // let a later mutation of claims.scopes corrupt every future login.
+      scopes: input.scopes ? [...input.scopes] : [],
       iss: this.issuer,
       iat: issuedAt,
       exp: issuedAt + this.expiresInSeconds,


### PR DESCRIPTION
## Summary

Follow-up to #211 (JWT `jti` denylist / logout revocation). Addresses the Copilot review note on that PR, which merged before this commit synced onto the branch.

`JwtService.issueWithClaims` returned a `claims` object whose `scopes` was the **same array reference** as the caller's `input.scopes`. The token payload is a serialized snapshot and is unaffected, but the returned `claims.scopes` aliased the input — and the sole caller (`AuthController` OAuth callback) passes the module-level `SESSION_SCOPES` constant. A future mutation of `claims.scopes` would therefore corrupt that shared constant for every subsequent login.

## Change

- `jwt.service.ts`: copy the array when building claims — `scopes: input.scopes ? [...input.scopes] : []` — so the returned claims are an independent snapshot. `issue()` (which discards claims) is unaffected.
- `jwt.service.spec.ts`: add a test asserting that mutating the caller's array after issuance does not leak into the returned `claims`, and that the claims still match the already-serialized token.

Low severity — no current caller mutates `claims.scopes`, so `main` is not broken; this is defensive hardening.

## Verification

`@engram/auth` tests 42 pass; typecheck, lint, prettier clean. Committed through the full pre-commit + commitlint hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
