### PR TITLE
ops(release): tag-driven GHCR release pipeline (#201)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,164 @@
+name: Release
+
+# Tag-driven release pipeline (#201).
+#
+# `ci.yml`'s docker-build job intentionally never pushes (`push: false`) —
+# it only validates that the image builds and boots. This workflow is the
+# single publisher of ghcr.io/osirison/engram/mcp-server, which
+# docker-compose.prod.yml pulls via `image: ...:${IMAGE_TAG:-latest}`.
+#
+# Cutting a release:
+#   git tag v1.2.3
+#   git push origin v1.2.3
+#
+# Published tags (docker/metadata-action): full semver (1.2.3), 1.2, 1,
+# sha-<full commit sha>, and `latest` for non-prerelease versions. Images
+# carry BuildKit provenance + SBOM attestations plus a GitHub
+# build-provenance attestation. See docs/deploy.md for the consumer side.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Least-privilege default; jobs elevate only what they need.
+permissions:
+  contents: read
+
+env:
+  # Must match the `image:` reference in docker-compose.prod.yml and
+  # docs/deploy.md (release-workflow.spec.ts asserts this wiring).
+  IMAGE_NAME: ghcr.io/osirison/engram/mcp-server
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Never cancel a half-finished publish: a cancelled push can leave the
+  # semver tags pointing at a manifest without its attestations.
+  cancel-in-progress: false
+
+jobs:
+  build-push:
+    name: Build, smoke-test & push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push image + attestation manifests to GHCR
+      id-token: write # keyless Sigstore signing for the provenance attestation
+      attestations: write # actions/attest-build-provenance
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        # GITHUB_TOKEN with packages:write is sufficient — no extra
+        # registry secret (there never was a REGISTRY_TOKEN; see #201).
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata (semver + sha tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          # Default flavor `latest=auto` also tags `latest` for
+          # non-prerelease semver tags, which docker-compose.prod.yml
+          # falls back to when IMAGE_TAG is unset.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=long
+
+      - name: Build image for smoke test
+        # Separate load-only build: buildx cannot `load` a manifest list
+        # that carries provenance/SBOM attestations, so boot-test a plain
+        # single-arch build first. The push build below reuses the layer
+        # cache, so this costs seconds, not a second full build.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/mcp-server/Dockerfile
+          push: false
+          load: true
+          tags: engram-mcp-server:release-smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test image (memory profile)
+        # Same boot check as ci.yml's docker-build job: never publish an
+        # image that cannot even start and serve /health.
+        run: |
+          docker run -d \
+            -e DEPLOYMENT_PROFILE=memory \
+            -e MCP_TRANSPORT=streamable-http \
+            -e EMBEDDING_PROVIDER=local \
+            -p 13000:3000 \
+            --name engram-release-smoke \
+            engram-mcp-server:release-smoke
+          ok=""
+          for _ in $(seq 1 30); do
+            if curl -sf http://localhost:13000/health; then ok=1; break; fi
+            sleep 2
+          done
+          echo
+          echo "--- container logs ---"
+          docker logs engram-release-smoke
+          docker rm -f engram-release-smoke || true
+          test -n "$ok"
+
+      - name: Build and push image (provenance + SBOM)
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/mcp-server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # In-toto SLSA provenance + SPDX SBOM attached to the image
+          # manifest (inspect with `docker buildx imagetools inspect`).
+          provenance: true
+          sbom: true
+          cache-from: type=gha
+
+      - name: Attest build provenance (GitHub attestation)
+        # Publishes a GitHub-signed build-provenance attestation for the
+        # pushed digest, verifiable with:
+        #   gh attestation verify oci://<image>:<tag> --repo osirison/engram
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: build-push
+    permissions:
+      contents: write # create the release + generated notes
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; skipping."
+            exit 0
+          fi
+          args=(--verify-tag --generate-notes --title "$GITHUB_REF_NAME")
+          case "$GITHUB_REF_NAME" in
+            *-*) args+=(--prerelease) ;;
+          esac
+          gh release create "$GITHUB_REF_NAME" "${args[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,9 +146,9 @@ jobs:
       contents: write # create the release + generated notes
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
+      # No checkout: `gh release` talks to the GitHub API and reads
+      # GITHUB_REPOSITORY; it needs no working tree. `--verify-tag` checks
+      # the tag server-side.
       - name: Create release with generated notes
         env:
           GH_TOKEN: ${{ github.token }}

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -84,7 +84,8 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.60.0"
+    "typescript-eslint": "^8.60.0",
+    "yaml": "^2.8.1"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/apps/mcp-server/src/__tests__/release-workflow.spec.ts
+++ b/apps/mcp-server/src/__tests__/release-workflow.spec.ts
@@ -60,9 +60,14 @@ const workflowSchema = z.object({
   jobs: z.record(z.string(), jobSchema),
 });
 
-const tagTriggerSchema = z.object({
-  push: z.object({ tags: z.array(z.string()) }).strict(),
-});
+// `.strict()` at both levels: the release must trigger on *only* a tag
+// push (no `workflow_dispatch`, `pull_request`, etc.) carrying *only* a
+// `tags` filter — any extra key fails the parse.
+const tagTriggerSchema = z
+  .object({
+    push: z.object({ tags: z.array(z.string()) }).strict(),
+  })
+  .strict();
 
 const composeSchema = z.object({
   services: z.record(
@@ -123,7 +128,9 @@ describe('release workflow (.github/workflows/release.yml)', () => {
 
   it('triggers only on v* tag pushes (no branch or PR triggers)', () => {
     const trigger = tagTriggerSchema.parse(workflow.on);
-    expect(trigger.push.tags).toContain('v*');
+    // Pin the exact filter: adding another pattern (e.g. `release/*`) must
+    // fail this, not silently pass as `toContain` would.
+    expect(trigger.push.tags).toEqual(['v*']);
   });
 
   it('keeps workflow-level permissions read-only', () => {

--- a/apps/mcp-server/src/__tests__/release-workflow.spec.ts
+++ b/apps/mcp-server/src/__tests__/release-workflow.spec.ts
@@ -1,0 +1,293 @@
+/**
+ * Release pipeline contract tests (#201).
+ *
+ * GitHub Actions workflows cannot execute locally, so these tests pin the
+ * *contract* of the tag-driven GHCR release pipeline at two levels:
+ *
+ *   1. Workflow level — `.github/workflows/release.yml` in isolation:
+ *      triggers on `v*` tag pushes, logs into GHCR with the workflow
+ *      GITHUB_TOKEN (packages: write), derives semver + sha image tags,
+ *      smoke-tests before publishing, pushes with provenance/SBOM
+ *      attestations, and attests the pushed digest.
+ *
+ *   2. Wiring level — cross-file consistency: the image name the release
+ *      workflow publishes is exactly the image `docker-compose.prod.yml`
+ *      pulls and `docs/deploy.md` documents, the workflow builds the same
+ *      Dockerfile the compose fallback build uses, and `ci.yml` stays
+ *      build-only (`push: false`) so CI can never publish by accident.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+import { z } from 'zod';
+
+const REPO_ROOT = join(__dirname, '../../../..');
+const RELEASE_WORKFLOW_PATH = join(REPO_ROOT, '.github/workflows/release.yml');
+const CI_WORKFLOW_PATH = join(REPO_ROOT, '.github/workflows/ci.yml');
+const PROD_COMPOSE_PATH = join(REPO_ROOT, 'docker-compose.prod.yml');
+const DEPLOY_DOC_PATH = join(REPO_ROOT, 'docs/deploy.md');
+
+/** The one image reference every producer/consumer must agree on. */
+const EXPECTED_IMAGE = 'ghcr.io/osirison/engram/mcp-server';
+const EXPECTED_DOCKERFILE = 'apps/mcp-server/Dockerfile';
+
+const stepSchema = z.object({
+  name: z.string().optional(),
+  id: z.string().optional(),
+  uses: z.string().optional(),
+  run: z.string().optional(),
+  env: z.record(z.string(), z.unknown()).optional(),
+  with: z.record(z.string(), z.unknown()).optional(),
+});
+type WorkflowStep = z.infer<typeof stepSchema>;
+
+const jobSchema = z.object({
+  name: z.string().optional(),
+  'runs-on': z.string(),
+  needs: z.union([z.string(), z.array(z.string())]).optional(),
+  permissions: z.record(z.string(), z.string()).optional(),
+  steps: z.array(stepSchema),
+});
+type WorkflowJob = z.infer<typeof jobSchema>;
+
+// The `yaml` package parses YAML 1.2, so the `on:` trigger key stays the
+// string "on" instead of collapsing to boolean true (a YAML 1.1 quirk).
+const workflowSchema = z.object({
+  name: z.string(),
+  on: z.unknown(),
+  permissions: z.record(z.string(), z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  jobs: z.record(z.string(), jobSchema),
+});
+
+const tagTriggerSchema = z.object({
+  push: z.object({ tags: z.array(z.string()) }).strict(),
+});
+
+const composeSchema = z.object({
+  services: z.record(
+    z.string(),
+    z.object({
+      image: z.string().optional(),
+      build: z
+        .object({
+          context: z.string(),
+          dockerfile: z.string(),
+        })
+        .optional(),
+    }),
+  ),
+});
+
+function loadYaml(path: string): unknown {
+  return parse(readFileSync(path, 'utf8')) as unknown;
+}
+
+function loadWorkflow(path: string): z.infer<typeof workflowSchema> {
+  return workflowSchema.parse(loadYaml(path));
+}
+
+function requireJob(
+  workflow: z.infer<typeof workflowSchema>,
+  jobKey: string,
+): WorkflowJob {
+  const job = workflow.jobs[jobKey];
+  if (!job) {
+    throw new Error(`workflow is missing expected job "${jobKey}"`);
+  }
+  return job;
+}
+
+function findStep(
+  job: WorkflowJob,
+  predicate: (step: WorkflowStep) => boolean,
+): WorkflowStep | undefined {
+  return job.steps.find(predicate);
+}
+
+function usesAction(step: WorkflowStep, action: string): boolean {
+  return step.uses !== undefined && step.uses.startsWith(`${action}@`);
+}
+
+describe('release workflow (.github/workflows/release.yml)', () => {
+  const workflow = loadWorkflow(RELEASE_WORKFLOW_PATH);
+  const buildPush = requireJob(workflow, 'build-push');
+  const githubRelease = requireJob(workflow, 'github-release');
+
+  it('exists with the expected jobs', () => {
+    expect(Object.keys(workflow.jobs).sort()).toEqual([
+      'build-push',
+      'github-release',
+    ]);
+  });
+
+  it('triggers only on v* tag pushes (no branch or PR triggers)', () => {
+    const trigger = tagTriggerSchema.parse(workflow.on);
+    expect(trigger.push.tags).toContain('v*');
+  });
+
+  it('keeps workflow-level permissions read-only', () => {
+    expect(workflow.permissions).toEqual({ contents: 'read' });
+  });
+
+  it('publishes the image name that production compose pulls', () => {
+    expect(workflow.env?.IMAGE_NAME).toBe(EXPECTED_IMAGE);
+  });
+
+  describe('build-push job', () => {
+    it('elevates exactly the permissions publishing requires', () => {
+      expect(buildPush.permissions).toEqual({
+        contents: 'read',
+        packages: 'write',
+        'id-token': 'write',
+        attestations: 'write',
+      });
+    });
+
+    it('logs into GHCR with the workflow GITHUB_TOKEN (no REGISTRY_TOKEN)', () => {
+      const login = findStep(buildPush, (step) =>
+        usesAction(step, 'docker/login-action'),
+      );
+      expect(login).toBeDefined();
+      expect(login?.with?.registry).toBe('ghcr.io');
+      expect(login?.with?.password).toBe('${{ secrets.GITHUB_TOKEN }}');
+    });
+
+    it('derives semver + sha tags from the git tag via metadata-action', () => {
+      const meta = findStep(buildPush, (step) =>
+        usesAction(step, 'docker/metadata-action'),
+      );
+      expect(meta).toBeDefined();
+      expect(meta?.id).toBe('meta');
+      expect(meta?.with?.images).toBe('${{ env.IMAGE_NAME }}');
+
+      const tags = z.string().parse(meta?.with?.tags);
+      expect(tags).toContain('type=semver,pattern={{version}}');
+      expect(tags).toContain('type=semver,pattern={{major}}.{{minor}}');
+      expect(tags).toContain('type=semver,pattern={{major}}');
+      expect(tags).toContain('type=sha,format=long');
+    });
+
+    it('smoke-tests a load-only build before anything is pushed', () => {
+      const loadIndex = buildPush.steps.findIndex(
+        (step) =>
+          usesAction(step, 'docker/build-push-action') &&
+          step.with?.push === false &&
+          step.with?.load === true,
+      );
+      const smokeIndex = buildPush.steps.findIndex(
+        (step) => step.run?.includes('/health') ?? false,
+      );
+      const pushIndex = buildPush.steps.findIndex(
+        (step) =>
+          usesAction(step, 'docker/build-push-action') &&
+          step.with?.push === true,
+      );
+
+      expect(loadIndex).toBeGreaterThanOrEqual(0);
+      expect(smokeIndex).toBeGreaterThan(loadIndex);
+      expect(pushIndex).toBeGreaterThan(smokeIndex);
+    });
+
+    it('pushes the metadata-derived tags with provenance and SBOM', () => {
+      const push = findStep(
+        buildPush,
+        (step) =>
+          usesAction(step, 'docker/build-push-action') &&
+          step.with?.push === true,
+      );
+      expect(push).toBeDefined();
+      expect(push?.id).toBe('push');
+      expect(push?.with?.file).toBe(EXPECTED_DOCKERFILE);
+      expect(push?.with?.tags).toBe('${{ steps.meta.outputs.tags }}');
+      expect(push?.with?.labels).toBe('${{ steps.meta.outputs.labels }}');
+      expect(push?.with?.provenance).toBe(true);
+      expect(push?.with?.sbom).toBe(true);
+    });
+
+    it('attests the pushed digest and stores it in the registry', () => {
+      const attest = findStep(buildPush, (step) =>
+        usesAction(step, 'actions/attest-build-provenance'),
+      );
+      expect(attest).toBeDefined();
+      expect(attest?.with?.['subject-name']).toBe('${{ env.IMAGE_NAME }}');
+      expect(attest?.with?.['subject-digest']).toBe(
+        '${{ steps.push.outputs.digest }}',
+      );
+      expect(attest?.with?.['push-to-registry']).toBe(true);
+    });
+  });
+
+  describe('github-release job', () => {
+    it('runs only after the image publish succeeds', () => {
+      expect(githubRelease.needs).toBe('build-push');
+    });
+
+    it('elevates only contents: write', () => {
+      expect(githubRelease.permissions).toEqual({ contents: 'write' });
+    });
+
+    it('creates a verified-tag release with generated notes', () => {
+      const release = findStep(
+        githubRelease,
+        (step) => step.run?.includes('gh release create') ?? false,
+      );
+      expect(release).toBeDefined();
+      expect(release?.run).toContain('--verify-tag');
+      expect(release?.run).toContain('--generate-notes');
+    });
+  });
+});
+
+describe('release wiring (compose, CI, and docs stay consistent)', () => {
+  const workflow = loadWorkflow(RELEASE_WORKFLOW_PATH);
+  const compose = composeSchema.parse(loadYaml(PROD_COMPOSE_PATH));
+  const mcpService = compose.services['mcp-server'];
+  if (!mcpService) {
+    throw new Error(
+      'docker-compose.prod.yml is missing the mcp-server service',
+    );
+  }
+
+  it('docker-compose.prod.yml pulls exactly the published image', () => {
+    expect(mcpService.image).toBe(`${EXPECTED_IMAGE}:\${IMAGE_TAG:-latest}`);
+    expect(mcpService.image?.startsWith(`${workflow.env?.IMAGE_NAME}:`)).toBe(
+      true,
+    );
+  });
+
+  it('the workflow builds the same Dockerfile as the compose fallback build', () => {
+    expect(mcpService.build?.dockerfile).toBe(EXPECTED_DOCKERFILE);
+
+    const push = findStep(
+      requireJob(workflow, 'build-push'),
+      (step) =>
+        usesAction(step, 'docker/build-push-action') &&
+        step.with?.push === true,
+    );
+    expect(push?.with?.file).toBe(mcpService.build?.dockerfile);
+  });
+
+  it('ci.yml stays build-only: no build-push step ever pushes', () => {
+    const ci = loadWorkflow(CI_WORKFLOW_PATH);
+    const buildSteps = Object.values(ci.jobs).flatMap((job) =>
+      job.steps.filter((step) => usesAction(step, 'docker/build-push-action')),
+    );
+
+    expect(buildSteps.length).toBeGreaterThan(0);
+    for (const step of buildSteps) {
+      expect(step.with?.push).toBe(false);
+    }
+  });
+
+  it('docs/deploy.md documents the real flow and drops the phantom REGISTRY_TOKEN gate', () => {
+    const doc = readFileSync(DEPLOY_DOC_PATH, 'utf8');
+
+    expect(doc).toContain(EXPECTED_IMAGE);
+    expect(doc).toContain('release.yml');
+    expect(doc).toContain('IMAGE_TAG');
+    // The pre-#201 doc claimed pushes were gated on a REGISTRY_TOKEN secret
+    // that never existed anywhere in the repo.
+    expect(doc).not.toContain('REGISTRY_TOKEN');
+  });
+});

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -151,16 +151,76 @@ can be added via `@opentelemetry/api` in service code.
 
 ## Image in CI
 
-The `docker-build` job in `.github/workflows/ci.yml` builds the image on
-every push to `main` and on pull requests. The image is not pushed unless
-`REGISTRY_TOKEN` is set in repository secrets.
+The `docker-build` job in `.github/workflows/ci.yml` builds and smoke-tests
+the image on every push to `main` and on pull requests, but **never pushes
+it** (`push: false`) — CI is build validation only. Published images come
+exclusively from the release workflow below.
+
+---
+
+## Releases (publishing to GHCR)
+
+The release workflow (`.github/workflows/release.yml`) publishes
+`ghcr.io/osirison/engram/mcp-server` — the image that
+`docker-compose.prod.yml` pulls. It runs when a git tag matching `v*` is
+pushed and authenticates with the workflow's own `GITHUB_TOKEN`
+(`packages: write`); no extra registry secret is required.
+
+### Cutting a release
+
+```bash
+git checkout main && git pull
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The workflow then:
+
+1. Builds the image and smoke-tests it (boots the `memory` profile and
+   polls `/health`) before anything is published.
+2. Pushes the image with BuildKit **provenance** and **SBOM** attestations
+   attached to the manifest.
+3. Records a GitHub build-provenance attestation for the pushed digest.
+4. Creates a GitHub release for the tag with auto-generated notes
+   (tags containing a `-`, e.g. `v1.3.0-rc.1`, are marked pre-release).
+
+### Published image tags
+
+| Tag                       | Example        | Notes                                  |
+| ------------------------- | -------------- | -------------------------------------- |
+| `<major>.<minor>.<patch>` | `1.2.3`        | Exact release                          |
+| `<major>.<minor>`         | `1.2`          | Latest patch of the minor line         |
+| `<major>`                 | `1`            | Latest release of the major line       |
+| `sha-<commit>`            | `sha-6c93444…` | Immutable; pins the exact build source |
+| `latest`                  | `latest`       | Non-prerelease releases only           |
+
+### Selecting a version in production
+
+`docker-compose.prod.yml` uses `image: ghcr.io/osirison/engram/mcp-server:${IMAGE_TAG:-latest}`.
+Pin a specific version in `.env.prod` instead of relying on `latest`:
+
+```bash
+IMAGE_TAG=1.2.3
+```
+
+### Verifying a pulled image
+
+```bash
+# GitHub build-provenance attestation
+gh attestation verify oci://ghcr.io/osirison/engram/mcp-server:1.2.3 \
+  --repo osirison/engram
+
+# BuildKit provenance / SBOM attached to the manifest
+docker buildx imagetools inspect ghcr.io/osirison/engram/mcp-server:1.2.3 \
+  --format '{{ json .Provenance }}'
+```
 
 ---
 
 ## Updating
 
 ```bash
-# Pull latest image or rebuild
+# Pull the released image (set IMAGE_TAG in .env.prod to move versions)
 docker compose -f docker-compose.prod.yml pull mcp-server
 docker compose -f docker-compose.prod.yml up -d mcp-server
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       typescript-eslint:
         specifier: ^8.60.0
         version: 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      yaml:
+        specifier: ^2.8.1
+        version: 2.9.0
 
   apps/vscode-copilot-compressor:
     devDependencies:


### PR DESCRIPTION
## What & why

Closes #201. Adds a tag-driven release pipeline that publishes
`ghcr.io/osirison/engram/mcp-server` — the image `docker-compose.prod.yml`
pulls. Previously `ci.yml`'s `docker-build` job only *validated* the image
(`push: false`) and `docs/deploy.md` described a `REGISTRY_TOKEN` gate that
never existed anywhere in the repo, so there was **no path to a published
image**. This closes that gap.

## `.github/workflows/release.yml`

Runs on `v*` tag pushes. Least-privilege default perms (`contents: read`),
jobs elevate only what they need.

- **`build-push`** — logs into GHCR with the workflow's own `GITHUB_TOKEN`
  (`packages: write`; no extra registry secret), derives semver + `sha-<sha>`
  tags via `docker/metadata-action`, **smoke-tests a load-only build**
  (boots the `memory` profile, polls `/health`) before anything is
  published, then pushes with BuildKit **provenance + SBOM** attestations
  and records a GitHub **build-provenance** attestation for the pushed digest.
- **`github-release`** — after the publish succeeds, creates a GitHub
  release with generated notes (tags containing `-`, e.g. `v1.3.0-rc.1`,
  are marked pre-release). Idempotent: skips if the release already exists.

`concurrency` never cancels in-progress publishes, so a cancelled run can't
leave semver tags pointing at a manifest missing its attestations.

## Tests — `release-workflow.spec.ts` (17 cases)

Workflows can't run locally, so these pin the **contract** at two levels:

1. **Workflow shape** — triggers, permissions, GHCR login, tag derivation,
   smoke-before-push ordering, provenance/SBOM, digest attestation.
2. **Cross-file wiring** — the image the release publishes is exactly the
   one prod compose pulls and the docs document; the workflow builds the
   same Dockerfile as the compose fallback build; `ci.yml` stays build-only
   (every `docker/build-push-action` step asserts `push: false`); and
   `docs/deploy.md` drops the phantom `REGISTRY_TOKEN`.

## Docs

`docs/deploy.md` now documents the real flow: cutting a release, the
published tag matrix, pinning `IMAGE_TAG` in prod, and verifying provenance.

## Verification

- `release-workflow` contract tests: 17/17 ✅
- mcp-server typecheck / lint / `docs:check`: ✅
- Release smoke-test step is byte-identical to `ci.yml`'s continuously-exercised boot check.

## Reviewer notes

- **Single-arch (linux/amd64):** the push build sets no `platforms:`,
  matching CI's existing single-arch build — not a regression, but `latest`
  won't resolve on arm64 hosts if that ever becomes a target.
- Addressed review (41307ab): tightened the trigger contract test
  (strict schema at both levels + exact `tags` array) and dropped the
  `github-release` job's unused `actions/checkout` (`gh release` is
  API-only and needs no working tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

