### PR TITLE
fix(security): meter ingest_conversation by chunk work to stop amplification (#204)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,13 +61,17 @@ JWT_EXPIRES_IN=7d
 
 # ─── Rate limiting (#132) ────────────────────────────────────────────────────
 # Redis-backed per-tenant / per-key / per-IP rate limiting (enterprise only).
+# Limits are metered in work units, not raw requests: most tool calls cost one
+# unit, but ingest_conversation costs one unit per 10 KB chunk it stores (#204),
+# so bulk ingests draw down the budget proportionally to the work they cause.
 # RATE_LIMIT_ENABLED=false
 # RATE_LIMIT_WINDOW_SEC=60          # window length; *_RPM values are per this window
 # RATE_LIMIT_USER_RPM=120          # per authenticated user
 # RATE_LIMIT_ORG_RPM=6000          # aggregated per organization
 # RATE_LIMIT_IP_RPM=60             # per unauthenticated client IP
-# Per-tool overrides as JSON, e.g. stricter limit on expensive admin tools:
-# RATE_LIMIT_TOOL_OVERRIDES={"reindex_memories":{"limit":2,"windowSeconds":3600}}
+# Per-tool overrides as JSON, e.g. stricter limit on expensive admin tools, or
+# a dedicated chunk budget for bulk ingestion:
+# RATE_LIMIT_TOOL_OVERRIDES={"reindex_memories":{"limit":2,"windowSeconds":3600},"ingest_conversation":{"limit":500,"windowSeconds":3600}}
 
 # BullMQ Queue
 BULL_QUEUE_NAME=engram-jobs

--- a/apps/mcp-server/src/auth/mcp-auth.middleware.ts
+++ b/apps/mcp-server/src/auth/mcp-auth.middleware.ts
@@ -42,21 +42,37 @@ function toAuthInfo(identity: AuthIdentity): McpAuthInfo {
   };
 }
 
-/** Extract the names of every `tools/call` in a JSON-RPC body (single or batch). */
-export function toolCallNames(body: unknown): string[] {
+/** One `tools/call` occurrence in a JSON-RPC body: tool name plus raw arguments. */
+export interface ToolCallEntry {
+  name: string;
+  /** Raw, not-yet-validated `params.arguments` (used for work-proportional rate costs). */
+  arguments: unknown;
+}
+
+/** Extract every `tools/call` in a JSON-RPC body (single or batch) with its arguments. */
+export function toolCallEntries(body: unknown): ToolCallEntry[] {
   const entries = Array.isArray(body) ? body : [body];
-  const names: string[] = [];
+  const calls: ToolCallEntry[] = [];
   for (const entry of entries) {
     if (
       entry &&
       typeof entry === 'object' &&
       (entry as { method?: unknown }).method === 'tools/call'
     ) {
-      const name = (entry as { params?: { name?: unknown } }).params?.name;
-      if (typeof name === 'string') names.push(name);
+      const params = (
+        entry as { params?: { name?: unknown; arguments?: unknown } }
+      ).params;
+      if (typeof params?.name === 'string') {
+        calls.push({ name: params.name, arguments: params.arguments });
+      }
     }
   }
-  return names;
+  return calls;
+}
+
+/** Extract the names of every `tools/call` in a JSON-RPC body (single or batch). */
+export function toolCallNames(body: unknown): string[] {
+  return toolCallEntries(body).map((entry) => entry.name);
 }
 
 function jsonRpcError(res: Response, status: number, message: string): void {

--- a/apps/mcp-server/src/auth/mcp-rate-limit.middleware.spec.ts
+++ b/apps/mcp-server/src/auth/mcp-rate-limit.middleware.spec.ts
@@ -10,13 +10,17 @@ class FakeStore implements RateLimitStore {
   increment(
     key: string,
     windowSeconds: number,
+    units = 1,
   ): Promise<RateLimitIncrementResult> {
     const existing = this.counters.get(key);
     if (!existing || existing.expiresAt <= this.now) {
-      this.counters.set(key, { count: 1, expiresAt: this.now + windowSeconds });
-      return Promise.resolve({ count: 1, ttlSeconds: windowSeconds });
+      this.counters.set(key, {
+        count: units,
+        expiresAt: this.now + windowSeconds,
+      });
+      return Promise.resolve({ count: units, ttlSeconds: windowSeconds });
     }
-    existing.count += 1;
+    existing.count += units;
     return Promise.resolve({
       count: existing.count,
       ttlSeconds: existing.expiresAt - this.now,
@@ -165,5 +169,133 @@ describe('McpRateLimitMiddleware', () => {
     const res = mockRes();
     await mw.handle(batchReq(), res, jest.fn());
     expect(res.statusCode).toBe(429);
+  });
+
+  describe('work-proportional metering for ingest_conversation (#204)', () => {
+    const ingestReq = (
+      turns: Array<{ role: string; content: string }>,
+    ): Request =>
+      ({
+        headers: {},
+        body: {
+          method: 'tools/call',
+          params: {
+            name: 'ingest_conversation',
+            arguments: { userId: 'cjld2cyuq0000t3rmniod1foy', turns },
+          },
+        },
+        auth: authInfo(),
+      }) as unknown as Request;
+
+    const shortTurns = (n: number): Array<{ role: string; content: string }> =>
+      Array.from({ length: n }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: `turn ${i}`,
+      }));
+
+    it('charges one unit per chunk instead of one per request', async () => {
+      const mw = new McpRateLimitMiddleware(
+        new FakeStore(),
+        config({ userRpm: 10 }),
+      );
+
+      // 3 short turns → 3 chunks → 3 units of the 10-unit budget.
+      const res = mockRes();
+      await mw.handle(ingestReq(shortTurns(3)), res, jest.fn());
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['X-RateLimit-Remaining']).toBe('7');
+    });
+
+    it('blocks an ingest whose chunk cost exceeds the remaining budget', async () => {
+      const mw = new McpRateLimitMiddleware(
+        new FakeStore(),
+        config({ userRpm: 10 }),
+      );
+
+      // 3 units consumed...
+      await mw.handle(ingestReq(shortTurns(3)), mockRes(), jest.fn());
+      // ...then 8 more units exceed the 10-unit budget → 429.
+      const blocked = mockRes();
+      await mw.handle(ingestReq(shortTurns(8)), blocked, jest.fn());
+      expect(blocked.statusCode).toBe(429);
+      expect(blocked.headers['Retry-After']).toBeDefined();
+    });
+
+    it('charges oversized turns per 10 KB chunk, not per turn', async () => {
+      const mw = new McpRateLimitMiddleware(
+        new FakeStore(),
+        config({ userRpm: 2 }),
+      );
+
+      // One turn of ~30 KB splits into ≥3 chunks → exceeds a 2-unit budget in
+      // a single request even though it is only one turn.
+      const oneBigTurn = [{ role: 'user', content: 'X'.repeat(30_720) }];
+      const res = mockRes();
+      await mw.handle(ingestReq(oneBigTurn), res, jest.fn());
+      expect(res.statusCode).toBe(429);
+    });
+
+    it('drains the organization budget proportionally as well', async () => {
+      const mw = new McpRateLimitMiddleware(
+        new FakeStore(),
+        config({ userRpm: 100, orgRpm: 5 }),
+      );
+      const req = (): Request =>
+        ({
+          ...(ingestReq(shortTurns(6)) as object),
+          auth: authInfo({ organizationId: 'org-1' }),
+        }) as unknown as Request;
+
+      const res = mockRes();
+      await mw.handle(req(), res, jest.fn());
+      // 6 chunks > 5-unit org budget → blocked by the org bucket.
+      expect(res.statusCode).toBe(429);
+    });
+
+    it('still charges a single unit when ingest arguments are malformed', async () => {
+      const mw = new McpRateLimitMiddleware(
+        new FakeStore(),
+        config({ userRpm: 10 }),
+      );
+      const malformed = {
+        headers: {},
+        body: {
+          method: 'tools/call',
+          params: { name: 'ingest_conversation', arguments: { turns: 'nope' } },
+        },
+        auth: authInfo(),
+      } as unknown as Request;
+
+      const res = mockRes();
+      await mw.handle(malformed, res, jest.fn());
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['X-RateLimit-Remaining']).toBe('9');
+    });
+
+    it('meters ingest chunks in unauthenticated (per-IP) buckets too', async () => {
+      const mw = new McpRateLimitMiddleware(
+        new FakeStore(),
+        config({ ipRpm: 4 }),
+      );
+      const anonReq = {
+        headers: {},
+        ip: '9.9.9.9',
+        body: {
+          method: 'tools/call',
+          params: {
+            name: 'ingest_conversation',
+            arguments: {
+              userId: 'cjld2cyuq0000t3rmniod1foy',
+              turns: shortTurns(5),
+            },
+          },
+        },
+      } as unknown as Request;
+
+      const res = mockRes();
+      await mw.handle(anonReq, res, jest.fn());
+      // 5 chunks > 4-unit IP budget → blocked in one request.
+      expect(res.statusCode).toBe(429);
+    });
   });
 });

--- a/apps/mcp-server/src/auth/mcp-rate-limit.middleware.ts
+++ b/apps/mcp-server/src/auth/mcp-rate-limit.middleware.ts
@@ -6,7 +6,8 @@ import {
   type RateLimitStore,
 } from '@engram/auth';
 import type { RateLimitConfig } from './auth.config';
-import { toolCallNames, type AuthedRequest } from './mcp-auth.middleware';
+import { toolCallEntries, type AuthedRequest } from './mcp-auth.middleware';
+import { toolCallUnits } from './tool-call-cost';
 
 function clientIp(req: Request): string {
   // req.ip is the direct TCP peer unless Express `trust proxy` is configured.
@@ -66,9 +67,19 @@ export class McpRateLimitMiddleware {
     // its tools/call entries, so charging only the first would let a single
     // batched request bypass the limit. Requests with no tools/call (e.g.
     // initialize) are charged once against the default bucket.
-    const names = toolCallNames(req.body);
-    const calls: Array<string | undefined> =
-      names.length > 0 ? names : [undefined];
+    //
+    // Each call is charged its work-proportional cost: ordinary tools cost one
+    // unit, while `ingest_conversation` costs one unit per 10 KB chunk it will
+    // store — a single metered request can no longer drive hundreds of
+    // embedding/DB operations (#204).
+    const entries = toolCallEntries(req.body);
+    const calls: Array<{ tool?: string; units: number }> =
+      entries.length > 0
+        ? entries.map((entry) => ({
+            tool: entry.name,
+            units: toolCallUnits(entry.name, entry.arguments),
+          }))
+        : [{ tool: undefined, units: 1 }];
 
     // Meter per-key for API keys (independent budget per key) and per-user for
     // interactive JWT sessions — satisfying #132's "per tenant/key".
@@ -77,21 +88,26 @@ export class McpRateLimitMiddleware {
       : `user:${auth?.extra.userId}`;
 
     const results: RateLimitResult[] = [];
-    for (const tool of calls) {
+    for (const { tool, units } of calls) {
       if (auth) {
         results.push(
-          await this.userLimiter.consume({ key: principalKey, tool }),
+          await this.userLimiter.consume({ key: principalKey, tool, units }),
         );
         if (auth.extra.organizationId) {
           results.push(
             await this.orgLimiter.consume({
               key: `org:${auth.extra.organizationId}`,
+              units,
             }),
           );
         }
       } else {
         results.push(
-          await this.ipLimiter.consume({ key: `ip:${clientIp(req)}`, tool }),
+          await this.ipLimiter.consume({
+            key: `ip:${clientIp(req)}`,
+            tool,
+            units,
+          }),
         );
       }
     }

--- a/apps/mcp-server/src/auth/redis-rate-limit.store.spec.ts
+++ b/apps/mcp-server/src/auth/redis-rate-limit.store.spec.ts
@@ -23,12 +23,30 @@ describe('RedisRateLimitStore', () => {
 
     expect(result).toEqual({ count: 3, ttlSeconds: 42 });
     expect(evalMock).toHaveBeenCalledWith(
-      expect.stringContaining('INCR'),
+      expect.stringContaining('INCRBY'),
       1,
       'rl:user:1',
       60,
+      1,
     );
     expect(redis.incr).not.toHaveBeenCalled();
+  });
+
+  it('passes multi-unit increments through the Lua eval path', async () => {
+    const evalMock = jest.fn().mockResolvedValue([7, 42]);
+    const redis = makeRedis({}, { eval: evalMock });
+    const store = new RedisRateLimitStore(redis);
+
+    const result = await store.increment('rl:user:1', 60, 7);
+
+    expect(result).toEqual({ count: 7, ttlSeconds: 42 });
+    expect(evalMock).toHaveBeenCalledWith(
+      expect.stringContaining('INCRBY'),
+      1,
+      'rl:user:1',
+      60,
+      7,
+    );
   });
 
   it('falls back to discrete commands when eval throws', async () => {
@@ -53,6 +71,50 @@ describe('RedisRateLimitStore', () => {
       count: 1,
       ttlSeconds: 30,
     });
+  });
+
+  it('increments by units in the fallback path and anchors the window on first hit', async () => {
+    const incrMock = jest.fn().mockResolvedValue(5);
+    const redis = makeRedis({ incr: incrMock });
+    const store = new RedisRateLimitStore(redis);
+
+    // Fresh window: counter equals the increment amount → TTL is applied.
+    expect(await store.increment('k', 30, 5)).toEqual({
+      count: 5,
+      ttlSeconds: 30,
+    });
+    expect(incrMock).toHaveBeenCalledWith('k', 5);
+    expect(redis.expire).toHaveBeenCalledWith('k', 30);
+  });
+
+  it('does not re-anchor the window on subsequent multi-unit hits', async () => {
+    const redis = makeRedis({
+      incr: jest.fn().mockResolvedValue(9), // 4 existing + 5 new ≠ 5 → not first hit
+      ttl: jest.fn().mockResolvedValue(21),
+    });
+    const store = new RedisRateLimitStore(redis);
+
+    expect(await store.increment('k', 60, 5)).toEqual({
+      count: 9,
+      ttlSeconds: 21,
+    });
+    expect(redis.expire).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes non-positive units to a single unit', async () => {
+    const evalMock = jest.fn().mockResolvedValue([1, 60]);
+    const redis = makeRedis({}, { eval: evalMock });
+    const store = new RedisRateLimitStore(redis);
+
+    await store.increment('k', 60, 0);
+
+    expect(evalMock).toHaveBeenCalledWith(
+      expect.stringContaining('INCRBY'),
+      1,
+      'k',
+      60,
+      1,
+    );
   });
 
   it('returns the existing TTL on subsequent hits within the window', async () => {

--- a/apps/mcp-server/src/auth/redis-rate-limit.store.ts
+++ b/apps/mcp-server/src/auth/redis-rate-limit.store.ts
@@ -11,22 +11,30 @@ interface EvalCapable {
   ) => Promise<unknown>;
 }
 
-// Atomically: increment the counter; set the window TTL only on the first hit;
-// return [count, ttl]. Keeping this in one round-trip avoids a window that can
-// grow without ever expiring if the process dies between INCR and EXPIRE.
+// Atomically: increment the counter by the requested units; set the window TTL
+// only on the first hit (counter equals the increment amount); return
+// [count, ttl]. Keeping this in one round-trip avoids a window that can grow
+// without ever expiring if the process dies between INCRBY and EXPIRE.
 const INCR_SCRIPT = `
-local count = redis.call('INCR', KEYS[1])
-if count == 1 then
+local count = redis.call('INCRBY', KEYS[1], ARGV[2])
+if count == tonumber(ARGV[2]) then
   redis.call('EXPIRE', KEYS[1], ARGV[1])
 end
 local ttl = redis.call('TTL', KEYS[1])
 return {count, ttl}
 `;
 
+/** Clamp increment units to a positive integer (defensive; the service already normalizes). */
+function sanitizeUnits(units: number): number {
+  return Number.isFinite(units) ? Math.max(1, Math.floor(units)) : 1;
+}
+
 /**
  * Redis-backed fixed-window counter for {@link RateLimitService}. Uses a Lua
- * script for an atomic INCR + first-hit EXPIRE + TTL read; falls back to
- * discrete commands if the client cannot `eval`.
+ * script for an atomic INCRBY + first-hit EXPIRE + TTL read; falls back to
+ * discrete commands if the client cannot `eval`. Increments by `units` so the
+ * limiter can charge work-proportional costs (e.g. one unit per ingested
+ * chunk) in a single atomic step.
  */
 @Injectable()
 export class RedisRateLimitStore implements RateLimitStore {
@@ -37,7 +45,9 @@ export class RedisRateLimitStore implements RateLimitStore {
   async increment(
     key: string,
     windowSeconds: number,
+    units = 1,
   ): Promise<RateLimitIncrementResult> {
+    const increment = sanitizeUnits(units);
     const client = this.redis.getClient() as EvalCapable;
     if (typeof client.eval === 'function') {
       try {
@@ -46,6 +56,7 @@ export class RedisRateLimitStore implements RateLimitStore {
           1,
           key,
           windowSeconds,
+          increment,
         )) as [number, number];
         return { count: Number(result[0]), ttlSeconds: Number(result[1]) };
       } catch (error) {
@@ -54,15 +65,17 @@ export class RedisRateLimitStore implements RateLimitStore {
         );
       }
     }
-    return this.incrementWithoutEval(key, windowSeconds);
+    return this.incrementWithoutEval(key, windowSeconds, increment);
   }
 
   private async incrementWithoutEval(
     key: string,
     windowSeconds: number,
+    units: number,
   ): Promise<RateLimitIncrementResult> {
-    const count = await this.redis.incr(key);
-    if (count === 1) {
+    const count = await this.redis.incr(key, units);
+    // First hit of a window: the counter equals this increment exactly.
+    if (count === units) {
       await this.redis.expire(key, windowSeconds);
       return { count, ttlSeconds: windowSeconds };
     }

--- a/apps/mcp-server/src/auth/tool-call-cost.spec.ts
+++ b/apps/mcp-server/src/auth/tool-call-cost.spec.ts
@@ -1,0 +1,72 @@
+import { toolCallUnits } from './tool-call-cost';
+import {
+  INGEST_CHUNK_CHAR_LIMIT,
+  INGEST_MAX_CHUNKS,
+  countConversationChunks,
+} from '../memory/conversation-chunking';
+
+describe('toolCallUnits', () => {
+  it('charges one unit for ordinary tools', () => {
+    expect(toolCallUnits('recall', { userId: 'u', query: 'q' })).toBe(1);
+    expect(toolCallUnits('remember', { content: 'x'.repeat(100_000) })).toBe(1);
+    expect(toolCallUnits('ping', undefined)).toBe(1);
+  });
+
+  it('charges ingest_conversation one unit per turn for normal-sized turns', () => {
+    const args = {
+      userId: 'u',
+      turns: [
+        { role: 'user', content: 'What is TypeScript?' },
+        { role: 'assistant', content: 'A typed superset of JavaScript.' },
+        { role: 'user', content: 'Thanks!' },
+      ],
+    };
+    expect(toolCallUnits('ingest_conversation', args)).toBe(3);
+  });
+
+  it('charges per chunk, not per turn, when turns exceed the chunk limit', () => {
+    // A single ~30 KB turn splits into multiple 10 KB chunks.
+    const turns = [
+      { role: 'user', content: 'X'.repeat(3 * INGEST_CHUNK_CHAR_LIMIT) },
+    ];
+    const units = toolCallUnits('ingest_conversation', { userId: 'u', turns });
+    expect(units).toBeGreaterThanOrEqual(3);
+    // Exactly the count the ingest path will produce.
+    expect(units).toBe(countConversationChunks(turns));
+  });
+
+  it('clamps units at INGEST_MAX_CHUNKS for an over-cap request (#204)', () => {
+    // A few oversized turns expand past the 500-chunk cap. Such a request is
+    // rejected by the schema before any remember() runs, so the meter must not
+    // charge more than the maximum legitimate ingest against shared buckets.
+    const bigContent = 'X'.repeat(90 * INGEST_CHUNK_CHAR_LIMIT);
+    const turns = Array.from({ length: 6 }, () => ({
+      role: 'user',
+      content: bigContent,
+    }));
+    expect(countConversationChunks(turns)).toBeGreaterThan(INGEST_MAX_CHUNKS);
+    expect(toolCallUnits('ingest_conversation', { userId: 'u', turns })).toBe(
+      INGEST_MAX_CHUNKS,
+    );
+  });
+
+  it.each([
+    ['null args', null],
+    ['non-object args', 'turns'],
+    ['array args', [{ role: 'user', content: 'hi' }]],
+    ['missing turns', { userId: 'u' }],
+    ['turns not an array', { turns: 'hello' }],
+    ['empty turns', { turns: [] }],
+    ['turn is not an object', { turns: ['hi'] }],
+    [
+      'turn with non-string content',
+      { turns: [{ role: 'user', content: 42 }] },
+    ],
+    ['turn with missing role', { turns: [{ content: 'hi' }] }],
+  ])(
+    'charges one unit for malformed arguments (%s) — Zod rejects them at dispatch',
+    (_label, args) => {
+      expect(toolCallUnits('ingest_conversation', args)).toBe(1);
+    },
+  );
+});

--- a/apps/mcp-server/src/auth/tool-call-cost.ts
+++ b/apps/mcp-server/src/auth/tool-call-cost.ts
@@ -1,0 +1,63 @@
+/**
+ * Work-proportional rate-limit costs for MCP tool calls.
+ *
+ * Most tools perform O(1) downstream work and cost one unit. A few fan out:
+ * `ingest_conversation` chunks its turns at 10 KB and calls `remember()`
+ * (embedding + vector search + DB write) once per chunk — up to hundreds of
+ * operations from a single `tools/call`. Charging one unit per chunk makes the
+ * limiter meter the actual work instead of the request count (issue #204).
+ */
+import {
+  INGEST_MAX_CHUNKS,
+  countConversationChunks,
+  type ConversationTurn,
+} from '../memory/conversation-chunking';
+
+const INGEST_CONVERSATION_TOOL = 'ingest_conversation';
+
+/**
+ * Best-effort extraction of `turns` from raw, not-yet-validated tool
+ * arguments. Returns null when the shape is unusable — such requests are
+ * charged a single unit and then rejected by Zod at dispatch before any
+ * fan-out work happens, so under-charging them is safe.
+ */
+function parseTurns(args: unknown): ConversationTurn[] | null {
+  if (args == null || typeof args !== 'object' || Array.isArray(args)) {
+    return null;
+  }
+  const turns = (args as { turns?: unknown }).turns;
+  if (!Array.isArray(turns) || turns.length === 0) return null;
+
+  const parsed: ConversationTurn[] = [];
+  for (const turn of turns) {
+    if (turn == null || typeof turn !== 'object' || Array.isArray(turn)) {
+      return null;
+    }
+    const { role, content } = turn as { role?: unknown; content?: unknown };
+    if (typeof role !== 'string' || typeof content !== 'string') return null;
+    parsed.push({ role, content });
+  }
+  return parsed;
+}
+
+/**
+ * Rate-limit units a single `tools/call` should be charged.
+ * One unit for ordinary tools; one unit per stored chunk for
+ * `ingest_conversation` (exactly the chunking the ingest path performs).
+ *
+ * Clamped to {@link INGEST_MAX_CHUNKS}: a request whose chunk count exceeds the
+ * cap is rejected by the schema before any `remember()` runs (#204), so it does
+ * zero downstream work. Charging it more than the maximum legitimate ingest
+ * would only let a to-be-rejected request drain the shared user/org budget past
+ * the real work ceiling, penalizing co-tenants — so the meter tops out at the
+ * cap the ingest can actually reach.
+ */
+export function toolCallUnits(name: string, args: unknown): number {
+  if (name !== INGEST_CONVERSATION_TOOL) return 1;
+  const turns = parseTurns(args);
+  if (turns == null) return 1;
+  return Math.min(
+    INGEST_MAX_CHUNKS,
+    Math.max(1, countConversationChunks(turns)),
+  );
+}

--- a/apps/mcp-server/src/memory/conversation-chunking.spec.ts
+++ b/apps/mcp-server/src/memory/conversation-chunking.spec.ts
@@ -1,0 +1,82 @@
+import {
+  INGEST_CHUNK_CHAR_LIMIT,
+  INGEST_MAX_CHUNKS,
+  countConversationChunks,
+  splitTurnsToChunks,
+} from './conversation-chunking';
+
+describe('conversation-chunking', () => {
+  describe('splitTurnsToChunks', () => {
+    it('returns one chunk per short turn', () => {
+      const chunks = splitTurnsToChunks([
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there' },
+      ]);
+      expect(chunks).toEqual(['user: Hello', 'assistant: Hi there']);
+    });
+
+    it('splits oversized turns into chunks within the char limit', () => {
+      const longContent = 'A'.repeat(6000) + '\n\n' + 'B'.repeat(6000);
+      const chunks = splitTurnsToChunks([
+        { role: 'user', content: longContent },
+      ]);
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const c of chunks) {
+        expect(c.length).toBeLessThanOrEqual(INGEST_CHUNK_CHAR_LIMIT);
+      }
+    });
+
+    it('hard-cuts a single paragraph longer than the limit, prefixing every slice', () => {
+      const chunks = splitTurnsToChunks([
+        { role: 'user', content: 'X'.repeat(25_000) },
+      ]);
+      expect(chunks.length).toBeGreaterThanOrEqual(3);
+      for (const c of chunks) {
+        expect(c.length).toBeLessThanOrEqual(INGEST_CHUNK_CHAR_LIMIT);
+        expect(c.startsWith('user: ')).toBe(true);
+      }
+    });
+  });
+
+  describe('countConversationChunks', () => {
+    it('always matches the length of the actual split (single source of truth)', () => {
+      const cases = [
+        [{ role: 'user', content: 'short' }],
+        [{ role: 'user', content: 'X'.repeat(25_000) }],
+        [
+          {
+            role: 'user',
+            content: 'A'.repeat(6000) + '\n\n' + 'B'.repeat(6000),
+          },
+          { role: 'assistant', content: 'ok' },
+        ],
+        Array.from({ length: 40 }, (_, i) => ({
+          role: 'user',
+          content: `turn ${i}`,
+        })),
+      ];
+      for (const turns of cases) {
+        expect(countConversationChunks(turns)).toBe(
+          splitTurnsToChunks(turns).length,
+        );
+      }
+    });
+
+    it('counts at least one chunk per turn', () => {
+      const turns = Array.from({ length: 7 }, (_, i) => ({
+        role: 'user',
+        content: `t${i}`,
+      }));
+      expect(countConversationChunks(turns)).toBe(7);
+    });
+  });
+
+  describe('caps', () => {
+    it('caps requests at 500 chunks, matching the 500-turn schema maximum', () => {
+      // Each turn yields at least one chunk, so a cap below the schema's max
+      // turn count would reject conversations the schema explicitly allows.
+      expect(INGEST_MAX_CHUNKS).toBe(500);
+      expect(INGEST_CHUNK_CHAR_LIMIT).toBe(10_240);
+    });
+  });
+});

--- a/apps/mcp-server/src/memory/conversation-chunking.ts
+++ b/apps/mcp-server/src/memory/conversation-chunking.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure helpers for splitting conversation turns into storable chunks.
+ *
+ * Shared by:
+ *   - `MemoryService.ingestConversation` (the actual chunk-and-store fan-out),
+ *   - the `ingest_conversation` Zod schema (rejecting requests whose chunk
+ *     fan-out exceeds {@link INGEST_MAX_CHUNKS}),
+ *   - the MCP rate-limit middleware (charging one rate-limit unit per chunk so
+ *     a single `tools/call` cannot amplify into hundreds of unmetered
+ *     embedding/DB operations — see issue #204).
+ *
+ * Keeping the split logic in one place guarantees the cap, the meter, and the
+ * ingest itself always agree on the chunk count.
+ */
+
+/** Max characters per stored chunk (single-memory size cap). */
+export const INGEST_CHUNK_CHAR_LIMIT = 10_240;
+
+/**
+ * Hard cap on the total chunks a single `ingest_conversation` request may
+ * expand to. Each turn yields at least one chunk, so this cap (aligned with
+ * the schema's 500-turn maximum) never rejects a conversation of normal-sized
+ * turns — it only stops oversized turns from amplifying one request into an
+ * unbounded number of `remember()` calls (embedding + vector search + DB
+ * write each). Requests above the cap are rejected with a clear error; the
+ * per-chunk rate-limit charge governs sustained throughput below it.
+ */
+export const INGEST_MAX_CHUNKS = 500;
+
+export interface ConversationTurn {
+  role: string;
+  content: string;
+}
+
+/**
+ * Format conversation turns into storable chunks ≤ `charLimit` chars each.
+ * Each turn becomes "<role>: <content>". Turns exceeding the limit are split
+ * at double-newline boundaries (paragraphs), falling back to hard char cuts.
+ */
+export function splitTurnsToChunks(
+  turns: ConversationTurn[],
+  charLimit = INGEST_CHUNK_CHAR_LIMIT,
+): string[] {
+  const chunks: string[] = [];
+  for (const { role, content } of turns) {
+    const formatted = `${role}: ${content}`;
+    if (formatted.length <= charLimit) {
+      chunks.push(formatted);
+      continue;
+    }
+    // Split oversized turns at paragraph breaks, then hard-cut if needed
+    const prefix = `${role}: `;
+    const paragraphs = content.split(/\n\n+/).filter((p) => p.trim() !== '');
+    if (paragraphs.length === 0) {
+      // All-whitespace oversized content: hard-cut as-is to avoid silent drop
+      for (let i = 0; i < formatted.length; i += charLimit) {
+        chunks.push(formatted.slice(i, i + charLimit));
+      }
+      continue;
+    }
+    let current = prefix;
+    for (const para of paragraphs) {
+      const addition = (current === prefix ? '' : '\n\n') + para;
+      if (current.length + addition.length <= charLimit) {
+        current += addition;
+      } else {
+        if (current !== prefix) {
+          chunks.push(current);
+        }
+        // Hard-cut: prefix every slice so each chunk is self-contained
+        const chunkContent = charLimit - prefix.length;
+        for (let i = 0; i < para.length; i += chunkContent) {
+          chunks.push(`${prefix}${para.slice(i, i + chunkContent)}`);
+        }
+        current = prefix;
+      }
+    }
+    if (current !== prefix) {
+      chunks.push(current);
+    }
+  }
+  return chunks;
+}
+
+/**
+ * Number of chunks `turns` expands to when ingested. Exact by construction:
+ * it runs the same splitter the ingest path uses.
+ */
+export function countConversationChunks(
+  turns: ConversationTurn[],
+  charLimit = INGEST_CHUNK_CHAR_LIMIT,
+): number {
+  return splitTurnsToChunks(turns, charLimit).length;
+}

--- a/apps/mcp-server/src/memory/dto/ingest-conversation.dto.spec.ts
+++ b/apps/mcp-server/src/memory/dto/ingest-conversation.dto.spec.ts
@@ -1,0 +1,58 @@
+import {
+  ingestConversationToolSchema,
+  INGEST_MAX_CHUNKS,
+} from './ingest-conversation.dto';
+import { countConversationChunks } from '../conversation-chunking';
+
+// A valid cuid1 accepted by userIdSchema.
+const USER_ID = 'cjld2cyuq0000t3rmniod1foy';
+
+describe('ingestConversationToolSchema', () => {
+  it('accepts a normal conversation within the chunk cap', () => {
+    const result = ingestConversationToolSchema.safeParse({
+      userId: USER_ID,
+      turns: [
+        { role: 'user', content: 'Hello, what is TypeScript?' },
+        { role: 'assistant', content: 'A typed superset of JavaScript.' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a conversation that expands past INGEST_MAX_CHUNKS (#204)', () => {
+    // A handful of oversized single-paragraph turns blow past the 500-chunk cap
+    // while staying within the 500-turn and 1 MB-per-turn limits — exactly the
+    // amplification (one request → hundreds of remember() calls) the cap stops.
+    const bigContent = 'X'.repeat(90 * 10_240);
+    const turns = Array.from({ length: 6 }, () => ({
+      role: 'user',
+      content: bigContent,
+    }));
+    // Sanity-check the fixture really exceeds the cap (guards against arithmetic
+    // drift if the chunk limit ever changes).
+    expect(countConversationChunks(turns)).toBeGreaterThan(INGEST_MAX_CHUNKS);
+
+    const result = ingestConversationToolSchema.safeParse({
+      userId: USER_ID,
+      turns,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((i) => i.message).join(' ')).toMatch(
+        /exceeding the maximum of 500/,
+      );
+    }
+  });
+
+  it('rejects more than 500 turns outright', () => {
+    const turns = Array.from({ length: 501 }, (_, i) => ({
+      role: 'user',
+      content: `t${i}`,
+    }));
+    expect(
+      ingestConversationToolSchema.safeParse({ userId: USER_ID, turns })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/apps/mcp-server/src/memory/dto/ingest-conversation.dto.ts
+++ b/apps/mcp-server/src/memory/dto/ingest-conversation.dto.ts
@@ -1,7 +1,10 @@
 import { userIdSchema } from '@engram/database';
 import { z } from 'zod';
-
-const CHUNK_CHAR_LIMIT = 10240;
+import {
+  INGEST_CHUNK_CHAR_LIMIT as CHUNK_CHAR_LIMIT,
+  INGEST_MAX_CHUNKS,
+  countConversationChunks,
+} from '../conversation-chunking';
 
 export const ingestConversationToolSchema = z
   .object({
@@ -11,6 +14,12 @@ export const ingestConversationToolSchema = z
      * Each turn is chunked by content; turns longer than 10 KB are split at
      * double-newline (paragraph) boundaries, with a hard character-cut fallback,
      * so no individual stored memory exceeds the 10 KB limit.
+     *
+     * The whole request is additionally capped at {@link INGEST_MAX_CHUNKS}
+     * total chunks: every chunk costs one `remember()` call (embedding +
+     * vector search + DB write), so an uncapped request could amplify into
+     * hundreds of downstream operations (#204). Requests above the cap are
+     * rejected — split the conversation into smaller ingests.
      */
     turns: z
       .array(
@@ -22,7 +31,18 @@ export const ingestConversationToolSchema = z
           .strict(),
       )
       .min(1)
-      .max(500),
+      .max(500)
+      .superRefine((turns, ctx) => {
+        const chunkCount = countConversationChunks(turns);
+        if (chunkCount > INGEST_MAX_CHUNKS) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              `conversation expands to ${chunkCount} chunks, exceeding the maximum of ` +
+              `${INGEST_MAX_CHUNKS} per request; split the ingest into smaller batches`,
+          });
+        }
+      }),
     tags: z.array(z.string().min(1).max(100)).max(50).optional().default([]),
     metadata: z.record(z.string(), z.unknown()).optional(),
     /**
@@ -38,3 +58,4 @@ export type IngestConversationToolInput = z.infer<
 >;
 
 export const INGEST_CHUNK_CHAR_LIMIT = CHUNK_CHAR_LIMIT;
+export { INGEST_MAX_CHUNKS };

--- a/apps/mcp-server/src/memory/memory.c1.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.c1.service.spec.ts
@@ -4,6 +4,7 @@ import { MemoryStmService, StmMemoryNotFoundError } from '@engram/memory-stm';
 import { MemoryLtmService, ImportanceScoringService } from '@engram/memory-ltm';
 import type { LtmMemory } from '@engram/memory-ltm';
 import type { Memory } from '@engram/database';
+import { INGEST_MAX_CHUNKS } from './conversation-chunking';
 
 const USER_ID = 'clm0000000000000000000000';
 const MEM_ID = 'clm1111111111111111111111';
@@ -800,6 +801,28 @@ describe('MemoryService — C2 Bulk Conversation Ingestion', () => {
       expect(result.total).toBe(100);
       expect(result.ingested + result.skipped + result.failed).toBe(100);
       expect(result.memoryIds).toHaveLength(100);
+    });
+
+    it('throws before any remember() when the conversation exceeds the chunk cap (#204)', async () => {
+      // Defense in depth behind the tool-schema cap: a caller that bypasses the
+      // Zod schema still cannot amplify one request into hundreds of remember()
+      // calls. 501 short turns → 501 chunks → over INGEST_MAX_CHUNKS (500).
+      const turns = Array.from({ length: INGEST_MAX_CHUNKS + 1 }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: `turn ${i}`,
+      }));
+
+      await expect(
+        service.ingestConversation({
+          userId: USER_ID,
+          turns,
+          concurrency: 5,
+          tags: [],
+        }),
+      ).rejects.toThrow(/exceeding the maximum of 500/);
+
+      // Rejected before fan-out — no embedding/DB writes were attempted.
+      expect(mockLtmService.create).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -12,6 +12,11 @@ import {
 } from '@engram/memory-ltm';
 import { Memory } from '@engram/database';
 import { MetricsService } from '../metrics/metrics.service';
+import {
+  INGEST_CHUNK_CHAR_LIMIT,
+  INGEST_MAX_CHUNKS,
+  splitTurnsToChunks,
+} from './conversation-chunking';
 
 type MemoryListResult = {
   items: Memory[];
@@ -884,6 +889,19 @@ export class MemoryService {
   }): Promise<IngestConversationResult> {
     const chunks = MemoryService.splitTurnsToChunks(input.turns);
 
+    // Defense in depth behind the schema-level cap: every chunk fans out into
+    // a remember() call (embedding + vector search + DB write), so an
+    // unbounded chunk count would let one request amplify into hundreds of
+    // downstream operations (#204). The tool schema rejects this earlier; this
+    // guard covers any other caller of the service.
+    if (chunks.length > INGEST_MAX_CHUNKS) {
+      throw new Error(
+        `ingest_conversation expands to ${chunks.length} chunks, exceeding the ` +
+          `maximum of ${INGEST_MAX_CHUNKS} per request; split the conversation ` +
+          `into smaller ingests`,
+      );
+    }
+
     const accum = {
       ingested: 0,
       skipped: 0,
@@ -1130,50 +1148,16 @@ export class MemoryService {
    * Format conversation turns into storable chunks ≤ 10 KB each.
    * Each turn becomes "<role>: <content>". Turns exceeding the limit are split
    * at double-newline boundaries (paragraphs), falling back to hard char cuts.
+   *
+   * Delegates to the shared `conversation-chunking` helper so the ingest path,
+   * the input-schema chunk cap, and the rate-limit cost meter all agree on the
+   * chunk count (#204).
    */
   static splitTurnsToChunks(
     turns: Array<{ role: string; content: string }>,
-    charLimit = 10240,
+    charLimit = INGEST_CHUNK_CHAR_LIMIT,
   ): string[] {
-    const chunks: string[] = [];
-    for (const { role, content } of turns) {
-      const formatted = `${role}: ${content}`;
-      if (formatted.length <= charLimit) {
-        chunks.push(formatted);
-        continue;
-      }
-      // Split oversized turns at paragraph breaks, then hard-cut if needed
-      const prefix = `${role}: `;
-      const paragraphs = content.split(/\n\n+/).filter((p) => p.trim() !== '');
-      if (paragraphs.length === 0) {
-        // All-whitespace oversized content: hard-cut as-is to avoid silent drop
-        for (let i = 0; i < formatted.length; i += charLimit) {
-          chunks.push(formatted.slice(i, i + charLimit));
-        }
-        continue;
-      }
-      let current = prefix;
-      for (const para of paragraphs) {
-        const addition = (current === prefix ? '' : '\n\n') + para;
-        if (current.length + addition.length <= charLimit) {
-          current += addition;
-        } else {
-          if (current !== prefix) {
-            chunks.push(current);
-          }
-          // Hard-cut: prefix every slice so each chunk is self-contained
-          const chunkContent = charLimit - prefix.length;
-          for (let i = 0; i < para.length; i += chunkContent) {
-            chunks.push(`${prefix}${para.slice(i, i + chunkContent)}`);
-          }
-          current = prefix;
-        }
-      }
-      if (current !== prefix) {
-        chunks.push(current);
-      }
-    }
-    return chunks;
+    return splitTurnsToChunks(turns, charLimit);
   }
 
   /**

--- a/packages/auth/src/ratelimit/rate-limit-store.ts
+++ b/packages/auth/src/ratelimit/rate-limit-store.ts
@@ -14,9 +14,13 @@ export interface RateLimitIncrementResult {
 
 export interface RateLimitStore {
   /**
-   * Atomically increment the counter at `key`. The window TTL must be applied
-   * on the first increment (when the counter becomes 1) and left untouched
-   * thereafter, giving a fixed window anchored at the first request.
+   * Atomically increment the counter at `key` by `units` (a positive integer,
+   * defaulting to 1). The window TTL must be applied on the first increment of
+   * a window (when the counter transitions from absent to `units`) and left
+   * untouched thereafter, giving a fixed window anchored at the first request.
+   *
+   * Multi-unit increments let the limiter meter by actual work: a request that
+   * fans out into N downstream operations charges N units in one atomic step.
    */
-  increment(key: string, windowSeconds: number): Promise<RateLimitIncrementResult>;
+  increment(key: string, windowSeconds: number, units?: number): Promise<RateLimitIncrementResult>;
 }

--- a/packages/auth/src/ratelimit/rate-limit.service.spec.ts
+++ b/packages/auth/src/ratelimit/rate-limit.service.spec.ts
@@ -14,13 +14,17 @@ class FakeStore implements RateLimitStore {
     this.now += seconds;
   }
 
-  async increment(key: string, windowSeconds: number): Promise<RateLimitIncrementResult> {
+  async increment(
+    key: string,
+    windowSeconds: number,
+    units = 1
+  ): Promise<RateLimitIncrementResult> {
     const existing = this.counters.get(key);
     if (!existing || existing.expiresAt <= this.now) {
-      this.counters.set(key, { count: 1, expiresAt: this.now + windowSeconds });
-      return { count: 1, ttlSeconds: windowSeconds };
+      this.counters.set(key, { count: units, expiresAt: this.now + windowSeconds });
+      return { count: units, ttlSeconds: windowSeconds };
     }
-    existing.count += 1;
+    existing.count += units;
     return { count: existing.count, ttlSeconds: existing.expiresAt - this.now };
   }
 }
@@ -96,5 +100,87 @@ describe('RateLimitService', () => {
     await svc.consume({ key: 'u' });
     const blocked = await svc.consume({ key: 'u' });
     expect(blocked.remaining).toBe(0);
+  });
+
+  describe('multi-unit charging (work-proportional metering)', () => {
+    it('charges N units for a consume of N units', async () => {
+      const store = new FakeStore();
+      const svc = new RateLimitService(store, {
+        defaultRule: { limit: 10, windowSeconds: 60 },
+      });
+
+      const r1 = await svc.consume({ key: 'u', units: 4 });
+      expect(r1).toMatchObject({ allowed: true, remaining: 6 });
+      const r2 = await svc.consume({ key: 'u', units: 4 });
+      expect(r2).toMatchObject({ allowed: true, remaining: 2 });
+      // 4 more units exceed the remaining budget of 2.
+      const r3 = await svc.consume({ key: 'u', units: 4 });
+      expect(r3.allowed).toBe(false);
+      expect(r3.remaining).toBe(0);
+      expect(r3.retryAfterSeconds).toBeGreaterThan(0);
+    });
+
+    it('blocks a single consume larger than the whole limit', async () => {
+      const store = new FakeStore();
+      const svc = new RateLimitService(store, {
+        defaultRule: { limit: 3, windowSeconds: 60 },
+      });
+      const blocked = await svc.consume({ key: 'u', units: 5 });
+      expect(blocked.allowed).toBe(false);
+      expect(blocked.remaining).toBe(0);
+    });
+
+    it('meters multi-unit consumes against per-tool override buckets', async () => {
+      const store = new FakeStore();
+      const svc = new RateLimitService(store, {
+        defaultRule: { limit: 100, windowSeconds: 60 },
+        toolOverrides: { ingest_conversation: { limit: 5, windowSeconds: 60 } },
+      });
+
+      const r1 = await svc.consume({ key: 'u', tool: 'ingest_conversation', units: 4 });
+      expect(r1).toMatchObject({ allowed: true, remaining: 1 });
+      const r2 = await svc.consume({ key: 'u', tool: 'ingest_conversation', units: 4 });
+      expect(r2.allowed).toBe(false);
+
+      // The default bucket for the same identity is untouched.
+      const other = await svc.consume({ key: 'u', tool: 'recall' });
+      expect(other).toMatchObject({ allowed: true, remaining: 99 });
+    });
+
+    it('resets multi-unit consumption after the window elapses', async () => {
+      const store = new FakeStore();
+      const svc = new RateLimitService(store, {
+        defaultRule: { limit: 5, windowSeconds: 60 },
+      });
+      expect((await svc.consume({ key: 'u', units: 5 })).allowed).toBe(true);
+      expect((await svc.consume({ key: 'u', units: 1 })).allowed).toBe(false);
+
+      store.advance(61);
+      expect((await svc.consume({ key: 'u', units: 5 })).allowed).toBe(true);
+    });
+
+    it.each([
+      [0, 'zero'],
+      [-3, 'negative'],
+      [0.4, 'fractional below one'],
+      [Number.NaN, 'NaN'],
+      [Number.POSITIVE_INFINITY, 'infinite'],
+    ])('normalizes unusable units (%s: %s) to a single unit', async (units) => {
+      const store = new FakeStore();
+      const svc = new RateLimitService(store, {
+        defaultRule: { limit: 2, windowSeconds: 60 },
+      });
+      const r = await svc.consume({ key: 'u', units });
+      expect(r).toMatchObject({ allowed: true, remaining: 1 });
+    });
+
+    it('floors fractional units above one', async () => {
+      const store = new FakeStore();
+      const svc = new RateLimitService(store, {
+        defaultRule: { limit: 10, windowSeconds: 60 },
+      });
+      const r = await svc.consume({ key: 'u', units: 2.9 });
+      expect(r).toMatchObject({ allowed: true, remaining: 8 });
+    });
   });
 });

--- a/packages/auth/src/ratelimit/rate-limit.service.ts
+++ b/packages/auth/src/ratelimit/rate-limit.service.ts
@@ -22,6 +22,14 @@ export interface ConsumeParams {
   key: string;
   /** MCP tool being invoked, when known (enables per-tool overrides). */
   tool?: string;
+  /**
+   * Work units this request represents (default 1). Tool calls that fan out
+   * into many downstream operations (e.g. `ingest_conversation` storing N
+   * chunks, each an embedding + vector search + DB write) charge one unit per
+   * operation, so a single metered request cannot amplify into unmetered
+   * work. Non-finite or sub-1 values are normalized to 1.
+   */
+  units?: number;
 }
 
 export interface RateLimitResult {
@@ -57,6 +65,7 @@ export class RateLimitService {
   async consume(params: ConsumeParams): Promise<RateLimitResult> {
     const override = params.tool != null ? this.toolOverrides[params.tool] : undefined;
     const rule = override ?? this.defaultRule;
+    const units = RateLimitService.normalizeUnits(params.units);
 
     // Overridden tools get a dedicated counter so their stricter budget is
     // tracked separately from the caller's general request budget.
@@ -64,7 +73,7 @@ export class RateLimitService {
       ? `${KEY_PREFIX}${params.key}:tool:${params.tool}`
       : `${KEY_PREFIX}${params.key}`;
 
-    const { count, ttlSeconds } = await this.store.increment(redisKey, rule.windowSeconds);
+    const { count, ttlSeconds } = await this.store.increment(redisKey, rule.windowSeconds, units);
 
     const allowed = count <= rule.limit;
     const remaining = Math.max(0, rule.limit - count);
@@ -79,5 +88,11 @@ export class RateLimitService {
       resetSeconds,
       retryAfterSeconds: allowed ? 0 : resetSeconds,
     };
+  }
+
+  /** Clamp `units` to a positive integer; anything unusable charges 1. */
+  private static normalizeUnits(units: number | undefined): number {
+    if (units == null || !Number.isFinite(units)) return 1;
+    return Math.max(1, Math.floor(units));
   }
 }


### PR DESCRIPTION
## Summary

Closes #204.

`ingest_conversation` accepted up to 500 turns × ~1 MB (bounded by the 4 MB body cap), chunked each turn at 10 KB → up to ~400+ chunks, each driving a `remember()` (embedding + vector search + DB write). The rate limiter charged the whole request as a **single** `tools/call`, so one metered unit could fan out into hundreds of embedding/DB operations — an embedding-cost blow-up and load-amplification / DoS vector.

The fix closes the gap on three fronts (matching all three directions the issue suggested):

- **Work-proportional metering.** Chunking is extracted into a shared pure module (`conversation-chunking.ts`) so the meter, the schema cap, and the ingest path always agree on the chunk count. `toolCallUnits()` charges **one rate-limit unit per stored chunk**; `units` is threaded atomically through `RateLimitStore` / `RateLimitService` / `RedisRateLimitStore` (via Redis `INCRBY` in one round-trip) and the MCP middleware — across the per-user, per-key, per-IP, and per-org buckets.
- **Always-on chunk cap.** Any request expanding beyond `INGEST_MAX_CHUNKS` (500) is rejected at **both** the Zod schema (`superRefine`) and the service layers, so the fan-out is bounded even when rate limiting is disabled (the default posture) and for any non-schema caller of the service.
- **Documented per-tool override.** `.env.example` shows a dedicated chunk budget for `ingest_conversation`.

## Hardening from an adversarial multi-agent review

A pre-commit review (4 review dimensions × per-finding adversarial verification, 14 findings raised → 2 confirmed) surfaced two real items, both fixed here:

- **Clamp `toolCallUnits` to `INGEST_MAX_CHUNKS`.** An over-cap request is rejected before any `remember()` runs, so charging it its full (~800) uncapped unit count would let a to-be-rejected request drain the shared user/org budget past the maximum legitimate ingest. The meter now tops out at the cap the ingest can actually reach.
- **Behavioral test coverage for the cap.** The cap is the *only* always-on defense (metering is opt-in), yet the sole prior test was a constant-equality assertion. Added tests that route an over-cap conversation through the schema (`ingest-conversation.dto.spec.ts`) and the service (`MemoryService.ingestConversation`), asserting rejection **before** any fan-out.

The other 12 findings were verified as pre-existing behavior, intentional fail-closed design, or nits (e.g. charging before Zod validation is the safe over-count direction; shared-bucket fairness predates this change).

## Verification

Full CI-equivalent gate on the rebased-onto-`main` tree, all green:

- `pnpm build` — 16/16
- `pnpm typecheck` — 15/15
- `pnpm lint` — 17/17
- `pnpm test` — all suites (mcp-server 555 passed, 2 skipped; `@engram/auth` 40 passed)
- `pnpm docs:check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
