### PR TITLE
ops(marketing-site): guard Pages custom-domain binding and add TLS ru…

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -60,6 +60,8 @@ jobs:
     # pull requests.
     needs: verify
     if: github.event_name != 'pull_request'
+    env:
+      MARKETING_SITE_DOMAIN: engram.events
     permissions:
       contents: read
       pages: write
@@ -72,10 +74,34 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      # Fail fast before configure/deploy: if the repository's Pages custom
+      # domain has drifted from the expected value, block the deploy instead of
+      # shipping a site that would serve an untrusted certificate.
+      - name: Verify Pages custom domain binding
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const expectedCname = process.env.MARKETING_SITE_DOMAIN;
+            const { data } = await github.rest.repos.getPages({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            core.info(`Pages html_url: ${data.html_url}`);
+            core.info(`Pages custom domain: ${data.cname ?? '(none)'}`);
+            core.info(`Pages https_enforced: ${data.https_enforced}`);
+
+            if (data.cname !== expectedCname) {
+              const runbookUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/docs/MARKETING_SITE_DOMAIN.md`;
+              core.setFailed(
+                `Expected Pages custom domain '${expectedCname}', found '${data.cname ?? '(none)'}'. See ${runbookUrl} for DNS/TLS setup instructions.`,
+              );
+            }
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:
-          cname: engram.events
+          cname: ${{ env.MARKETING_SITE_DOMAIN }}
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Release SLO and quality gates live in [docs/RELEASE_GATES.md](docs/RELEASE_GATES
 | Detailed local setup and MCP client setup | [docs/SETUP.md](docs/SETUP.md)                                                       |
 | Release SLOs and quality gates            | [docs/RELEASE_GATES.md](docs/RELEASE_GATES.md)                                       |
 | Current roadmap                           | [docs/roadmap.md](docs/roadmap.md)                                                   |
+| Marketing site domain/TLS runbook         | [docs/MARKETING_SITE_DOMAIN.md](docs/MARKETING_SITE_DOMAIN.md)                       |
 | MCP server details                        | [apps/mcp-server/README.md](apps/mcp-server/README.md)                               |
 | Web app details                           | [apps/web/README.md](apps/web/README.md)                                             |
 | Docs app details                          | [apps/docs/README.md](apps/docs/README.md)                                           |

--- a/docs/MARKETING_SITE_DOMAIN.md
+++ b/docs/MARKETING_SITE_DOMAIN.md
@@ -1,0 +1,72 @@
+---
+title: Marketing Site Domain Runbook
+description: DNS and TLS checklist for engram.events on GitHub Pages
+---
+
+# Marketing site domain/TLS runbook
+
+This runbook covers DNS and certificate setup for the marketing site hosted on
+GitHub Pages at `engram.events`.
+
+## Source of truth in repository
+
+- Deploy workflow: `.github/workflows/node.js.yml`
+- Custom domain in workflow: `cname: ${{ env.MARKETING_SITE_DOMAIN }}`, sourced
+  from the `MARKETING_SITE_DOMAIN` job env in the `deploy` job (currently
+  `engram.events`)
+- Build output deployed to Pages: `apps/marketing-site/dist`
+
+## Required GitHub Pages settings
+
+In repository **Settings → Pages**:
+
+1. Set **Custom domain** to `engram.events`.
+2. Enable **Enforce HTTPS** (after DNS is correct and cert is issued).
+
+## Required DNS records
+
+Configure DNS at your provider:
+
+### Apex (`engram.events`)
+
+Use one of:
+
+- `A` records to GitHub Pages IPs:
+  - `185.199.108.153`
+  - `185.199.109.153`
+  - `185.199.110.153`
+  - `185.199.111.153`
+- or provider ALIAS/ANAME flattening to your `<owner>.github.io` Pages host.
+
+### `www` (`www.engram.events`)
+
+- `CNAME` to `<owner>.github.io`
+- or provider-level redirect to apex.
+
+Remove conflicting records that point to non-GitHub infrastructure.
+
+## Verification checklist
+
+1. DNS resolves correctly:
+   - `dig +short engram.events A`
+   - `dig +short www.engram.events CNAME`
+2. GitHub Pages is bound to expected custom domain:
+   - workflow step **Verify Pages custom domain binding** passes.
+3. Certificate includes expected hostname(s):
+   - `openssl s_client -servername engram.events -connect engram.events:443 </dev/null 2>/dev/null | openssl x509 -noout -subject -ext subjectAltName`
+4. Browser checks:
+   - `https://engram.events` opens without certificate warnings.
+   - `https://www.engram.events` behavior is intentional (redirect or valid host).
+
+## Rollback/contingency
+
+If cert issuance is stuck or browser shows domain mismatch:
+
+1. Temporarily remove custom domain in GitHub Pages settings.
+2. Redeploy Pages.
+3. Fix DNS records to match GitHub Pages requirements.
+4. Re-add `engram.events` as custom domain.
+5. Re-enable HTTPS once cert is re-issued.
+
+If your DNS provider uses CDN/proxy SSL modes, switch to DNS-only during cert
+issuance and restore proxy mode after certificate validation succeeds.


### PR DESCRIPTION
…nbook

Pages served an untrusted cert when its custom-domain binding drifted from the CNAME. Adds a deploy-time check that fails on mismatch, centralizes the domain in MARKETING_SITE_DOMAIN, and adds a DNS/TLS runbook.