### PR TITLE
ci(security): flip trivy image scan to blocking (#208)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,19 +264,45 @@ jobs:
           docker rm -f engram-ci-smoke || true
           test -n "$ok"
 
+      - name: Install trivy (pinned + cached)
+        # Standalone setup-trivy instead of trivy-action's built-in installer
+        # (#208): trivy-action v0.33.1 defaults to trivy v0.65.0, whose release
+        # assets were removed upstream, so the built-in install 404s on every
+        # run (the "flaky download" was actually a permanent 404). Pin a live
+        # version here and cache the binary via actions/cache so post-warmup
+        # runs never touch the GitHub release download at all.
+        # When bumping `version`, keep it to a tag that still has release
+        # assets: https://github.com/aquasecurity/trivy/releases
+        uses: aquasecurity/setup-trivy@v0.3.1
+        with:
+          version: v0.72.0
+          cache: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Scan image for vulnerabilities (trivy)
-        # Report-only for now (see #208): the scan is informational until the
-        # preexisting base-image/dep CVEs are triaged, and `continue-on-error`
-        # keeps a flaky binary download (unauthenticated GitHub rate limit)
-        # from gating an otherwise-green build. Flip exit-code to '1' and drop
-        # continue-on-error once #208 is resolved.
+        # Blocking (#208): fails the build on fixable CRITICAL/HIGH findings in
+        # the production image. Base-image and dep CVEs were triaged before the
+        # flip (npm's vendored picomatch/sigstore CVEs are dropped from the
+        # runtime image in apps/mcp-server/Dockerfile). `ignore-unfixed` keeps
+        # unpatchable OS findings from reddening builds we cannot act on.
         uses: aquasecurity/trivy-action@v0.33.1
-        continue-on-error: true
         env:
           TRIVY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Primary DB mirror plus ghcr fallback so an anonymous-pull rate
+          # limit on one registry cannot fail the (now blocking) scan.
+          TRIVY_DB_REPOSITORY: mirror.gcr.io/aquasec/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
         with:
           image-ref: engram-mcp-server:ci-${{ github.sha }}
           format: table
-          exit-code: '0'
+          exit-code: '1'
           ignore-unfixed: true
           severity: CRITICAL,HIGH
+          # Scope the (now blocking) gate to vuln scanning — exactly what was
+          # triaged for #208. trivy-action leaves `scanners` empty by default,
+          # which lets trivy enable secret scanning too; a secret finding is
+          # CRITICAL and not covered by `ignore-unfixed`, so an unrelated PR
+          # could red CI on a false positive with no allow-rule infra here.
+          # Pinning it also makes the gate immune to trivy default-scanner drift.
+          scanners: vuln
+          # Trivy is already installed (pinned + cached) by setup-trivy above.
+          skip-setup-trivy: true

--- a/apps/mcp-server/Dockerfile
+++ b/apps/mcp-server/Dockerfile
@@ -57,6 +57,13 @@ LABEL org.opencontainers.image.title="engram-mcp-server" \
 # Non-root user for least-privilege runtime.
 RUN addgroup -S engram && adduser -S -G engram engram
 
+# Drop the npm CLI from the runtime image. The app runs plain `node
+# dist/main.js` (npm/npx are never invoked at runtime), and npm's vendored
+# node_modules ship fixable HIGH CVEs (picomatch CVE-2026-33671, sigstore
+# CVE-2026-48815) that would trip the blocking trivy CI gate (#208). Removing
+# the CLI also shrinks the image and its attack surface.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+
 WORKDIR /app
 
 # Copy the pruned production artefact from builder.


### PR DESCRIPTION
Follow-up to #199, closes #208. Flips the `docker-build` job's trivy image scan from report-only (`continue-on-error` + `exit-code: 0`) to **blocking** on fixable CRITICAL/HIGH.

## What changed
- **Fix the install (was a permanent 404, not flakiness).** trivy-action@v0.33.1 defaults to trivy v0.65.0, whose release assets were removed upstream, so the built-in installer 404s on every run. A standalone `aquasecurity/setup-trivy@v0.3.1` step now pins **v0.72.0** and caches the binary; the scan step sets `skip-setup-trivy: true` to reuse it. (`skip-setup-trivy` is a real input in v0.33.1 — verified against its `action.yaml`.)
- **DB mirror fallback.** `TRIVY_DB_REPOSITORY` lists `mirror.gcr.io` + `ghcr.io` so an anonymous-pull rate limit on one registry can't fail the now-blocking scan.
- **Triage the findings.** The only fixable HIGH CVEs were npm's vendored `picomatch` (CVE-2026-33671) and `sigstore` (CVE-2026-48815). The runtime never invokes npm/npx (`CMD ["node", "dist/main.js"]`), so the Dockerfile now removes the npm CLI from the production stage — clearing both CVEs and shrinking attack surface.
- **Scope the gate deterministically.** trivy-action leaves `scanners` empty, which lets trivy also enable secret scanning; a secret finding is CRITICAL and not covered by `ignore-unfixed`, so a false positive could red an unrelated PR (there is no allow-rule infra here). Pinned `scanners: vuln` so the blocking gate matches exactly what was triaged and is immune to trivy default-scanner drift.
- **Flip to blocking.** `exit-code: '1'`, `continue-on-error` dropped. `ignore-unfixed: true` retained so unpatchable OS CVEs don't red builds we can't act on.

## Local verification (rebased onto current main, CI's exact scanner + flags)
Scanner: `aquasec/trivy:0.72.0 image --ignore-unfixed --severity CRITICAL,HIGH --exit-code 1`

| Image / config | Result |
| --- | --- |
| `node:22-alpine` base (npm present), `--scanners vuln` | **exit 1** — CVE-2026-33671 (`npm/node_modules/picomatch`), CVE-2026-48815 (`npm/node_modules/sigstore`) |
| production image (npm removed), `--scanners vuln` | **exit 0** — alpine 3.24.1 + all node-pkg targets clean |
| production image, **default scanners** (`vuln,secret`, = trivy-action pre-pin) | **exit 0** — secret scanning enabled, zero secret findings |

Confirms the attribution (both HIGH CVEs are npm-vendored), that the flip stays green, and that no secret false-positive lurks even before the `scanners: vuln` pin.

## Accepted risk
`node:22-alpine` is a floating tag, so with a blocking scan a *future* unrelated PR can go red if the trivy DB later adds a fixable CVE to the base image or a prod dep. That is the intended trade-off per #208; when it happens, bump the base image / add a `pnpm-workspace.yaml` CVE override (or, last resort, a scoped `.trivyignore`). Bumping trivy's `version:` should track a tag that still has release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)