### PR TITLE
feat(memory-ui): WP2 residual follow-ups — T3 TTL, T6 bulk-delete, T9 authz

### DIFF
--- a/apps/mcp-server/src/memory/dto/bulk-delete.dto.spec.ts
+++ b/apps/mcp-server/src/memory/dto/bulk-delete.dto.spec.ts
@@ -1,0 +1,54 @@
+import { bulkDeleteToolSchema } from './bulk-delete.dto';
+
+/** WP2 T6/D9 — the batch bounds are the tool's safety envelope: the server must
+ *  reject an empty or >100 batch and strip unknown keys (`.strict()`). */
+describe('bulkDeleteToolSchema (WP2 T6/D9)', () => {
+  const base = { userId: 'qp', memoryIds: ['a'] };
+
+  it('accepts a valid single-id batch', () => {
+    const parsed = bulkDeleteToolSchema.parse(base);
+    expect(parsed.memoryIds).toEqual(['a']);
+  });
+
+  it('accepts a full batch of exactly 100 ids', () => {
+    const memoryIds = Array.from({ length: 100 }, (_, i) => `id${i}`);
+    expect(() =>
+      bulkDeleteToolSchema.parse({ userId: 'qp', memoryIds }),
+    ).not.toThrow();
+  });
+
+  it('rejects an empty id list (min 1)', () => {
+    expect(() =>
+      bulkDeleteToolSchema.parse({ userId: 'qp', memoryIds: [] }),
+    ).toThrow();
+  });
+
+  it('rejects more than 100 ids (max 100)', () => {
+    const memoryIds = Array.from({ length: 101 }, (_, i) => `id${i}`);
+    expect(() =>
+      bulkDeleteToolSchema.parse({ userId: 'qp', memoryIds }),
+    ).toThrow();
+  });
+
+  it('rejects unknown keys (.strict)', () => {
+    expect(() =>
+      bulkDeleteToolSchema.parse({ ...base, surprise: true }),
+    ).toThrow();
+  });
+
+  it('carries optional scope and actorLabel', () => {
+    const parsed = bulkDeleteToolSchema.parse({
+      ...base,
+      scope: 'project:engram',
+      actorLabel: 'op@example.com',
+    });
+    expect(parsed.scope).toBe('project:engram');
+    expect(parsed.actorLabel).toBe('op@example.com');
+  });
+
+  it('rejects an actorLabel longer than 256 chars', () => {
+    expect(() =>
+      bulkDeleteToolSchema.parse({ ...base, actorLabel: 'x'.repeat(257) }),
+    ).toThrow();
+  });
+});

--- a/apps/mcp-server/src/memory/memory.service.spec.ts
+++ b/apps/mcp-server/src/memory/memory.service.spec.ts
@@ -710,6 +710,44 @@ describe('MemoryService', () => {
       expect(result.deleted).toEqual(['a']);
       expect(ltmService.delete).toHaveBeenCalledTimes(1);
     });
+
+    it('caps in-flight deletions at the bounded concurrency of 5', async () => {
+      // Block every per-item delete on a manual resolver so we can observe how
+      // many run at once. With 12 ids and a cap of 5, at most 5 are ever
+      // in-flight (runConcurrent worker pool — WP2 T6/D9).
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const resolvers: Array<() => void> = [];
+      const deleteSpy = jest.spyOn(service, 'deleteMemory').mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            resolvers.push(() => {
+              inFlight--;
+              resolve(true);
+            });
+          }),
+      );
+
+      const ids = Array.from({ length: 12 }, (_, i) => `id-${i}`);
+      const pending = service.bulkDeleteMemories('user-1', ids);
+
+      // Let the first wave of workers register.
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      expect(maxInFlight).toBe(5);
+
+      // Drain in rounds until the batch completes.
+      while (resolvers.length > 0) {
+        resolvers.splice(0).forEach((release) => release());
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+      }
+
+      const result = await pending;
+      expect(result.deleted).toHaveLength(12);
+      expect(maxInFlight).toBe(5);
+      deleteSpy.mockRestore();
+    });
   });
 
   describe('promoteMemory', () => {

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -36,8 +36,11 @@ export default function SettingsPage() {
   const session = trpc.meta.session.useQuery();
   const capabilities = trpc.meta.capabilities.useQuery();
   const owners = trpc.meta.owners.useQuery();
+  // The data owners this operator is bound to (WP2 T9): `'*'` when unbound.
+  const allowedTenants = trpc.meta.allowedTenants.useQuery();
 
   const user = session.data?.user;
+  const allowed = allowedTenants.data;
 
   return (
     <PageContainer>
@@ -70,6 +73,20 @@ export default function SettingsPage() {
                   <Badge variant="outline" className="ml-auto capitalize">
                     {user.provider}
                   </Badge>
+                )}
+              </div>
+            )}
+            {allowed !== undefined && (
+              <div className="rounded-md border px-3 py-2 text-sm">
+                <span className="text-muted-foreground">Data-owner access: </span>
+                {allowed === '*' ? (
+                  <span className="font-medium">All data owners</span>
+                ) : allowed.length > 0 ? (
+                  <span className="font-mono text-xs font-medium">{allowed.join(', ')}</span>
+                ) : (
+                  <span className="font-medium text-[var(--warning)]">
+                    None — no tenant binding matches your account
+                  </span>
                 )}
               </div>
             )}

--- a/apps/web/components/layout/scope-switcher.test.tsx
+++ b/apps/web/components/layout/scope-switcher.test.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ScopeSwitcher } from './scope-switcher';
+
+const h = vi.hoisted(() => ({
+  setUserId: vi.fn(),
+  owners: [] as Array<{ userId: string; count: number }>,
+  allowed: '*' as '*' | string[],
+}));
+
+vi.mock('@/components/user-scope', () => ({
+  useUserScope: () => ({ userId: 'qp', setUserId: h.setUserId }),
+}));
+
+// Render the popover inline so the filter input is always reachable (Radix
+// portals + pointer events are awkward under the test DOM).
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/trpc/react', () => ({
+  trpc: {
+    meta: {
+      owners: { useQuery: () => ({ data: h.owners, isLoading: false }) },
+      allowedTenants: { useQuery: () => ({ data: h.allowed }) },
+    },
+  },
+}));
+
+describe('ScopeSwitcher — tenant gate (WP2 T9)', () => {
+  beforeEach(() => {
+    h.setUserId.mockReset();
+    h.owners = [];
+    h.allowed = '*';
+  });
+
+  it('allows free-text entry of any owner when unbound (allowedTenants = *)', () => {
+    h.allowed = '*';
+    render(<ScopeSwitcher />);
+    const input = screen.getByPlaceholderText('Find or enter a userId…');
+    fireEvent.change(input, { target: { value: 'newuser' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(h.setUserId).toHaveBeenCalledWith('newuser');
+  });
+
+  it('blocks free-text entry of a forbidden tenant when bound', () => {
+    h.allowed = ['qp'];
+    render(<ScopeSwitcher />);
+    const input = screen.getByPlaceholderText('Find or enter a userId…');
+    fireEvent.change(input, { target: { value: 'other' } });
+    expect(screen.getByText(/not permitted to manage "other"/)).toBeInTheDocument();
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(h.setUserId).not.toHaveBeenCalled();
+  });
+
+  it('allows entry of a bound tenant', () => {
+    h.allowed = ['qp'];
+    render(<ScopeSwitcher />);
+    const input = screen.getByPlaceholderText('Find or enter a userId…');
+    fireEvent.change(input, { target: { value: 'qp' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(h.setUserId).toHaveBeenCalledWith('qp');
+  });
+});

--- a/apps/web/components/layout/scope-switcher.tsx
+++ b/apps/web/components/layout/scope-switcher.tsx
@@ -22,6 +22,22 @@ export function ScopeSwitcher() {
   const [open, setOpen] = React.useState(false);
   const [filter, setFilter] = React.useState('');
   const owners = trpc.meta.owners.useQuery(undefined, { staleTime: 60_000 });
+  // The data owners this operator may manage (WP2 T9). `'*'` when unbound; the
+  // server (`assertCanManageUser`) is the real boundary, so this only keeps the
+  // free-text entry honest rather than letting it target a forbidden tenant.
+  const allowedTenants = trpc.meta.allowedTenants.useQuery(undefined, { staleTime: 60_000 });
+  const bound = Array.isArray(allowedTenants.data);
+
+  // Permissive while the binding is still loading or unset — a bound operator
+  // only ever gets forbidden values blocked here, never their own tenants.
+  const isAllowed = React.useCallback(
+    (value: string) => {
+      const allowed = allowedTenants.data;
+      if (allowed === undefined || allowed === '*') return true;
+      return allowed.includes(value);
+    },
+    [allowedTenants.data]
+  );
 
   const filtered = React.useMemo(() => {
     const list = owners.data ?? [];
@@ -32,7 +48,7 @@ export function ScopeSwitcher() {
 
   const select = (next: string) => {
     const value = next.trim();
-    if (!value) return;
+    if (!value || !isAllowed(value)) return;
     setUserId(value);
     setOpen(false);
     setFilter('');
@@ -77,7 +93,9 @@ export function ScopeSwitcher() {
             {!owners.isLoading && filtered.length === 0 && (
               <p className="px-2 py-3 text-sm text-muted-foreground">
                 {filter.trim()
-                  ? `Press Enter to view "${filter.trim()}"`
+                  ? isAllowed(filter.trim())
+                    ? `Press Enter to view "${filter.trim()}"`
+                    : `You are not permitted to manage "${filter.trim()}".`
                   : 'No data owners found yet.'}
               </p>
             )}
@@ -105,6 +123,12 @@ export function ScopeSwitcher() {
             ))}
           </div>
         </ScrollArea>
+        {bound && (
+          <p className="border-t px-2 py-1.5 text-xs text-muted-foreground">
+            Limited to your assigned data owner
+            {(allowedTenants.data as string[]).length === 1 ? '' : 's'}.
+          </p>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/apps/web/components/memories/bulk-delete-dialog.test.tsx
+++ b/apps/web/components/memories/bulk-delete-dialog.test.tsx
@@ -51,4 +51,48 @@ describe('BulkDeleteDialog (WP2 T6)', () => {
     // 7 selected, 2 previews shown → "and 5 more".
     expect(screen.getByText(/and 5 more/)).toBeInTheDocument();
   });
+
+  it('switches to an outcome view with an expandable failure list on partial failure', () => {
+    render(
+      <BulkDeleteDialog
+        open
+        onOpenChange={vi.fn()}
+        count={0}
+        previews={[]}
+        isPending={false}
+        onConfirm={vi.fn()}
+        result={{
+          deleted: ['a', 'b'],
+          failed: [
+            { id: 'gone-1', reason: 'not-found' },
+            { id: 'boom-1', reason: 'db exploded' },
+          ],
+        }}
+      />
+    );
+    // Heading reports "Deleted X of N" (2 of 4) and the failure list is present.
+    expect(screen.getByText('Deleted 2 of 4')).toBeInTheDocument();
+    expect(screen.getByText('gone-1')).toBeInTheDocument();
+    expect(screen.getByText('not-found')).toBeInTheDocument();
+    expect(screen.getByText('boom-1')).toBeInTheDocument();
+    expect(screen.getByText('db exploded')).toBeInTheDocument();
+    // The confirmation footer is replaced by a Done button (no Delete action).
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Delete/ })).not.toBeInTheDocument();
+  });
+
+  it('shows the confirmation view (not the outcome view) when a result has no failures', () => {
+    render(
+      <BulkDeleteDialog
+        open
+        onOpenChange={vi.fn()}
+        count={3}
+        previews={['first memory']}
+        isPending={false}
+        onConfirm={vi.fn()}
+        result={{ deleted: ['a', 'b', 'c'], failed: [] }}
+      />
+    );
+    expect(screen.getByText('Delete 3 memories?')).toBeInTheDocument();
+  });
 });

--- a/apps/web/components/memories/bulk-delete-dialog.tsx
+++ b/apps/web/components/memories/bulk-delete-dialog.tsx
@@ -19,10 +19,18 @@ import { truncate } from '@/lib/format';
 const TYPE_TO_CONFIRM_THRESHOLD = 10;
 const CONFIRM_WORD = 'delete';
 
+/** Per-item outcome of a bulk delete (WP2 T6/D9). */
+export type BulkDeleteOutcome = {
+  deleted: string[];
+  failed: Array<{ id: string; reason: string }>;
+};
+
 /**
  * Hardened bulk-delete confirmation (WP2 T6/D7). Shows the count and a preview of
  * the first few contents; for large selections (>10) it gates the destructive
- * action behind typing the word "delete".
+ * action behind typing the word "delete". When a completed `result` carries
+ * per-item failures, the dialog switches to an outcome view with an expandable
+ * failure list instead of closing silently.
  */
 export function BulkDeleteDialog({
   open,
@@ -31,6 +39,7 @@ export function BulkDeleteDialog({
   previews,
   isPending,
   onConfirm,
+  result,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -39,6 +48,8 @@ export function BulkDeleteDialog({
   previews: string[];
   isPending: boolean;
   onConfirm: () => void;
+  /** Set after a partial-failure run so the operator can see what failed. */
+  result?: BulkDeleteOutcome | null;
 }) {
   const [typed, setTyped] = React.useState('');
 
@@ -49,6 +60,47 @@ export function BulkDeleteDialog({
 
   const needsTyped = count > TYPE_TO_CONFIRM_THRESHOLD;
   const confirmDisabled = isPending || (needsTyped && typed.trim().toLowerCase() !== CONFIRM_WORD);
+
+  // Outcome view: a completed run left some items undeleted. Show what failed and
+  // why; the successful ids are already gone from the list.
+  if (result && result.failed.length > 0) {
+    const total = result.deleted.length + result.failed.length;
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Deleted {result.deleted.length} of {total}
+            </DialogTitle>
+            <DialogDescription>
+              {result.failed.length} memor{result.failed.length === 1 ? 'y' : 'ies'} could not be
+              deleted. Successful deletions have already been removed from the list.
+            </DialogDescription>
+          </DialogHeader>
+
+          <details className="rounded-md border bg-muted/30 p-2 text-sm" open>
+            <summary className="cursor-pointer font-medium">
+              Show {result.failed.length} failure{result.failed.length === 1 ? '' : 's'}
+            </summary>
+            <ul className="mt-2 max-h-48 space-y-1 overflow-auto">
+              {result.failed.map((f) => (
+                <li key={f.id} className="flex items-start justify-between gap-3">
+                  <span className="truncate font-mono text-xs text-muted-foreground">{f.id}</span>
+                  <span className="shrink-0 text-xs text-destructive">{f.reason}</span>
+                </li>
+              ))}
+            </ul>
+          </details>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/web/components/memories/memory-detail-sheet.test.tsx
+++ b/apps/web/components/memories/memory-detail-sheet.test.tsx
@@ -125,6 +125,50 @@ describe('MemoryDetailSheet — version conflict (WP2 T4)', () => {
     expect(screen.queryByText('+1h TTL')).not.toBeInTheDocument();
   });
 
+  it('preserves the remaining TTL window on an STM save, not the full stored window (WP2 T3/D4)', () => {
+    // The stored window is 3600s but only ~1800s remain. A plain console save
+    // must send the REMAINING window so the store keeps the current expiry —
+    // sending 3600 would reset the expiry to a full window (the D4 regression).
+    const expiresAt = new Date(Date.now() + 1800_000).toISOString();
+    h.memory = fixture({ type: 'short-term', ttlSeconds: 3600, expiresAt });
+    renderWithClient(<MemoryDetailSheet userId="qp" memoryId="m1" open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByText('Edit'));
+    // The TTL input is prefilled with the remaining seconds (~1800), not 3600.
+    const ttlInput = screen.getByLabelText('TTL in seconds') as HTMLInputElement;
+    expect(Number(ttlInput.value)).toBeGreaterThanOrEqual(1795);
+    expect(Number(ttlInput.value)).toBeLessThanOrEqual(1800);
+
+    fireEvent.click(screen.getByText('Save changes'));
+    const arg = h.updateMutate.mock.calls.at(-1)?.[0] as { ttl?: number };
+    expect(arg.ttl).toBeGreaterThanOrEqual(1795);
+    expect(arg.ttl).toBeLessThanOrEqual(1800);
+    expect(arg.ttl).not.toBe(3600);
+  });
+
+  it('honors an operator-overridden TTL on an STM save (WP2 T3/D4)', () => {
+    h.memory = fixture({
+      type: 'short-term',
+      ttlSeconds: 3600,
+      expiresAt: new Date(Date.now() + 1800_000).toISOString(),
+    });
+    renderWithClient(<MemoryDetailSheet userId="qp" memoryId="m1" open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByText('Edit'));
+    fireEvent.change(screen.getByLabelText('TTL in seconds'), { target: { value: '120' } });
+    fireEvent.click(screen.getByText('Save changes'));
+    expect(h.updateMutate).toHaveBeenLastCalledWith(expect.objectContaining({ ttl: 120 }));
+  });
+
+  it('renders no TTL input and threads no ttl for a long-term memory (WP2 T3)', () => {
+    h.memory = fixture({ type: 'long-term' });
+    renderWithClient(<MemoryDetailSheet userId="qp" memoryId="m1" open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByText('Edit'));
+    expect(screen.queryByLabelText('TTL in seconds')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Save changes'));
+    const arg = h.updateMutate.mock.calls.at(-1)?.[0] as { ttl?: number };
+    expect(arg.ttl).toBeUndefined();
+  });
+
   it('shows a stale-vector badge and a Re-embed action that calls the mutation', () => {
     h.memory = fixture({ embeddingStale: true });
     renderWithClient(<MemoryDetailSheet userId="qp" memoryId="m1" open onOpenChange={vi.fn()} />);

--- a/apps/web/components/memories/memory-detail-sheet.tsx
+++ b/apps/web/components/memories/memory-detail-sheet.tsx
@@ -20,6 +20,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
+import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -29,6 +30,7 @@ import {
   formatUptime,
   memoryTypeLabel,
   relativeTime,
+  secondsUntil,
 } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import { trpc } from '@/trpc/react';
@@ -36,6 +38,11 @@ import { trpc } from '@/trpc/react';
 /** Minimal shapes for the optimistic-delete cache surgery (WP2 T8). */
 type EvictItem = { id: string };
 type InfinitePages = { pages: Array<{ items: EvictItem[] }>; pageParams: unknown[] };
+
+/** STM TTL bounds — mirror `update-memory.dto.ts` (min 60s, max 7 days). */
+const MIN_TTL = 60;
+const MAX_TTL = 604_800;
+const clampTtl = (seconds: number) => Math.min(Math.max(Math.round(seconds), MIN_TTL), MAX_TTL);
 
 /**
  * Remove a memory id from a cached query's data (WP2 T8), handling both the
@@ -97,6 +104,9 @@ export function MemoryDetailSheet({
   const [isEditing, setIsEditing] = React.useState(false);
   const [draftContent, setDraftContent] = React.useState('');
   const [draftTags, setDraftTags] = React.useState<string[]>([]);
+  // STM-only TTL draft (WP2 T3/D4): pre-filled with the REMAINING window on edit
+  // so a plain save keeps roughly the current expiry instead of resetting it.
+  const [draftTtl, setDraftTtl] = React.useState('');
   const [confirmingDelete, setConfirmingDelete] = React.useState(false);
   // Optimistic-concurrency conflict UI (WP2 T4/D5): set when a save is rejected
   // because another writer moved the version. `preservedDraft` keeps the
@@ -119,6 +129,14 @@ export function MemoryDetailSheet({
     if (!memory.data) return;
     setDraftContent(memory.data.content);
     setDraftTags(memory.data.tags);
+    if (memory.data.type === 'short-term') {
+      // Prefill with the REMAINING window (expiresAt − now), NOT the stored
+      // ttlSeconds (which is the full window) — the store recomputes
+      // expiresAt = now + ttl on save, so sending the remaining seconds keeps
+      // roughly the current expiry rather than resetting it (WP2 T3/D4).
+      const remaining = secondsUntil(memory.data.expiresAt) ?? memory.data.ttlSeconds ?? 3600;
+      setDraftTtl(String(clampTtl(remaining)));
+    }
     setIsEditing(true);
   };
 
@@ -250,12 +268,22 @@ export function MemoryDetailSheet({
   const saveEdit = () => {
     if (!memoryId) return;
     setConflict(false);
+    // STM saves carry a TTL so the store keeps the (remaining) expiry window
+    // rather than defaulting to the full stored window (WP2 T3/D4). The user may
+    // override the prefilled value; fall back to the remaining window if cleared.
+    let ttl: number | undefined;
+    if (memory.data?.type === 'short-term') {
+      const parsed = Number.parseInt(draftTtl, 10);
+      const remaining = secondsUntil(memory.data.expiresAt) ?? memory.data.ttlSeconds ?? 3600;
+      ttl = clampTtl(Number.isFinite(parsed) && parsed > 0 ? parsed : remaining);
+    }
     update.mutate({
       userId,
       memoryId,
       content: draftContent,
       tags: draftTags,
       scope: memory.data?.scope ?? undefined,
+      ttl,
       // Optimistic concurrency (WP2 T4): the save is rejected with CONFLICT if the
       // memory has moved past the version we loaded/reloaded.
       expectedVersion: memory.data?.version,
@@ -384,6 +412,29 @@ export function MemoryDetailSheet({
                   <p className="text-sm text-muted-foreground">No tags</p>
                 )}
               </section>
+
+              {/* STM TTL (WP2 T3/D4): prefilled with the remaining window so a
+                  save preserves the current expiry by default. */}
+              {isEditing && data.type === 'short-term' && (
+                <section className="space-y-2">
+                  <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    TTL (seconds)
+                  </h3>
+                  <Input
+                    type="number"
+                    min={MIN_TTL}
+                    max={MAX_TTL}
+                    value={draftTtl}
+                    onChange={(e) => setDraftTtl(e.target.value)}
+                    aria-label="TTL in seconds"
+                    className="w-40"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Saving sets a new expiry window from now. Prefilled with the time remaining, so
+                    a save keeps the current expiry.
+                  </p>
+                </section>
+              )}
 
               <section>
                 <h3 className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">

--- a/apps/web/components/memories/memory-filters.tsx
+++ b/apps/web/components/memories/memory-filters.tsx
@@ -28,6 +28,20 @@ import {
   type MemoryTypeFilter,
 } from '@/lib/memory-filters';
 
+/**
+ * Wraps a filter control so an explanatory `title` still surfaces when the
+ * control is disabled: a native tooltip does not render on a disabled `<button>`
+ * (e.g. a disabled `SelectTrigger`), so we hang it on a non-disabled span
+ * instead (Copilot review, WP2 T9/D3).
+ */
+function FilterControl({ hint, children }: { hint?: string; children: React.ReactNode }) {
+  return (
+    <span className="inline-flex" title={hint}>
+      {children}
+    </span>
+  );
+}
+
 export function MemoryFiltersBar({
   filters,
   onChange,
@@ -57,77 +71,75 @@ export function MemoryFiltersBar({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <Select
-        value={filters.type}
-        disabled={searching}
-        onValueChange={(value) => onChange({ type: value as MemoryTypeFilter })}
-      >
-        <SelectTrigger
-          size="sm"
-          className="w-[140px]"
-          title={searching ? 'Type filter does not apply to semantic search' : undefined}
+      <FilterControl hint={searching ? 'Type filter does not apply to semantic search' : undefined}>
+        <Select
+          value={filters.type}
+          disabled={searching}
+          onValueChange={(value) => onChange({ type: value as MemoryTypeFilter })}
         >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {TYPE_OPTIONS.map((o) => (
-            <SelectItem key={o.value} value={o.value}>
-              {o.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+          <SelectTrigger size="sm" className="w-[140px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TYPE_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </FilterControl>
 
-      <Select
-        value={filters.range}
-        disabled={stmView}
-        onValueChange={(value) => onChange({ range: value as RangeKey })}
+      <FilterControl
+        hint={stmView ? 'Date range does not apply to the live short-term tier' : undefined}
       >
-        <SelectTrigger
-          size="sm"
-          className="w-[150px]"
-          title={stmView ? 'Date range does not apply to the live short-term tier' : undefined}
+        <Select
+          value={filters.range}
+          disabled={stmView}
+          onValueChange={(value) => onChange({ range: value as RangeKey })}
         >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {RANGE_OPTIONS.map((o) => (
-            <SelectItem key={o.value} value={o.value}>
-              {o.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+          <SelectTrigger size="sm" className="w-[150px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RANGE_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </FilterControl>
 
-      <Select
-        value={`${filters.sort}:${filters.order}`}
-        disabled={searching || stmView}
-        onValueChange={(value) => {
-          const [sort, order] = value.split(':') as [SortKey, OrderKey];
-          onChange({ sort, order });
-        }}
+      <FilterControl
+        hint={
+          searching
+            ? 'Sort does not apply to semantic search (ranked by relevance)'
+            : stmView
+              ? 'Short-term items are ordered by time to expiry'
+              : undefined
+        }
       >
-        <SelectTrigger
-          size="sm"
-          className="w-[160px]"
-          title={
-            searching
-              ? 'Sort does not apply to semantic search (ranked by relevance)'
-              : stmView
-                ? 'Short-term items are ordered by time to expiry'
-                : undefined
-          }
+        <Select
+          value={`${filters.sort}:${filters.order}`}
+          disabled={searching || stmView}
+          onValueChange={(value) => {
+            const [sort, order] = value.split(':') as [SortKey, OrderKey];
+            onChange({ sort, order });
+          }}
         >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {SORT_OPTIONS.map((o) => (
-            <SelectItem key={o.value} value={o.value}>
-              {o.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+          <SelectTrigger size="sm" className="w-[160px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SORT_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </FilterControl>
 
       <Input
         value={scopeDraft}

--- a/apps/web/components/memories/memory-filters.tsx
+++ b/apps/web/components/memories/memory-filters.tsx
@@ -32,11 +32,15 @@ export function MemoryFiltersBar({
   filters,
   onChange,
   searching = false,
+  stmView = false,
 }: {
   filters: MemoryFilters;
   onChange: (patch: Partial<MemoryFilters>) => void;
   /** In semantic-search mode, type and sort don't apply, so they're disabled. */
   searching?: boolean;
+  /** On the live short-term tier, SCAN order is undefined and rows are sorted
+   *  client-side by expiry — so sort + date-range don't apply (WP2 T3/D3). */
+  stmView?: boolean;
 }) {
   const active = activeFilterCount(filters);
 
@@ -76,9 +80,14 @@ export function MemoryFiltersBar({
 
       <Select
         value={filters.range}
+        disabled={stmView}
         onValueChange={(value) => onChange({ range: value as RangeKey })}
       >
-        <SelectTrigger size="sm" className="w-[150px]">
+        <SelectTrigger
+          size="sm"
+          className="w-[150px]"
+          title={stmView ? 'Date range does not apply to the live short-term tier' : undefined}
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -92,7 +101,7 @@ export function MemoryFiltersBar({
 
       <Select
         value={`${filters.sort}:${filters.order}`}
-        disabled={searching}
+        disabled={searching || stmView}
         onValueChange={(value) => {
           const [sort, order] = value.split(':') as [SortKey, OrderKey];
           onChange({ sort, order });
@@ -102,7 +111,11 @@ export function MemoryFiltersBar({
           size="sm"
           className="w-[160px]"
           title={
-            searching ? 'Sort does not apply to semantic search (ranked by relevance)' : undefined
+            searching
+              ? 'Sort does not apply to semantic search (ranked by relevance)'
+              : stmView
+                ? 'Short-term items are ordered by time to expiry'
+                : undefined
           }
         >
           <SelectValue />

--- a/apps/web/components/memories/memory-navigator.test.tsx
+++ b/apps/web/components/memories/memory-navigator.test.tsx
@@ -1,0 +1,114 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MemoryNavigator } from './memory-navigator';
+
+// Capture the `enabled` flag each data source receives so we can assert which
+// tier the navigator queries for a given filter state (WP2 T3/D3 source switch).
+const h = vi.hoisted(() => ({
+  listEnabled: undefined as boolean | undefined,
+  stmEnabled: undefined as boolean | undefined,
+  searchEnabled: undefined as boolean | undefined,
+  params: new URLSearchParams(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  usePathname: () => '/memories',
+  useSearchParams: () => h.params,
+}));
+
+vi.mock('@/components/user-scope', () => ({
+  useUserScope: () => ({ userId: 'qp', setUserId: vi.fn() }),
+}));
+
+// Mock the trpc-heavy children so the test targets the navigator's own routing.
+vi.mock('@/components/memories/memory-detail-sheet', () => ({ MemoryDetailSheet: () => null }));
+vi.mock('@/components/memories/stm-strip', () => ({ StmStrip: () => null }));
+vi.mock('@/components/memories/export-dialog', () => ({ ExportDialog: () => null }));
+vi.mock('@/components/memories/bulk-delete-dialog', () => ({ BulkDeleteDialog: () => null }));
+
+vi.mock('@/trpc/react', () => {
+  const emptyInfinite = {
+    data: { pages: [{ items: [], totalCount: 0 }] },
+    isLoading: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    refetch: vi.fn(),
+  };
+  const emptyQuery = { data: undefined, isLoading: false, error: null, refetch: vi.fn() };
+  const noop = { invalidate: vi.fn().mockResolvedValue(undefined) };
+  type Opts = { enabled?: boolean };
+  return {
+    trpc: {
+      useUtils: () => ({
+        memory: { list: noop, listStm: noop, search: noop },
+        analytics: { invalidate: vi.fn().mockResolvedValue(undefined) },
+      }),
+      memory: {
+        list: {
+          useInfiniteQuery: (_input: unknown, opts?: Opts) => {
+            h.listEnabled = opts?.enabled;
+            return emptyInfinite;
+          },
+        },
+        listStm: {
+          useInfiniteQuery: (_input: unknown, opts?: Opts) => {
+            h.stmEnabled = opts?.enabled;
+            return emptyInfinite;
+          },
+        },
+        search: {
+          useQuery: (_input: unknown, opts?: Opts) => {
+            h.searchEnabled = opts?.enabled;
+            return emptyQuery;
+          },
+        },
+        bulkDelete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+        export: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      },
+    },
+  };
+});
+
+describe('MemoryNavigator — tier source switch (WP2 T3/D3)', () => {
+  beforeEach(() => {
+    h.listEnabled = undefined;
+    h.stmEnabled = undefined;
+    h.searchEnabled = undefined;
+  });
+
+  it('queries the persisted (Postgres) list on the default "all" view', () => {
+    h.params = new URLSearchParams();
+    render(<MemoryNavigator />);
+    expect(h.listEnabled).toBe(true);
+    expect(h.stmEnabled).toBe(false);
+    expect(h.searchEnabled).toBe(false);
+  });
+
+  it('switches to the live short-term (Redis) source when type=short-term', () => {
+    h.params = new URLSearchParams('type=short-term');
+    render(<MemoryNavigator />);
+    expect(h.stmEnabled).toBe(true);
+    expect(h.listEnabled).toBe(false);
+    expect(h.searchEnabled).toBe(false);
+  });
+
+  it('keeps the persisted list (not STM) for type=long-term', () => {
+    h.params = new URLSearchParams('type=long-term');
+    render(<MemoryNavigator />);
+    expect(h.listEnabled).toBe(true);
+    expect(h.stmEnabled).toBe(false);
+  });
+
+  it('routes to semantic search — never a list source — when a query is present', () => {
+    // Even a short-term filter yields to search: STM is not vector-indexed (D3).
+    h.params = new URLSearchParams('type=short-term&q=hello');
+    render(<MemoryNavigator />);
+    expect(h.searchEnabled).toBe(true);
+    expect(h.listEnabled).toBe(false);
+    expect(h.stmEnabled).toBe(false);
+  });
+});

--- a/apps/web/components/memories/memory-navigator.tsx
+++ b/apps/web/components/memories/memory-navigator.tsx
@@ -6,7 +6,7 @@ import { Database, Download, Loader2, Search, Sparkles, X } from 'lucide-react';
 
 import { toast } from 'sonner';
 
-import { BulkDeleteDialog } from '@/components/memories/bulk-delete-dialog';
+import { BulkDeleteDialog, type BulkDeleteOutcome } from '@/components/memories/bulk-delete-dialog';
 import { ExportDialog, type ExportOptions } from '@/components/memories/export-dialog';
 import { MemoryDetailSheet } from '@/components/memories/memory-detail-sheet';
 import { MemoryFiltersBar } from '@/components/memories/memory-filters';
@@ -29,6 +29,10 @@ import {
   type MemoryTypeFilter,
 } from '@/lib/memory-filters';
 import { trpc } from '@/trpc/react';
+
+/** Server-enforced bulk-delete batch cap (WP2 T6). Mirrored client-side so a
+ *  larger selection is blocked with a hint before the round-trip. */
+const MAX_BULK_DELETE = 100;
 
 function parseFilters(params: URLSearchParams): MemoryFilters {
   const type = params.get('type');
@@ -150,6 +154,10 @@ export function MemoryNavigator() {
   // it is cleared when the filter/search context changes so stale ids can't leak.
   const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
   const [bulkDialogOpen, setBulkDialogOpen] = React.useState(false);
+  // Per-item outcome of the last bulk delete (WP2 T6): set only on partial
+  // failure so the dialog can show which ids failed and why.
+  const [bulkResult, setBulkResult] = React.useState<BulkDeleteOutcome | null>(null);
+  const overBulkCap = selectedIds.size > MAX_BULK_DELETE;
   const selectionContext = `${filters.type}|${filters.scope}|${filters.tags.join(',')}|${filters.q}`;
   React.useEffect(() => {
     // Reset selection when the filter/search context changes (canonical
@@ -179,22 +187,31 @@ export function MemoryNavigator() {
   const bulkDelete = trpc.memory.bulkDelete.useMutation({
     onSuccess: async (result) => {
       const failedCount = result.failed.length;
-      toast.success(`Deleted ${result.deleted.length} of ${result.deleted.length + failedCount}`, {
-        description:
-          failedCount > 0
-            ? `${failedCount} could not be deleted (${result.failed[0]?.reason ?? 'error'}${
-                failedCount > 1 ? ', …' : ''
-              }).`
-            : undefined,
-      });
-      setSelectedIds(new Set());
-      setBulkDialogOpen(false);
+      const total = result.deleted.length + failedCount;
       await Promise.all([
         utils.memory.list.invalidate(),
         utils.memory.listStm.invalidate(),
         utils.memory.search.invalidate(),
         utils.analytics.invalidate(),
       ]);
+      if (failedCount === 0) {
+        toast.success(`Deleted ${result.deleted.length}`);
+        setSelectedIds(new Set());
+        setBulkResult(null);
+        setBulkDialogOpen(false);
+        return;
+      }
+      // Partial failure: keep the dialog open with an expandable failure list,
+      // and drop the successfully-deleted ids so a retry targets only failures.
+      toast.warning(`Deleted ${result.deleted.length} of ${total}`, {
+        description: `${failedCount} could not be deleted — see details.`,
+      });
+      setBulkResult(result);
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        for (const id of result.deleted) next.delete(id);
+        return next;
+      });
     },
     onError: (error) => toast.error('Bulk delete failed', { description: error.message }),
   });
@@ -276,7 +293,12 @@ export function MemoryNavigator() {
           </form>
 
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <MemoryFiltersBar filters={filters} onChange={writeFilters} searching={isSearch} />
+            <MemoryFiltersBar
+              filters={filters}
+              onChange={writeFilters}
+              searching={isSearch}
+              stmView={isStmView}
+            />
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               {isSearch && search.data && (
                 <Badge variant={search.data.semantic ? 'success' : 'muted'}>
@@ -339,13 +361,30 @@ export function MemoryNavigator() {
                 />
               )}
               {selectedIds.size > 0 && (
-                <div className="flex items-center justify-between rounded-md border bg-muted/40 px-3 py-2 text-sm">
-                  <span>{selectedIds.size} selected</span>
+                <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+                  <span>
+                    {selectedIds.size} selected
+                    {overBulkCap && (
+                      <span className="ml-2 text-[var(--warning)]">
+                        Select at most {MAX_BULK_DELETE} to delete at once.
+                      </span>
+                    )}
+                  </span>
                   <div className="flex items-center gap-2">
                     <Button variant="ghost" size="sm" onClick={() => setSelectedIds(new Set())}>
                       Clear
                     </Button>
-                    <Button variant="destructive" size="sm" onClick={() => setBulkDialogOpen(true)}>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      disabled={overBulkCap}
+                      title={
+                        overBulkCap
+                          ? `Bulk delete is limited to ${MAX_BULK_DELETE} memories at once.`
+                          : undefined
+                      }
+                      onClick={() => setBulkDialogOpen(true)}
+                    >
                       Delete {selectedIds.size} selected
                     </Button>
                   </div>
@@ -392,10 +431,14 @@ export function MemoryNavigator() {
 
       <BulkDeleteDialog
         open={bulkDialogOpen}
-        onOpenChange={setBulkDialogOpen}
+        onOpenChange={(o) => {
+          setBulkDialogOpen(o);
+          if (!o) setBulkResult(null);
+        }}
         count={selectedIds.size}
         previews={previews}
         isPending={bulkDelete.isPending}
+        result={bulkResult}
         onConfirm={() => bulkDelete.mutate({ userId, memoryIds: selectionArray })}
       />
 

--- a/apps/web/server/trpc/routers/routers.test.ts
+++ b/apps/web/server/trpc/routers/routers.test.ts
@@ -174,6 +174,21 @@ describe('memory router', () => {
     );
   });
 
+  it('threads a TTL through update for STM preserve-by-default (WP2 T3/D4)', async () => {
+    const updateMemory = vi.fn().mockResolvedValue({ id: 'm1' });
+    const backend = makeBackend({ updateMemory });
+    const api = caller(backend);
+    await api.memory.update({ userId: 'qp', memoryId: 'm1', content: 'x', ttl: 1800 });
+    expect(updateMemory).toHaveBeenCalledWith(expect.objectContaining({ ttl: 1800 }));
+  });
+
+  it('rejects an out-of-range TTL on update (WP2 T3)', async () => {
+    const api = caller(makeBackend());
+    await expect(
+      api.memory.update({ userId: 'qp', memoryId: 'm1', content: 'x', ttl: 5 })
+    ).rejects.toBeTruthy();
+  });
+
   it('injects the operator email as actorLabel on delete (WP2 T5)', async () => {
     const deleteMemory = vi.fn().mockResolvedValue({ deleted: true });
     const backend = makeBackend({ deleteMemory });
@@ -315,5 +330,11 @@ describe('health + analytics + meta routers', () => {
     await expect(api.meta.session()).resolves.toMatchObject({
       user: { email: 'op@example.com' },
     });
+  });
+
+  it('exposes the operator tenant binding as "*" when unbound (WP2 T9)', async () => {
+    // No ENGRAM_OPERATOR_TENANTS in the test env ⇒ every operator is unbound.
+    const api = caller(makeBackend());
+    await expect(api.meta.allowedTenants()).resolves.toBe('*');
   });
 });

--- a/apps/web/server/trpc/routers/routers.test.ts
+++ b/apps/web/server/trpc/routers/routers.test.ts
@@ -2,6 +2,7 @@ import type { Session } from 'next-auth';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BackendError, type EngramBackend } from '@/server/backend';
+import { allowedTenantsFor } from '@/server/env';
 import type { TRPCContext } from '../context';
 import { createCaller } from '../root';
 
@@ -332,9 +333,11 @@ describe('health + analytics + meta routers', () => {
     });
   });
 
-  it('exposes the operator tenant binding as "*" when unbound (WP2 T9)', async () => {
-    // No ENGRAM_OPERATOR_TENANTS in the test env ⇒ every operator is unbound.
+  it('exposes the operator tenant binding from the env snapshot (WP2 T9)', async () => {
+    // Compare against the same env-derived source the router reads (session email
+    // op@example.com), so a set ENGRAM_OPERATOR_TENANTS in CI/dev can't make this
+    // assertion flaky (Copilot review).
     const api = caller(makeBackend());
-    await expect(api.meta.allowedTenants()).resolves.toBe('*');
+    await expect(api.meta.allowedTenants()).resolves.toEqual(allowedTenantsFor('op@example.com'));
   });
 });

--- a/docs/plans/2026-07-memory-platform/STATE.md
+++ b/docs/plans/2026-07-memory-platform/STATE.md
@@ -10,8 +10,8 @@ built + verified?).** The [`README.md`](./README.md) "Status" table tracks a dif
 axis — whether each _plan document_ was authored. A WP can be "plan: done" there and
 "execution: not started" here.
 
-- **Last updated:** 2026-07-06 (qp session — verified WP2, started this tracker, merged the suite to `main`).
-- **Last run:** WP2 (Memory Management UI) — executed + merged.
+- **Last updated:** 2026-07-08 (WP2 T3/T6 residual follow-ups remediated; earlier: 2026-07-06 verified WP2 + merged the suite to `main`).
+- **Last run:** WP2 residual follow-ups (T3 TTL-preserve input, T6 client cap + failure list, plan-mandated tests, T9 client polish, D3) — on a follow-up branch.
 
 ## Branch / worktree topology (resolved)
 
@@ -32,14 +32,14 @@ the superset — the executor's record plus the independent-verification section
 
 Legend: ✅ done+verified · 🟨 partial · ⬜ not started · 📄 plan authored only.
 
-| WP      | Deliverable                                    | Plan | Execution                                                | Where                                       |
-| ------- | ---------------------------------------------- | ---- | -------------------------------------------------------- | ------------------------------------------- |
-| WP1     | Marketing-site validation + R1–R13 remediation | ✅   | ⬜ not started¹                                          | report in this worktree                     |
-| **WP2** | **Memory management UI (SHARED-2 + T1–T9)**    | ✅   | ✅ **done — verified** (8/10 tasks clean, T3+T6 partial) | **merged `main` @109e0d8 (PR #222)**        |
-| WP3     | Rich markdown export (SHARED-1 + T1–T9)        | ✅   | ✅ **done — verified** (T1–T9; SHARED-1 deferred)        | branch `feat/markdown-export-wp3`           |
-| WP4     | Agentic memory import (SHARED-1 + T1–T16)      | ✅   | ✅ **done — verified** (SHARED-1 + T1–T16)               | worktree `worktree-wp4-agent-memory-import` |
-| WP5     | Engram as primary agent memory (D1–D8, T1–T13) | ✅   | ⬜ not started                                           | plan only                                   |
-| WP6     | Developer docs app (Starlight, D1–D10, T1–T14) | ✅   | 🟨 **foundation done** (T1,T3,T4,T5,T2,T6)               | branch `feat/developer-docs-wp6`            |
+| WP      | Deliverable                                    | Plan | Execution                                                                         | Where                                                   |
+| ------- | ---------------------------------------------- | ---- | --------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| WP1     | Marketing-site validation + R1–R13 remediation | ✅   | ⬜ not started¹                                                                   | report in this worktree                                 |
+| **WP2** | **Memory management UI (SHARED-2 + T1–T9)**    | ✅   | ✅ **done — verified** (T1–T9 + SHARED-2; T3/T6 follow-ups remediated 2026-07-08) | **merged `main` @109e0d8 (PR #222)** + follow-up branch |
+| WP3     | Rich markdown export (SHARED-1 + T1–T9)        | ✅   | ✅ **done — verified** (T1–T9; SHARED-1 deferred)                                 | branch `feat/markdown-export-wp3`                       |
+| WP4     | Agentic memory import (SHARED-1 + T1–T16)      | ✅   | ✅ **done — verified** (SHARED-1 + T1–T16)                                        | worktree `worktree-wp4-agent-memory-import`             |
+| WP5     | Engram as primary agent memory (D1–D8, T1–T13) | ✅   | ⬜ not started                                                                    | plan only                                               |
+| WP6     | Developer docs app (Starlight, D1–D10, T1–T14) | ✅   | 🟨 **foundation done** (T1,T3,T4,T5,T2,T6)                                        | branch `feat/developer-docs-wp6`                        |
 
 ¹ WP1 is a findings report (R1–R13 remediation tasks), not shipped code. One adjacent
 marketing-site commit exists on main (`3241bae` — Pages custom-domain guard + TLS runbook)
@@ -84,51 +84,58 @@ the executor reports them green on the execution branch.
 
 **Independent per-task verification (static code + test audit, 10 agents):**
 
-| Task                   | Verdict        | Both-levels tests | Note                                                                  |
-| ---------------------- | -------------- | ----------------- | --------------------------------------------------------------------- |
-| SHARED-2               | ✅ implemented | ✓                 | schema/migration exact; DB-gated round-trip spec                      |
-| T1 keyset pagination   | ✅ implemented | ✓                 | cursor.ts + 60-row real-PG walk                                       |
-| T2 STM read path       | ✅ implemented | ✓                 | delegable + structured JSON; fixed a real STM SCAN drop-items bug     |
-| T3 STM UI              | 🟨 **partial** | ✓                 | **D4 TTL-preserve edit input missing** + 2 plan-required tests absent |
-| T4 version CAS         | ✅ implemented | ✓                 | LTM CAS + STM read-compare-set; minor test gaps                       |
-| T5 audit + restore     | ✅ implemented | ✓                 | ToolCallContext + restore-by-original-id verified live                |
-| T6 bulk delete         | 🟨 **partial** | ✓                 | **>100 client cap missing**; DTO-bounds + concurrency tests absent    |
-| T7 re-embed integrity  | ✅ implemented | ✓                 | clean — no gaps found                                                 |
-| T8 optimistic delete   | ✅ implemented | ✓                 | cache surgery correct; round-trip test uses pure helper               |
-| T9 proportionate authz | ✅ implemented | ✓                 | server enforcement solid; client polish deferred (as executor noted)  |
+| Task                   | Verdict        | Both-levels tests | Note                                                                                                  |
+| ---------------------- | -------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
+| SHARED-2               | ✅ implemented | ✓                 | schema/migration exact; DB-gated round-trip spec                                                      |
+| T1 keyset pagination   | ✅ implemented | ✓                 | cursor.ts + 60-row real-PG walk                                                                       |
+| T2 STM read path       | ✅ implemented | ✓                 | delegable + structured JSON; fixed a real STM SCAN drop-items bug                                     |
+| T3 STM UI              | ✅ implemented | ✓                 | D4 TTL-preserve edit input + navigator source-switch/ttl tests added (2026-07-08 follow-up)           |
+| T4 version CAS         | ✅ implemented | ✓                 | LTM CAS + STM read-compare-set; minor test gaps                                                       |
+| T5 audit + restore     | ✅ implemented | ✓                 | ToolCallContext + restore-by-original-id verified live                                                |
+| T6 bulk delete         | ✅ implemented | ✓                 | client >100 cap + expandable failure list + DTO-bounds/concurrency tests added (2026-07-08 follow-up) |
+| T7 re-embed integrity  | ✅ implemented | ✓                 | clean — no gaps found                                                                                 |
+| T8 optimistic delete   | ✅ implemented | ✓                 | cache surgery correct; round-trip test uses pure helper                                               |
+| T9 proportionate authz | ✅ implemented | ✓                 | server enforcement solid; client polish deferred (as executor noted)                                  |
 
-All 10 tasks satisfy the suite's tests-at-both-levels rule. The two 🟨 tasks have genuine
-unmet acceptance criteria beyond what the executor's STATE.md admitted.
+All 10 tasks satisfy the suite's tests-at-both-levels rule. The two 🟨 tasks had genuine
+unmet acceptance criteria beyond what the executor's STATE.md admitted; those were
+**remediated on 2026-07-08** (see below).
 
-### WP2 residual follow-ups (not blocking; tracked here)
+### WP2 residual follow-ups — remediated 2026-07-08
 
-Ranked. None is a security or data-correctness hole; the gate is green.
+Items 1–5 are **done** on the follow-up branch; item 6 (CI-only e2e) is unchanged. The gate
+(`build`/`lint`/`typecheck`/`test`/`docs:check`) is green.
 
-1. **T3 — D4 "TTL preserve-by-default" is unimplemented (behavioral).** There is no
-   edit-mode "TTL (seconds)" input; `saveEdit` threads no `ttl`. Because the STM store
-   computes `newTtl = input.ttl ?? existing.ttl` (full stored window, not remaining), a
-   plain console edit of an STM item **resets its expiry to a full window** — the exact
-   regression D4 set out to prevent. Only the standalone "+1h TTL" button threads a ttl.
-   _Fix:_ add the remaining-TTL-prefilled input per T3 step 3 + its detail-sheet test.
-2. **T6 — ">100 selection blocked client-side with a hint" is unmet.** The 100 cap is
-   server-side Zod only; a >100 attempt shows a generic "Bulk delete failed" toast, not a
-   proactive client hint. _Fix:_ client-side cap + disabled state + hint.
-3. **Missing plan-mandated tests** (both-levels rule technically met elsewhere, but these
-   specific required specs are absent): T3 navigator "source-switch on `type=short-term`"
-   test (no `memory-navigator.test.tsx` exists), T3 `routers.test.ts` ttl-threading case,
-   T6 DTO-bounds spec, T6 concurrency-cap assertion.
-4. **T6 expandable failure list** not built — the toast shows only the first failure + "…".
-5. **T9 client polish** (executor-admitted): `meta.allowedTenants` is exposed but not
-   consumed; free-text scope-switcher entry has no client gate; settings page shows the
-   delegation limitation but no explicit per-operator binding readout. Server enforcement
-   (`assertCanManageUser`) is complete and tested — this is UX only.
-6. **`test:e2e:docker`** (CI-only) not run locally; no e2e spec asserts prose on the changed
-   `get_memory`/`delete_memory`/`promote_memory` tool results.
+1. ✅ **T3 — D4 "TTL preserve-by-default" implemented.** `memory-detail-sheet.tsx` now
+   shows an STM edit-mode "TTL (seconds)" input pre-filled with the **remaining** window —
+   derived from `secondsUntil(expiresAt)`, NOT `ttlSeconds` (which is the stored full
+   window), clamped to `[60, 604800]` — and `saveEdit` threads it. A plain STM save now
+   keeps roughly the current expiry instead of resetting to a full window. Behavioral
+   detail-sheet tests assert remaining-window (≈1800s), operator override, and
+   LTM-omits-ttl.
+2. ✅ **T6 — client >100 cap with a hint.** The navigator disables the "Delete N selected"
+   action and shows "Select at most 100 to delete at once" when the selection exceeds
+   `MAX_BULK_DELETE` (server Zod remains the backstop).
+3. ✅ **Missing plan-mandated tests added:** `memory-navigator.test.tsx` (tier source-switch
+   on `type=short-term` / `all` / `long-term` / search), `routers.test.ts` ttl-threading +
+   out-of-range cases, `bulk-delete.dto.spec.ts` (min/max/strict bounds),
+   `memory.service.spec.ts` concurrency-cap assertion (≤5 in-flight).
+4. ✅ **T6 expandable failure list built.** On partial failure the dialog stays open in an
+   outcome view ("Deleted X of N") with an expandable per-item `{id, reason}` list; the
+   successfully-deleted ids drop out of the selection so a retry targets only the failures.
+5. ✅ **T9 client polish.** The scope-switcher consumes `meta.allowedTenants`, gating
+   free-text entry (blocked with a hint for forbidden tenants; a "Limited to …" footer when
+   bound); the settings page shows a "Data-owner access" readout. Also D3: the STM view now
+   disables the sort + date-range controls with explanatory tooltips. Server enforcement
+   (`assertCanManageUser`) was already complete and tested.
+6. **`test:e2e:docker`** (CI-only) still not run locally; no e2e spec asserts prose on the
+   changed `get_memory`/`delete_memory`/`promote_memory` tool results. Unchanged.
 
-### Doc nit found during verification
+### Doc nit found during verification — ✅ fixed 2026-07-08
 
-`WP2-memory-ui/PLAN.md` (~line 343) has a garbled parenthetical: it calls the `MemoryLink`
-model "SHARED-2" and references a nonexistent `../SHARED-2-memory-link.md`. The
+`WP2-memory-ui/PLAN.md` (~line 347) had a garbled parenthetical: it called the `MemoryLink`
+model "SHARED-2" and referenced a nonexistent `../SHARED-2-memory-link.md` (now corrected to
+`SHARED-1` / `../SHARED-1-memory-link.md`). The
 [`README.md`](./README.md) registry is authoritative: **SHARED-1 = `MemoryLink`**
 (`SHARED-1-memory-link.md`), **SHARED-2 = version/audit** (what WP2 actually built). The
 task card itself is labelled correctly; only the parenthetical is stale.

--- a/docs/plans/2026-07-memory-platform/WP2-memory-ui/PLAN.md
+++ b/docs/plans/2026-07-memory-platform/WP2-memory-ui/PLAN.md
@@ -344,8 +344,8 @@ Modify `prisma/schema.prisma`:
 STM needs no migration: its `version` lives in the Redis JSON payload (absent ⇒ treated
 as 1). No backfill: `version` defaults to 1 for existing rows.
 
-Task card below (**SHARED-2** — renumbered per the suite registry in `../README.md`:
-SHARED-2 is the `MemoryLink` model, canonical in `../SHARED-2-memory-link.md`; this
+Task card below (**SHARED-2** — per the suite registry in `../README.md`:
+SHARED-1 is the `MemoryLink` model, canonical in `../SHARED-1-memory-link.md`; this
 version/audit task is SHARED-2).
 
 ## Work breakdown

--- a/docs/plans/2026-07-memory-platform/WP2-memory-ui/STATE.md
+++ b/docs/plans/2026-07-memory-platform/WP2-memory-ui/STATE.md
@@ -142,3 +142,34 @@ plan-required case (see the follow-ups in [`../STATE.md`](../STATE.md)).
 cap are unmet, and several plan-mandated tests are missing. None is a security or
 data-correctness hole and the gate is green, so WP2 ships — the residual items are logged
 as follow-ups in [`../STATE.md`](../STATE.md).
+
+---
+
+## Residual follow-up remediation (2026-07-08)
+
+The two 🟨 tasks and the non-blocking polish were completed on a follow-up branch. The
+closing gate (`build` / `lint` / `typecheck` / `test` / `docs:check`) is green.
+
+- **T3 → ✅** D4 TTL-preserve-by-default implemented. The STM edit form now renders a
+  "TTL (seconds)" input pre-filled with the **remaining** window
+  (`secondsUntil(expiresAt)`, clamped `[60, 604800]`) — deliberately NOT `ttlSeconds`,
+  which is the stored **full** window (`StmMemory.ttl`, serialized verbatim by
+  `list_memories`). `saveEdit` threads the value for STM only, so a plain console save keeps
+  roughly the current expiry. Tests: remaining-window (≈1800s vs a 3600s stored window),
+  operator override, LTM-omits-ttl.
+- **T6 → ✅** Client-side `MAX_BULK_DELETE = 100` cap (disabled action + hint), and an
+  expandable per-item failure list — on partial failure the dialog stays open in an outcome
+  view ("Deleted X of N") listing each `{id, reason}`; deleted ids leave the selection so a
+  retry targets only failures.
+- **Plan-mandated tests added:** `memory-navigator.test.tsx` (tier source-switch),
+  `routers.test.ts` ttl-threading + out-of-range, `bulk-delete.dto.spec.ts` (min/max/strict),
+  `memory.service.spec.ts` concurrency-cap (≤5 in-flight).
+- **T9 client polish → ✅** Scope-switcher consumes `meta.allowedTenants` to gate free-text
+  entry (hint for forbidden tenants, "Limited to …" footer when bound); settings page shows
+  a "Data-owner access" readout; scope-switcher tests + a `meta.allowedTenants` router test.
+  Server enforcement (`assertCanManageUser`) was already complete.
+- **D3 → ✅** The short-term view disables the sort + date-range controls (SCAN order is
+  undefined; STM is ordered by expiry) with explanatory tooltips.
+- **Doc nit → ✅** `PLAN.md` SHARED-1/SHARED-2 parenthetical corrected.
+
+Not addressed (unchanged): `test:e2e:docker` (CI-only) and prose-assertion e2e specs.


### PR DESCRIPTION
## WP2 residual follow-ups (T3, T6, T9 + D3)

Completes the documented residual follow-ups for the already-merged WP2 memory-management console (PR #222). Each item had a genuine unmet acceptance criterion recorded in `docs/plans/2026-07-memory-platform/STATE.md`.

### T3 / D4 — preserve remaining STM TTL on console edit (behavioral fix)
The STM edit form now shows a **TTL (seconds)** input pre-filled with the **remaining** window and threads it on save, so a plain edit keeps the current expiry instead of resetting it to a full window.
- Load-bearing detail: the prefill comes from `secondsUntil(expiresAt)`, **not** `ttlSeconds` — `StmMemory.ttl`/`ttlSeconds` is the *stored full window* (serialized verbatim by `list_memories`), so using it would re-introduce the exact D4 regression. Clamped to `[60, 604800]`.

### T6 — bulk-delete client cap + expandable failure list
- Navigator disables "Delete N selected" with a hint when the selection exceeds `MAX_BULK_DELETE = 100` (server Zod remains the backstop).
- On partial failure the dialog stays open in an outcome view ("Deleted X of N") with an expandable per-item `{id, reason}` list; successfully-deleted ids leave the selection so a retry targets only failures.

### T9 — operator→tenant binding UI (server enforcement was already complete)
- Scope-switcher consumes `meta.allowedTenants` to gate free-text entry (hint for forbidden tenants; "Limited to …" footer when bound).
- Settings page shows a **Data-owner access** readout.

### D3 — the short-term view disables the sort + date-range controls (SCAN order is undefined; STM is ordered by expiry) with explanatory tooltips.

### Plan-mandated tests added
- `memory-navigator.test.tsx` — tier source-switch (all / short-term / long-term / search).
- `routers.test.ts` — update ttl-threading + out-of-range; `meta.allowedTenants` binding.
- `bulk-delete.dto.spec.ts` — min/max/strict bounds.
- `memory.service.spec.ts` — bulk-delete concurrency cap (≤5 in-flight).
- `memory-detail-sheet.test.tsx` — remaining-window prefill, operator override, LTM-omits-ttl.
- `bulk-delete-dialog.test.tsx` + `scope-switcher.test.tsx` — failure-list view and tenant gate.

### Docs
- Flipped T3/T6 rows to done and logged the remediation in both STATE trackers.
- Fixed the garbled `SHARED-1`/`SHARED-2` `MemoryLink` parenthetical in `WP2-memory-ui/PLAN.md`.

### Quality gate
`pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm test` ✅ (31/31 turbo tasks; web 188, mcp-server 762) · `pnpm docs:check` ✅. No schema/migration changes.

### Closes
Closes #228 · Closes #229 · Closes #230 · Closes #231 · Closes #232
(#233 — e2e prose asserts — is out of scope for this branch and stays open.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

