### PR TITLE
fix(release): restore github-release checkout (regressed in #217)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,9 +146,14 @@ jobs:
       contents: write # create the release + generated notes
 
     steps:
-      # No checkout: `gh release` talks to the GitHub API and reads
-      # GITHUB_REPOSITORY; it needs no working tree. `--verify-tag` checks
-      # the tag server-side.
+      # Load-bearing — do not remove. `gh release create --verify-tag`
+      # shells out to local `git` to resolve the tag, so it needs a
+      # checkout; without one the step dies with "fatal: not a git
+      # repository" (regressed once in #217, fixed here). A checkout on a
+      # tag push also materialises refs/tags/<tag> for --verify-tag to find.
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Create release with generated notes
         env:
           GH_TOKEN: ${{ github.token }}

--- a/apps/mcp-server/src/__tests__/release-workflow.spec.ts
+++ b/apps/mcp-server/src/__tests__/release-workflow.spec.ts
@@ -243,6 +243,21 @@ describe('release workflow (.github/workflows/release.yml)', () => {
       expect(release?.run).toContain('--verify-tag');
       expect(release?.run).toContain('--generate-notes');
     });
+
+    it('checks out the repo before creating the release', () => {
+      // `gh release create --verify-tag` shells out to local `git`, so the
+      // job needs a working tree — removing this checkout regressed the
+      // release job in #217 ("fatal: not a git repository"). The checkout
+      // must precede the `gh release create` step.
+      const checkoutIndex = githubRelease.steps.findIndex((step) =>
+        usesAction(step, 'actions/checkout'),
+      );
+      const releaseIndex = githubRelease.steps.findIndex(
+        (step) => step.run?.includes('gh release create') ?? false,
+      );
+      expect(checkoutIndex).toBeGreaterThanOrEqual(0);
+      expect(releaseIndex).toBeGreaterThan(checkoutIndex);
+    });
   });
 });
 


### PR DESCRIPTION
## What & why

Follow-up to #217 / #201. The `v0.0.1` release run exposed a regression:
the `github-release` job failed with

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

**Root cause:** #217 dropped the `actions/checkout` step from the
`github-release` job on the (mistaken) assumption that `gh release create`
is purely an API call. It isn't — `gh release create --verify-tag` shells
out to local `git` to resolve the tag, so the job needs a working tree.
A static "unused checkout" review flagged it; CI proved otherwise.

The image side was **unaffected** — `v0.0.1` published fine
(`ghcr.io/osirison/engram/mcp-server:0.0.1` @ `sha256:d8ccdb33…`, plus
`0.0`, `0`, `sha-95a8c51…`, `latest`, with provenance + SBOM). Only the
GitHub release creation failed; that release was created manually to
unblock `v0.0.1`.

## Fix

- Restore the `actions/checkout` step in `github-release`, with a comment
  explaining it's **load-bearing** (so it isn't trimmed again).
- Add a contract test (`checks out the repo before creating the release`)
  asserting the job has a checkout that precedes `gh release create` —
  locks the exact contract that just regressed.

## Verification

- `release-workflow` contract tests: **18/18** ✅ (was 17 + the new one).
- Note: this restores the known-good pre-#217 design; it will be
  exercised end-to-end on the **next** tag push (not re-validated here to
  avoid cutting a throwaway tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
