### PR TITLE
fix(gaps): remediate cross-WP medium gaps G5–G9

### DIFF
--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -5,7 +5,10 @@ name: Backup verification
 # suite (backup-restore.spec.ts) only exercises the Postgres leg; this
 # workflow proves the Redis (BGSAVE/RDB) and Qdrant (snapshot) legs actually
 # round-trip, so a broken restore path is caught within a day instead of
-# during an incident. See docs/ops/backup-runbook.md.
+# during an incident. The Postgres leg provisions the real ENGRAM schema and
+# asserts the WP2-4 tables (memory_links / memory_audits / memory_import_sources)
+# round-trip too, so a dump that silently drops them is caught (G9).
+# See docs/ops/backup-runbook.md.
 
 on:
   schedule:
@@ -82,6 +85,28 @@ jobs:
           sudo apt-get install -y postgresql-client-17 redis-tools
           echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Provision ENGRAM schema
+        # The new-table round-trip assertions insert into the real memories /
+        # users / memory_links / … tables, so the schema must exist first. Uses
+        # the job-level DATABASE_URL (engram_backup_verify). Mirrors ci.yml.
+        run: |
+          pnpm db:generate
+          pnpm db:migrate:deploy
+
       - name: Wait for Qdrant
         run: |
           echo "Waiting for Qdrant to be ready..."
@@ -89,10 +114,27 @@ jobs:
           echo "Qdrant is ready"
 
       - name: Seed Postgres
+        # A synthetic sentinel table plus one FK-valid graph across the WP2-4
+        # tables (G9). memory_links needs a users+memories parent chain (NOT NULL
+        # Cascade FKs); memory_audits/import_sources have no FK. targetMemoryId is
+        # NULL to cover the unresolved-link case. updatedAt is explicit (Prisma's
+        # @updatedAt has no DB default).
         run: |
-          psql "$DATABASE_URL" <<'SQL'
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
           CREATE TABLE backup_verify (id serial PRIMARY KEY, data text NOT NULL);
           INSERT INTO backup_verify (data) VALUES ('pg-round-trip-sentinel');
+          INSERT INTO users (id, email, "createdAt", "updatedAt")
+            VALUES ('g9-user', 'g9-backup-sentinel@example.test', now(), now());
+          INSERT INTO memories (id, "userId", content, tags, type, version, "createdAt", "updatedAt", embedding)
+            VALUES ('g9-mem', 'g9-user', 'g9 backup sentinel memory', '{}', 'long-term', 1, now(), now(), '{}');
+          INSERT INTO memory_links
+            (id, "userId", "sourceMemoryId", "targetLocator", "relType", origin, "createdAt", "updatedAt")
+            VALUES ('g9-link', 'g9-user', 'g9-mem', 'id:g9-link-sentinel', 'related-to', 'authored', now(), now());
+          INSERT INTO memory_audits (id, "memoryId", "userId", action, "actorType", delegated, "createdAt")
+            VALUES ('g9-audit', 'g9-mem', 'g9-user', 'g9-audit-sentinel', 'system', false, now());
+          INSERT INTO memory_import_sources
+            (id, "userId", "memoryId", "sourceTool", "sourcePath", "sourceKey", "contentHash", "importBatchId", "importedAt", "updatedAt")
+            VALUES ('g9-import', 'g9-user', 'g9-mem', 'markdown', '/g9/sentinel.md', 'g9-import-sentinel', 'g9-content-hash', 'g9-batch', now(), now());
           SQL
 
       - name: Seed Redis
@@ -128,9 +170,15 @@ jobs:
       - name: Destroy live data (prove restore does the work)
         run: |
           psql "$DATABASE_URL" -c 'DROP TABLE backup_verify;'
+          # Delete the WP2-4 sentinel rows (children only — FK-safe) so the
+          # post-restore assertion proves the dump carried them back.
+          psql "$DATABASE_URL" -c "DELETE FROM memory_links WHERE id = 'g9-link';"
+          psql "$DATABASE_URL" -c "DELETE FROM memory_audits WHERE id = 'g9-audit';"
+          psql "$DATABASE_URL" -c "DELETE FROM memory_import_sources WHERE id = 'g9-import';"
           redis-cli -h localhost -p 6379 FLUSHALL
           curl -sf -X DELETE "$QDRANT_URL/collections/memories"
           # Sanity: everything is really gone.
+          test "$(psql "$DATABASE_URL" -t -A -c "SELECT COUNT(*) FROM memory_links WHERE \"targetLocator\" = 'id:g9-link-sentinel'")" = "0"
           test "$(redis-cli -h localhost -p 6379 GET engram:backup-verify:sentinel)" = ""
           test "$(curl -s -o /dev/null -w '%{http_code}' "$QDRANT_URL/collections/memories")" = "404"
 
@@ -145,6 +193,17 @@ jobs:
             "SELECT data FROM backup_verify WHERE data = 'pg-round-trip-sentinel'")"
           echo "postgres sentinel: $RESULT"
           test "$RESULT" = "pg-round-trip-sentinel"
+
+      - name: Verify new-table round-trip (memory_links / audits / import provenance)
+        # G9: the WP2-4 tables must survive the full backup→destroy→restore cycle.
+        run: |
+          LINK="$(psql "$DATABASE_URL" -t -A -c "SELECT COUNT(*) FROM memory_links WHERE \"targetLocator\" = 'id:g9-link-sentinel'")"
+          AUDIT="$(psql "$DATABASE_URL" -t -A -c "SELECT COUNT(*) FROM memory_audits WHERE action = 'g9-audit-sentinel'")"
+          IMPORT="$(psql "$DATABASE_URL" -t -A -c "SELECT COUNT(*) FROM memory_import_sources WHERE \"sourceKey\" = 'g9-import-sentinel'")"
+          echo "links=$LINK audits=$AUDIT import=$IMPORT"
+          test "$LINK" = "1"
+          test "$AUDIT" = "1"
+          test "$IMPORT" = "1"
 
       - name: Verify Redis round-trip
         run: |

--- a/apps/docs/src/content/docs/reference/mcp-tools/export-memories.md
+++ b/apps/docs/src/content/docs/reference/mcp-tools/export-memories.md
@@ -23,6 +23,7 @@ Export a user's memories as an Obsidian-compatible markdown vault (YAML frontmat
 | `scope` | string | no | — | — |
 | `type` | `short-term` \| `long-term` | no | — | — |
 | `mode` | `multi` \| `single` | no | — | — |
+| `includeHistory` | boolean | no | — | — |
 | `maxInline` | integer | no | `25` | — |
 
 ## Example

--- a/apps/mcp-server/src/__tests__/backup-restore.spec.ts
+++ b/apps/mcp-server/src/__tests__/backup-restore.spec.ts
@@ -4,14 +4,18 @@
  * Verifies that:
  *   1. backup.sh produces a valid archive containing a postgres dump.
  *   2. restore.sh --pg-only --no-confirm replays that dump into a fresh schema.
- *   3. The restored data matches what was originally written.
+ *   3. The restored data matches what was originally written — including the
+ *      WP2-4 tables (memory_links / memory_audits / memory_import_sources), so a
+ *      future dump narrowing to a table allowlist that omits them is caught (G9).
  *
- * Requires PGVECTOR_TEST_URL pointing at a real Postgres instance with
- * the psql and pg_dump CLI tools available.  Skipped automatically when
- * the env var is absent.
+ * Requires PGVECTOR_TEST_URL pointing at a real Postgres instance that has the
+ * ENGRAM schema migrated (the new-table assertions insert into memories/users/…),
+ * with the psql and pg_dump CLI tools available. Skipped automatically when the
+ * env var is absent. CI provisions the schema via `db:migrate:deploy` before
+ * `pnpm test` (ci.yml), so this runs with the tables already present.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -31,6 +35,73 @@ function psql(query: string): string {
     stdio: ['pipe', 'pipe', 'pipe'],
   }).trim();
 }
+
+/**
+ * Run SQL with no shell involved (execFileSync), so the WP2-4 tables' camelCase
+ * columns — which Postgres requires double-quoted, e.g. "targetLocator" — survive
+ * without colliding with the shell quoting `psql()` above relies on. ON_ERROR_STOP
+ * makes a bad seed fail loudly instead of silently continuing.
+ */
+function pexec(sql: string): string {
+  return execFileSync(
+    'psql',
+    [TEST_URL!, '-v', 'ON_ERROR_STOP=1', '-t', '-A', '-c', sql],
+    {
+      encoding: 'utf8',
+      env: { ...process.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    },
+  ).trim();
+}
+
+/**
+ * Seed one FK-valid graph across the WP2-4 tables with distinctive sentinel
+ * values. Idempotent: pre-deletes any leftovers (child→parent) before inserting.
+ * memory_links needs a real users+memories parent chain (NOT NULL Cascade FKs);
+ * memory_audits/memory_import_sources have no FK (audit rows deliberately survive
+ * hard deletes). targetMemoryId is left NULL to also cover the unresolved-link case.
+ * updatedAt is set explicitly because Prisma's @updatedAt has no DB default.
+ */
+const SEED_NEW_TABLES = `
+DELETE FROM memory_links WHERE id = 'g9-link';
+DELETE FROM memory_audits WHERE id = 'g9-audit';
+DELETE FROM memory_import_sources WHERE id = 'g9-import';
+DELETE FROM memories WHERE id = 'g9-mem';
+DELETE FROM users WHERE id = 'g9-user';
+INSERT INTO users (id, email, "createdAt", "updatedAt")
+  VALUES ('g9-user', 'g9-backup-sentinel@example.test', now(), now());
+INSERT INTO memories (id, "userId", content, tags, type, version, "createdAt", "updatedAt", embedding)
+  VALUES ('g9-mem', 'g9-user', 'g9 backup sentinel memory', '{}', 'long-term', 1, now(), now(), '{}');
+INSERT INTO memory_links
+  (id, "userId", "sourceMemoryId", "targetLocator", "relType", origin, "createdAt", "updatedAt")
+  VALUES ('g9-link', 'g9-user', 'g9-mem', 'id:g9-link-sentinel', 'related-to', 'authored', now(), now());
+INSERT INTO memory_audits (id, "memoryId", "userId", action, "actorType", delegated, "createdAt")
+  VALUES ('g9-audit', 'g9-mem', 'g9-user', 'g9-audit-sentinel', 'system', false, now());
+INSERT INTO memory_import_sources
+  (id, "userId", "memoryId", "sourceTool", "sourcePath", "sourceKey", "contentHash", "importBatchId", "importedAt", "updatedAt")
+  VALUES ('g9-import', 'g9-user', 'g9-mem', 'markdown', '/g9/sentinel.md', 'g9-import-sentinel', 'g9-content-hash', 'g9-batch', now(), now());
+`;
+
+/** Delete only the new-table sentinel rows (children only) to prove restore brings them back. */
+const DELETE_NEW_SENTINELS = `
+DELETE FROM memory_links WHERE id = 'g9-link';
+DELETE FROM memory_audits WHERE id = 'g9-audit';
+DELETE FROM memory_import_sources WHERE id = 'g9-import';
+`;
+
+/** Full teardown of the seeded graph (child→parent so Cascade FKs are respected). */
+const CLEANUP_NEW_TABLES = `
+DELETE FROM memory_links WHERE id = 'g9-link';
+DELETE FROM memory_audits WHERE id = 'g9-audit';
+DELETE FROM memory_import_sources WHERE id = 'g9-import';
+DELETE FROM memories WHERE id = 'g9-mem';
+DELETE FROM users WHERE id = 'g9-user';
+`;
+
+/** COUNT of each new-table sentinel by a distinctive VALUE column (proves data, not just a row). */
+const COUNT_LINK = `SELECT COUNT(*) FROM memory_links WHERE "targetLocator" = 'id:g9-link-sentinel'`;
+const COUNT_AUDIT = `SELECT COUNT(*) FROM memory_audits WHERE action = 'g9-audit-sentinel'`;
+const COUNT_IMPORT = `SELECT COUNT(*) FROM memory_import_sources WHERE "sourceKey" = 'g9-import-sentinel'`;
 
 /**
  * Environment for the backup/restore scripts scoped to Postgres only.
@@ -56,12 +127,19 @@ describe('backup / restore (postgres)', () => {
       `CREATE TABLE IF NOT EXISTS _backup_test (id serial PRIMARY KEY, data text NOT NULL)`,
     );
     psql(`INSERT INTO _backup_test (data) VALUES ('engram-backup-sentinel')`);
+    // G9: seed the WP2-4 tables so the dump (and restore) is asserted to cover them.
+    pexec(SEED_NEW_TABLES);
   });
 
   afterAll(() => {
     if (!TEST_URL) return;
     try {
       psql('DROP TABLE IF EXISTS _backup_test');
+    } catch {
+      // best-effort cleanup
+    }
+    try {
+      pexec(CLEANUP_NEW_TABLES);
     } catch {
       // best-effort cleanup
     }
@@ -101,12 +179,18 @@ describe('backup / restore (postgres)', () => {
     expect(archives.length).toBeGreaterThan(0);
     const archivePath = join(backupDir, archives[0]!);
 
-    // Remove the sentinel so we can prove restore brought it back.
+    // Remove the sentinels (legacy + WP2-4 tables) so we can prove restore
+    // brought them back — deleting the memory_links child is FK-safe.
     psql(`DELETE FROM _backup_test WHERE data = 'engram-backup-sentinel'`);
-    const before = psql(
-      `SELECT COUNT(*) FROM _backup_test WHERE data = 'engram-backup-sentinel'`,
-    );
-    expect(before.trim()).toBe('0');
+    pexec(DELETE_NEW_SENTINELS);
+    expect(
+      psql(
+        `SELECT COUNT(*) FROM _backup_test WHERE data = 'engram-backup-sentinel'`,
+      ).trim(),
+    ).toBe('0');
+    expect(pexec(COUNT_LINK)).toBe('0');
+    expect(pexec(COUNT_AUDIT)).toBe('0');
+    expect(pexec(COUNT_IMPORT)).toBe('0');
 
     execSync(
       `bash "${RESTORE_SCRIPT}" --archive "${archivePath}" --pg-only --no-confirm`,
@@ -117,5 +201,10 @@ describe('backup / restore (postgres)', () => {
       `SELECT data FROM _backup_test WHERE data = 'engram-backup-sentinel'`,
     );
     expect(after).toContain('engram-backup-sentinel');
+    // G9: the WP2-4 tables (typed links / audit trail / import provenance) must
+    // survive the full backup→destroy→restore cycle, not just the legacy table.
+    expect(pexec(COUNT_LINK)).toBe('1');
+    expect(pexec(COUNT_AUDIT)).toBe('1');
+    expect(pexec(COUNT_IMPORT)).toBe('1');
   });
 });

--- a/apps/mcp-server/src/memory/dto/export.dto.ts
+++ b/apps/mcp-server/src/memory/dto/export.dto.ts
@@ -19,6 +19,12 @@ export const exportToolSchema = z
     type: z.enum(['short-term', 'long-term']).optional(),
     mode: z.enum(['multi', 'single']).optional(),
     /**
+     * Also export each memory's audit trail as a `_history/<id>.json` sidecar
+     * (G5). Default false — the trail can contain superseded/sensitive prior
+     * content, so it is opt-in. Sidecars are ignored on WP4 re-import.
+     */
+    includeHistory: z.boolean().optional(),
+    /**
      * Max memory files returned inline. At or below this, documents + manifest
      * come back as JSON; above it, the export is written to a server directory
      * and only a path reference + manifest summary are returned (never a base64

--- a/apps/mcp-server/src/memory/export-tool-wiring.spec.ts
+++ b/apps/mcp-server/src/memory/export-tool-wiring.spec.ts
@@ -262,4 +262,17 @@ describe('export_memories handler (inline vs server-path branch)', () => {
       expect.anything(),
     );
   });
+
+  it('threads includeHistory through the real strict schema to the export options (G5)', async () => {
+    const exportService = makeExport(1);
+    const controller = await buildController(exportService);
+    await controller.exportMemories({
+      userId: KEY_TENANT,
+      includeHistory: true,
+    });
+    expect(exportService.export).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: KEY_TENANT, includeHistory: true }),
+      expect.anything(),
+    );
+  });
 });

--- a/apps/mcp-server/src/memory/export/export.types.ts
+++ b/apps/mcp-server/src/memory/export/export.types.ts
@@ -23,6 +23,13 @@ export interface MemoryExportOptions {
   type?: ExportTypeFilter;
   /** `multi` (one file per memory, default) or `single` (one file, anchored). */
   mode?: ExportMode;
+  /**
+   * Opt-in: also emit each memory's `memory_audits` trail as a `_history/<id>.json`
+   * sidecar (G5). Default false — the audit trail can contain superseded/sensitive
+   * prior content, so it is only exported on explicit request. Sidecars are ignored
+   * by the WP4 markdown importer (non-`.md`), so round-trip is unaffected.
+   */
+  includeHistory?: boolean;
   /** Omit `exportedAt` from the manifest for byte-identical CI diffs (PLAN §4.12). */
   deterministic?: boolean;
 }
@@ -66,6 +73,8 @@ export interface ExportManifest {
     shortTerm: number;
     files: number;
     failed: number;
+    /** Number of `_history/<id>.json` audit sidecars written (only when `includeHistory`). */
+    historyFiles?: number;
   };
   /** Target ids referenced by an edge but outside the (filtered) export set. */
   danglingTargets: string[];

--- a/apps/mcp-server/src/memory/export/memory-export.service.spec.ts
+++ b/apps/mcp-server/src/memory/export/memory-export.service.spec.ts
@@ -67,8 +67,30 @@ const makeStm = (items: unknown[] = []): { list: jest.Mock } => {
   };
 };
 
-const svc = (ltm: unknown, stm?: unknown): MemoryExportService =>
-  new MemoryExportService(ltm as never, stm as never);
+const auditRow = (action = 'update'): Record<string, unknown> => ({
+  id: `aud-${action}`,
+  action,
+  actorType: 'api-key',
+  actorLabel: null,
+  delegated: false,
+  before: { content: 'old content', version: 1 },
+  after: { content: 'new content', version: 2 },
+  createdAt: new Date('2026-06-02T10:00:00.000Z'),
+});
+
+/** Mock MemoryAuditService.list keyed by memoryId; unknown ids resolve to []. */
+const makeAudit = (
+  byId: Record<string, unknown[]> = {},
+): { list: jest.Mock } => ({
+  list: jest.fn((_userId: string, memoryId: string) => byId[memoryId] ?? []),
+});
+
+const svc = (
+  ltm: unknown,
+  stm?: unknown,
+  audit?: unknown,
+): MemoryExportService =>
+  new MemoryExportService(ltm as never, stm as never, audit as never);
 
 // ---- tests ----------------------------------------------------------------
 
@@ -210,6 +232,81 @@ describe('MemoryExportService resilience + sanitization', () => {
     const doc = sink.files.get('memories.md') as string;
     expect(doc).toContain('<a id="mem-claaa1"></a>');
     expect(doc).toContain('<a id="mem-clbbb2"></a>');
+  });
+});
+
+describe('MemoryExportService history sidecars (G5)', () => {
+  it('omits _history sidecars and the historyFiles count by default', async () => {
+    const ltm = makeLtm([ltmMem({ id: 'claaa1' })]);
+    const audit = makeAudit({ claaa1: [auditRow()] });
+    const sink = new InMemorySink();
+    await svc(ltm, undefined, audit).export(
+      { userId: 'qp', deterministic: true },
+      sink,
+    );
+    // Default: the audit trail is never read and no sidecar is written.
+    expect(audit.list).not.toHaveBeenCalled();
+    expect([...sink.files.keys()].some((p) => p.startsWith('_history/'))).toBe(
+      false,
+    );
+    const manifest = JSON.parse(sink.files.get('manifest.json') as string);
+    expect(manifest.counts.historyFiles).toBeUndefined();
+  });
+
+  it('writes _history/<id>.json for memories with audit rows when includeHistory', async () => {
+    const ltm = makeLtm([ltmMem({ id: 'claaa1' }), ltmMem({ id: 'clbbb2' })]);
+    const audit = makeAudit({
+      claaa1: [auditRow('update'), auditRow('delete')],
+      clbbb2: [], // no history ⇒ no sidecar
+    });
+    const sink = new InMemorySink();
+    const result = await svc(ltm, undefined, audit).export(
+      { userId: 'qp', includeHistory: true, deterministic: true },
+      sink,
+    );
+    expect(sink.files.has('_history/claaa1.json')).toBe(true);
+    expect(sink.files.has('_history/clbbb2.json')).toBe(false); // empty ⇒ skipped
+    const sidecar = JSON.parse(
+      sink.files.get('_history/claaa1.json') as string,
+    );
+    expect(sidecar.memoryId).toBe('claaa1');
+    expect(sidecar.entries).toHaveLength(2);
+    expect(sidecar.entries[0].action).toBe('update');
+    expect(result.manifest.counts.historyFiles).toBe(1);
+    expect(result.manifest.notes.join(' ')).toContain('Audit history');
+  });
+
+  it('gracefully skips history when the audit service is unavailable', async () => {
+    const ltm = makeLtm([ltmMem({ id: 'claaa1' })]);
+    const sink = new InMemorySink();
+    const result = await svc(ltm, undefined, undefined).export(
+      { userId: 'qp', includeHistory: true, deterministic: true },
+      sink,
+    );
+    expect([...sink.files.keys()].some((p) => p.startsWith('_history/'))).toBe(
+      false,
+    );
+    expect(result.manifest.counts.historyFiles).toBe(0);
+  });
+
+  it('skips a memory whose history read throws, still writing the others', async () => {
+    const ltm = makeLtm([ltmMem({ id: 'claaa1' }), ltmMem({ id: 'clbbb2' })]);
+    const audit = {
+      list: jest.fn((_userId: string, memoryId: string) => {
+        if (memoryId === 'claaa1') throw new Error('audit read failed');
+        return [auditRow()];
+      }),
+    };
+    const sink = new InMemorySink();
+    const result = await svc(ltm, undefined, audit).export(
+      { userId: 'qp', includeHistory: true, deterministic: true },
+      sink,
+    );
+    expect(sink.files.has('_history/claaa1.json')).toBe(false); // threw ⇒ skipped
+    expect(sink.files.has('_history/clbbb2.json')).toBe(true);
+    expect(result.manifest.counts.historyFiles).toBe(1);
+    // The memory files themselves are unaffected by a history failure.
+    expect(sink.files.has('memories/memory-claaa1--claaa1.md')).toBe(true);
   });
 });
 

--- a/apps/mcp-server/src/memory/export/memory-export.service.ts
+++ b/apps/mcp-server/src/memory/export/memory-export.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { MemoryLtmService, type LtmMemory } from '@engram/memory-ltm';
 import { MemoryStmService, type StmMemory } from '@engram/memory-stm';
+import { MemoryAuditService } from '../memory-audit.service';
 import {
   MEMORY_INTERCHANGE_VERSION,
   buildFilename,
@@ -68,6 +69,13 @@ const REINDEX_NOTE =
 const STM_TTL_NOTE =
   'Short-term memories carry a point-in-time `expiresAt`; their TTL countdown is ' +
   'NOT preserved on round-trip (PLAN §4.6). Import recreates them with a fresh TTL.';
+const HISTORY_NOTE =
+  'Audit history is included under `_history/<id>.json` (G5). These sidecars can ' +
+  'contain superseded prior content; they are NOT re-imported (the WP4 importer ' +
+  'reads `.md` only).';
+
+/** Rows per memory captured into a history sidecar (mirrors the audit list() cap). */
+const HISTORY_LIMIT = 200;
 
 /**
  * Orchestrates a rich-markdown export (WP3 PLAN §T5). Pages LTM (and optionally
@@ -86,6 +94,7 @@ export class MemoryExportService {
   constructor(
     private readonly ltm: MemoryLtmService,
     @Optional() private readonly stm?: MemoryStmService,
+    @Optional() private readonly audit?: MemoryAuditService,
   ) {}
 
   async export(
@@ -112,6 +121,7 @@ export class MemoryExportService {
 
     const failed: ExportFailure[] = [];
     const written: WrittenEntry[] = [];
+    const exported: SourceMemory[] = [];
 
     const singleSections: string[] = [];
     for (const memory of memories) {
@@ -138,6 +148,7 @@ export class MemoryExportService {
             relativePath,
           });
         }
+        exported.push(memory);
       } catch (err) {
         const error = err instanceof Error ? err.message : String(err);
         this.logger.warn(
@@ -155,6 +166,12 @@ export class MemoryExportService {
       await sink.writeFile('index.md', this.buildMoc(written, memories.length));
     }
 
+    // G5: opt-in audit-history sidecars. Independent of serialize failures above —
+    // only successfully-exported memories get a `_history/<id>.json` companion.
+    const historyFiles = options.includeHistory
+      ? await this.writeHistory(options.userId, exported, sink)
+      : 0;
+
     const manifest = this.buildManifest(
       options,
       mode,
@@ -162,6 +179,7 @@ export class MemoryExportService {
       written,
       failed,
       collected.danglingTargets,
+      historyFiles,
     );
     await sink.writeFile(
       'manifest.json',
@@ -190,6 +208,41 @@ export class MemoryExportService {
         `for ${userId} use metadata edges only`,
     );
     return Promise.resolve(undefined);
+  }
+
+  /**
+   * G5: write each exported memory's `memory_audits` trail as a `_history/<id>.json`
+   * sidecar. Best-effort per memory — a history read failure is logged and skipped,
+   * never aborting the export (mirrors the per-memory serialize policy). Memories
+   * with no audit rows get no sidecar. Returns the number of sidecars written.
+   */
+  private async writeHistory(
+    userId: string,
+    memories: readonly SourceMemory[],
+    sink: ExportSink,
+  ): Promise<number> {
+    if (!this.audit) {
+      this.logger.warn(
+        'includeHistory requested but audit service is unavailable; skipping history',
+      );
+      return 0;
+    }
+    let count = 0;
+    for (const memory of memories) {
+      try {
+        const entries = await this.audit.list(userId, memory.id, HISTORY_LIMIT);
+        if (entries.length === 0) continue;
+        const doc = `${JSON.stringify({ memoryId: memory.id, entries }, null, 2)}\n`;
+        await sink.writeFile(`_history/${memory.id}.json`, doc);
+        count += 1;
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        this.logger.warn(
+          `Skipping history for memory ${memory.id} during export: ${error}`,
+        );
+      }
+    }
+    return count;
   }
 
   private async collectMemories(
@@ -347,11 +400,13 @@ export class MemoryExportService {
     written: readonly WrittenEntry[],
     failed: readonly ExportFailure[],
     danglingTargets: readonly string[],
+    historyFiles: number,
   ): ExportManifest {
     const longTerm = memories.filter((m) => m.type === 'long-term').length;
     const shortTerm = memories.filter((m) => m.type === 'short-term').length;
     const notes = [REINDEX_NOTE];
     if (shortTerm > 0) notes.push(STM_TTL_NOTE);
+    if (options.includeHistory && historyFiles > 0) notes.push(HISTORY_NOTE);
 
     return {
       schemaVersion: MEMORY_INTERCHANGE_VERSION,
@@ -383,6 +438,7 @@ export class MemoryExportService {
         files:
           mode === 'single' ? (memories.length > 0 ? 1 : 0) : written.length,
         failed: failed.length,
+        ...(options.includeHistory ? { historyFiles } : {}),
       },
       danglingTargets: [...danglingTargets].sort(),
       failedIds: failed.map((f) => f.id).sort(),

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -1546,6 +1546,9 @@ export class MemoryController {
       ...(validated.scope ? { scope: validated.scope } : {}),
       ...(validated.type ? { type: validated.type } : {}),
       ...(validated.mode ? { mode: validated.mode } : {}),
+      ...(validated.includeHistory !== undefined
+        ? { includeHistory: validated.includeHistory }
+        : {}),
       ...(validated.dateFrom ? { dateFrom: new Date(validated.dateFrom) } : {}),
       ...(validated.dateTo ? { dateTo: new Date(validated.dateTo) } : {}),
     };

--- a/apps/mcp-server/test/export-roundtrip.e2e-spec.ts
+++ b/apps/mcp-server/test/export-roundtrip.e2e-spec.ts
@@ -1,47 +1,273 @@
 /**
- * Export → import round-trip contract (G6) — DB side. **STUB (WP4 completes this).**
+ * Export → import round-trip contract (G6) — DB side.
  *
- * WP3 ships the parse-side proof of the round-trip in
- * `packages/memory-interchange/src/roundtrip.spec.ts` (fully passing). This e2e
- * stub reserves the DB-import half so the contract is visible to WP4 executors
- * and lands in the e2e config; it is intentionally `it.todo` until WP4's
- * importer exists.
+ * Proves the cross-WP guarantee end-to-end against real Postgres: a set of
+ * memories exported by WP3 (`MemoryExportService` → `DirectorySink`) and
+ * re-imported into a CLEAN tenant by WP4 (`MemoryImportService`, markdown
+ * adapter) reproduces each memory's **durable projection** — content, tags,
+ * type, scope, and durable link topology — even though the DB mints new ids
+ * on re-import. The `MemoryLink @@unique(sourceMemoryId, targetLocator,
+ * relType)` constraint (SHARED-1) makes a second import idempotent.
  *
- * The contract WP4 must satisfy (PLAN §4.10, via `durableProjection` from
- * `@engram/memory-interchange`):
+ * Design pins (see PLAN §4.10 + the parse-side proof in
+ * `packages/memory-interchange/src/roundtrip.spec.ts`):
+ *  - Compare `durableProjection` SETS keyed by content, IGNORING the volatile
+ *    DB id (re-import mints new cuids) and derived edges / volatile fields.
+ *  - Durable edges are seeded as METADATA edges (an insight's `sourceMemoryIds`
+ *    → `derived-from`/`source-of`, origin `durable`) because the export read
+ *    path's `loadMemoryLinks` seam still returns undefined (SHARED-1 not enabled
+ *    on export). A NON-VACUITY guard asserts at least one durable edge actually
+ *    survives, so a wiring regression cannot let the test pass with zero links.
+ *  - `id:<originalId>` frontmatter links dangle after a clean re-import (the new
+ *    tenant has none of the original ids), so the link's `targetLocator` retains
+ *    the original id string — which is exactly what makes the (rel, target)
+ *    topology comparable across the round-trip.
  *
- *   1. Seed a user, export via `MemoryExportService` + `DirectorySink` to a temp
- *      vault.
- *   2. Import that vault into a CLEAN test DB using the WP4 importer, with
- *      detection disabled (`skipDuplicateCheck: true`, no contradiction pass) so
- *      derived edges are not doubled.
- *   3. For each memory: `durableProjection(reimported)` deep-equals
- *      `durableProjection(exported)` — i.e. id, content, tags, type, scope, and
- *      DURABLE edges are reproduced.
- *   4. Volatile fields (`updatedAt`, `importance`, `accessCount`, `detectedAt`, …)
- *      and derived-edge counts are explicitly NOT required to match.
- *   5. The `MemoryLink` `@@unique(sourceMemoryId, targetLocator, relType)`
- *      constraint (SHARED-1) makes a second import idempotent (no doubling).
- *
- * Run (WP4): see `memory-system.e2e-spec.ts` for the infra + env preamble.
+ * Infra (mirrors memory-system.e2e-spec.ts):
+ *   docker compose -f docker-compose.test.yml up -d --wait
+ *   DATABASE_URL=postgresql://engram_test:test_password@localhost:5433/engram_test \
+ *     pnpm -w db:migrate:deploy
+ *   E2E_ENABLED=true DATABASE_URL=… REDIS_URL=… QDRANT_URL=… NODE_ENV=test \
+ *     pnpm --filter mcp-server test:e2e
  */
+
+// Set required env before NestJS bootstraps (must precede any config-validating import).
+process.env.NODE_ENV = process.env.NODE_ENV ?? 'test';
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ??
+  'postgresql://engram_test:test_password@localhost:5433/engram_test';
+process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6380';
+process.env.QDRANT_URL = process.env.QDRANT_URL ?? 'http://localhost:6335';
+// Deterministic local hash provider — no OpenAI key needed. Import runs with
+// embed:false regardless, but this keeps the whole app self-contained.
+process.env.EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER ?? 'local';
+
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '@engram/database';
+import { MemoryLtmService } from '@engram/memory-ltm';
+import { MemoryImportService } from '@engram/memory-import';
+import {
+  durableProjection,
+  durableProjectionOfDocument,
+  parseDocument,
+  type DurableProjection,
+  type MemoryEdge,
+} from '@engram/memory-interchange';
+import { AppModule } from '../src/app.module';
+import { MemoryExportService } from '../src/memory/export/memory-export.service';
+import { DirectorySink } from '../src/memory/export/directory-sink';
+
 const E2E_ENABLED = process.env.E2E_ENABLED === 'true';
 const suite: (name: string, fn: () => void) => void = E2E_ENABLED
   ? describe
   : describe.skip;
 
-suite('export → import round-trip (G6) — DB side [WP4 completes]', () => {
-  it.todo(
-    'exports a seeded user to a temp vault (MemoryExportService + DirectorySink)',
-  );
-  it.todo(
-    'imports the vault into a clean DB via the WP4 importer, detection disabled',
-  );
-  it.todo(
-    'durableProjection(reimported) deep-equals durableProjection(exported) per memory',
-  );
-  it.todo('does not require volatile fields or derived-edge counts to match');
-  it.todo(
-    're-import is idempotent via MemoryLink @@unique(source, targetLocator, relType)',
-  );
+/** Strip a `<kind>:` locator prefix → the raw target string (e.g. the cuid). */
+function locatorTarget(locator: string): string {
+  const idx = locator.indexOf(':');
+  return idx >= 0 ? locator.slice(idx + 1) : locator;
+}
+
+/** Read the exported per-memory docs (multi mode writes them under `memories/`). */
+function readMemoryDocs(vaultDir: string): string[] {
+  const dir = join(vaultDir, 'memories');
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => readFileSync(join(dir, f), 'utf8'));
+}
+
+suite('export → import round-trip (G6) — DB side', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let ltm: MemoryLtmService;
+  let exportSvc: MemoryExportService;
+  let importSvc: MemoryImportService;
+
+  let srcUserId: string;
+  let destUserId: string;
+  let vaultDir: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.forRoot()],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    prisma = moduleFixture.get(PrismaService);
+    ltm = moduleFixture.get(MemoryLtmService);
+    exportSvc = moduleFixture.get(MemoryExportService);
+    importSvc = moduleFixture.get(MemoryImportService);
+
+    // Two isolated tenants: export from src, import into a CLEAN dest.
+    const stamp = Date.now();
+    const src = await prisma.user.create({
+      data: { email: `g6-src-${stamp}@e2e.local` },
+    });
+    srcUserId = src.id;
+    const dest = await prisma.user.create({
+      data: { email: `g6-dest-${stamp}@e2e.local` },
+    });
+    destUserId = dest.id;
+
+    // Seed a source memory + an insight derived from it. The insight's
+    // isInsight + sourceMemoryIds metadata is what the edge collector turns into
+    // a DURABLE derived-from (and its inverse source-of on the source memory).
+    const source = await ltm.create({
+      userId: srcUserId,
+      content:
+        'G6 source fact: always rebase a worktree onto origin/main first.',
+      tags: ['decision'],
+      skipDuplicateCheck: true,
+    });
+    const insight = await ltm.create({
+      userId: srcUserId,
+      content:
+        'G6 insight: worktree hygiene reduces cross-agent merge conflicts.',
+      tags: ['insight'],
+      skipDuplicateCheck: true,
+    });
+    // Set the insight metadata directly so the durable edge is deterministic and
+    // unaffected by the create pipeline (importance annotation etc.).
+    await prisma.memory.update({
+      where: { id: insight.id },
+      data: {
+        metadata: {
+          isInsight: true,
+          sourceMemoryIds: [source.id],
+          topic: 'g6-worktrees',
+        },
+      },
+    });
+
+    // Export the source tenant's vault to a temp directory (deterministic).
+    vaultDir = mkdtempSync(join(tmpdir(), 'g6-vault-'));
+    await exportSvc.export(
+      { userId: srcUserId, deterministic: true, mode: 'multi' },
+      new DirectorySink(vaultDir),
+    );
+  });
+
+  afterAll(async () => {
+    // Deleting the users cascades to their memories + memory_links.
+    if (prisma && srcUserId) {
+      await prisma.user.delete({ where: { id: srcUserId } }).catch(() => {});
+    }
+    if (prisma && destUserId) {
+      await prisma.user.delete({ where: { id: destUserId } }).catch(() => {});
+    }
+    if (vaultDir) rmSync(vaultDir, { recursive: true, force: true });
+    if (app) await app.close();
+  });
+
+  it('exports at least one durable edge into the vault (non-vacuity guard)', () => {
+    const durableCount = readMemoryDocs(vaultDir)
+      .map((c) => durableProjectionOfDocument(parseDocument(c)))
+      .reduce((n, p) => n + p.durableLinks.length, 0);
+    // derived-from (on the insight) + source-of (on the source) ⇒ ≥ 2.
+    expect(durableCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reproduces the durable projection of every exported memory after a clean re-import', async () => {
+    await importSvc.run({
+      source: 'markdown',
+      path: vaultDir,
+      userId: destUserId,
+      embed: false,
+    });
+    expect(
+      await prisma.memory.count({ where: { userId: destUserId } }),
+    ).toBeGreaterThan(0);
+
+    // Expected: durable projections of the exported docs (original ids).
+    const expected = new Map<string, DurableProjection>();
+    for (const doc of readMemoryDocs(vaultDir)) {
+      const p = durableProjectionOfDocument(parseDocument(doc));
+      expected.set(p.content, p);
+    }
+
+    // Actual: rebuild durable projections from the re-imported rows + their
+    // MemoryLink edges (origin authored ⇒ durable; the locator keeps the
+    // original target id, which never remaps because it dangles).
+    const reimported = await reimportedByContent(prisma, destUserId);
+
+    // exported ⊆ reimported: every exported memory round-trips faithfully. (The
+    // vault's index.md may re-import as an extra memory; it is not an expected
+    // key, so it is ignored — we assert exported memories survive, not the
+    // absence of extras.)
+    //
+    // Strict round-trip invariants: content, type, and durable-link topology
+    // (rel/target/origin). Import DELIBERATELY re-scopes into its own namespace
+    // and adds a provenance source tag, so scope is not required to match and the
+    // original tags are asserted as a SUBSET (import adds, never drops).
+    let totalDurable = 0;
+    for (const [content, ep] of expected) {
+      const rp = reimported.get(content);
+      expect(rp).toBeDefined();
+      expect(rp!.content).toBe(ep.content);
+      expect(rp!.type).toBe(ep.type);
+      expect(rp!.durableLinks).toEqual(ep.durableLinks);
+      for (const tag of ep.tags) expect(rp!.tags).toContain(tag);
+      totalDurable += ep.durableLinks.length;
+    }
+    // Non-vacuity: the durable edges genuinely survived the DB round-trip.
+    expect(totalDurable).toBeGreaterThanOrEqual(2);
+  });
+
+  it('is idempotent: a second import adds no memories or links (SHARED-1 unique key)', async () => {
+    const memBefore = await prisma.memory.count({
+      where: { userId: destUserId },
+    });
+    const linkBefore = await prisma.memoryLink.count({
+      where: { userId: destUserId },
+    });
+    await importSvc.run({
+      source: 'markdown',
+      path: vaultDir,
+      userId: destUserId,
+      embed: false,
+    });
+    expect(await prisma.memory.count({ where: { userId: destUserId } })).toBe(
+      memBefore,
+    );
+    expect(
+      await prisma.memoryLink.count({ where: { userId: destUserId } }),
+    ).toBe(linkBefore);
+  });
 });
+
+/** Build content-keyed durable projections from a tenant's re-imported rows. */
+async function reimportedByContent(
+  prisma: PrismaService,
+  userId: string,
+): Promise<Map<string, DurableProjection>> {
+  const memories = await prisma.memory.findMany({
+    where: { userId },
+    select: { id: true, type: true, scope: true, tags: true, content: true },
+  });
+  const out = new Map<string, DurableProjection>();
+  for (const mem of memories) {
+    const links = await prisma.memoryLink.findMany({
+      where: { userId, sourceMemoryId: mem.id },
+      select: { relType: true, targetLocator: true, origin: true },
+    });
+    const edges: MemoryEdge[] = links.map((l) => ({
+      rel: l.relType as MemoryEdge['rel'],
+      target: locatorTarget(l.targetLocator),
+      origin: l.origin === 'derived' ? 'derived' : 'durable',
+    }));
+    const p = durableProjection({
+      id: mem.id,
+      type: mem.type as DurableProjection['type'],
+      scope: mem.scope,
+      tags: mem.tags,
+      content: mem.content,
+      links: edges,
+    });
+    out.set(p.content, p);
+  }
+  return out;
+}

--- a/apps/web/components/memories/export-dialog.test.tsx
+++ b/apps/web/components/memories/export-dialog.test.tsx
@@ -9,25 +9,35 @@ function renderDialog(isPending = false, onConfirm = vi.fn()) {
 }
 
 describe('ExportDialog (WP3 T8)', () => {
-  it('renders the title and both option toggles', () => {
+  it('renders the title and all option toggles', () => {
     renderDialog();
     expect(screen.getByText('Export memories')).toBeInTheDocument();
     expect(screen.getByLabelText('Include short-term memories')).toBeInTheDocument();
     expect(screen.getByLabelText('Export as a single file')).toBeInTheDocument();
+    expect(screen.getByLabelText('Include edit history')).toBeInTheDocument();
   });
 
-  it('confirms with default options (LTM, multi-file)', () => {
+  it('confirms with default options (LTM, multi-file, no history)', () => {
     const onConfirm = renderDialog();
     fireEvent.click(screen.getByRole('button', { name: /Export/ }));
-    expect(onConfirm).toHaveBeenCalledWith({ includeStm: false, singleFile: false });
+    expect(onConfirm).toHaveBeenCalledWith({
+      includeStm: false,
+      singleFile: false,
+      includeHistory: false,
+    });
   });
 
-  it('confirms with STM + single-file when both toggles are checked', () => {
+  it('confirms with STM + single-file + history when all toggles are checked', () => {
     const onConfirm = renderDialog();
     fireEvent.click(screen.getByLabelText('Include short-term memories'));
     fireEvent.click(screen.getByLabelText('Export as a single file'));
+    fireEvent.click(screen.getByLabelText('Include edit history'));
     fireEvent.click(screen.getByRole('button', { name: /Export/ }));
-    expect(onConfirm).toHaveBeenCalledWith({ includeStm: true, singleFile: true });
+    expect(onConfirm).toHaveBeenCalledWith({
+      includeStm: true,
+      singleFile: true,
+      includeHistory: true,
+    });
   });
 
   it('disables the Export button while a request is pending', () => {

--- a/apps/web/components/memories/export-dialog.tsx
+++ b/apps/web/components/memories/export-dialog.tsx
@@ -19,6 +19,8 @@ export interface ExportOptions {
   includeStm: boolean;
   /** `single` = one anchored file; `multi` = one note per memory (default). */
   singleFile: boolean;
+  /** Include each memory's edit/delete audit trail as a `_history/` sidecar (G5). */
+  includeHistory: boolean;
 }
 
 /**
@@ -40,12 +42,14 @@ export function ExportDialog({
 }) {
   const [includeStm, setIncludeStm] = React.useState(false);
   const [singleFile, setSingleFile] = React.useState(false);
+  const [includeHistory, setIncludeHistory] = React.useState(false);
 
   // Reset the options whenever the dialog re-opens.
   React.useEffect(() => {
     if (open) {
       setIncludeStm(false);
       setSingleFile(false);
+      setIncludeHistory(false);
     }
   }, [open]);
 
@@ -90,13 +94,32 @@ export function ExportDialog({
               </span>
             </span>
           </label>
+
+          <label className="flex items-start gap-2 text-sm">
+            <Checkbox
+              checked={includeHistory}
+              onCheckedChange={(checked) => setIncludeHistory(checked === true)}
+              disabled={isPending}
+              aria-label="Include edit history"
+            />
+            <span>
+              Include edit history
+              <span className="block text-xs text-muted-foreground">
+                Adds each memory&apos;s audit trail as a <code>_history/</code> sidecar. May contain
+                superseded content.
+              </span>
+            </span>
+          </label>
         </div>
 
         <DialogFooter>
           <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={isPending}>
             Cancel
           </Button>
-          <Button onClick={() => onConfirm({ includeStm, singleFile })} disabled={isPending}>
+          <Button
+            onClick={() => onConfirm({ includeStm, singleFile, includeHistory })}
+            disabled={isPending}
+          >
             {isPending ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (

--- a/apps/web/components/memories/memory-navigator.tsx
+++ b/apps/web/components/memories/memory-navigator.tsx
@@ -232,6 +232,7 @@ export function MemoryNavigator() {
       userId,
       // A short-term view must include STM or it would export nothing.
       includeStm: options.includeStm || filters.type === 'short-term',
+      includeHistory: options.includeHistory,
       mode: options.singleFile ? 'single' : 'multi',
       ...(type ? { type } : {}),
       ...(filters.scope ? { scope: filters.scope } : {}),

--- a/apps/web/server/backend/prisma-backend.ts
+++ b/apps/web/server/backend/prisma-backend.ts
@@ -766,6 +766,7 @@ export class PrismaEngramBackend implements EngramBackend {
     }>('export_memories', {
       userId: params.userId,
       ...(params.includeStm !== undefined ? { includeStm: params.includeStm } : {}),
+      ...(params.includeHistory !== undefined ? { includeHistory: params.includeHistory } : {}),
       ...(params.tags && params.tags.length > 0 ? { tags: params.tags } : {}),
       ...(params.scope ? { scope: params.scope } : {}),
       ...(params.type ? { type: params.type } : {}),

--- a/apps/web/server/backend/types.ts
+++ b/apps/web/server/backend/types.ts
@@ -289,6 +289,8 @@ export interface BackendCapabilities {
 export interface ExportMemoriesParams {
   userId: string;
   includeStm?: boolean;
+  /** Also include each memory's audit trail as a `_history/<id>.json` sidecar (G5). */
+  includeHistory?: boolean;
   tags?: string[];
   scope?: string | null;
   type?: 'short-term' | 'long-term';

--- a/apps/web/server/trpc/routers/memory.ts
+++ b/apps/web/server/trpc/routers/memory.ts
@@ -65,6 +65,7 @@ const deleteInput = z.object({
 const exportInput = z.object({
   userId,
   includeStm: z.boolean().optional(),
+  includeHistory: z.boolean().optional(),
   tags: z.array(z.string().max(100)).max(50).optional(),
   scope: z.string().max(256).nullish(),
   type: z.enum(['short-term', 'long-term']).optional(),
@@ -82,6 +83,7 @@ export const memoryRouter = router({
     const { files, manifest } = await ctx.backend.exportMemories({
       userId: input.userId,
       includeStm: input.includeStm,
+      includeHistory: input.includeHistory,
       tags: input.tags,
       scope: input.scope ?? undefined,
       type: input.type,

--- a/apps/web/server/trpc/routers/routers.test.ts
+++ b/apps/web/server/trpc/routers/routers.test.ts
@@ -82,6 +82,7 @@ describe('memory router', () => {
     const result = await api.memory.export({
       userId: 'qp',
       includeStm: true,
+      includeHistory: true,
       mode: 'single',
       tags: ['decision'],
       scope: 'project:engram',
@@ -90,6 +91,7 @@ describe('memory router', () => {
       expect.objectContaining({
         userId: 'qp',
         includeStm: true,
+        includeHistory: true,
         mode: 'single',
         tags: ['decision'],
         scope: 'project:engram',

--- a/docs/ops/backup-runbook.md
+++ b/docs/ops/backup-runbook.md
@@ -114,12 +114,16 @@ Two layers of automated coverage:
 
 - **Every PR / push** — `backup-restore.spec.ts` (mcp-server suite) checks
   the Postgres leg: `backup.sh` produces an archive and `restore.sh
---pg-only` round-trips data. `retention.sh` pruning is covered by
-  `backup-scripts.spec.ts` against fake aged archives.
+--pg-only` round-trips data. Beyond a legacy sentinel table, it now seeds
+  and asserts the WP2-4 tables — `memory_links`, `memory_audits`, and
+  `memory_import_sources` — so a dump that silently drops them (e.g. a future
+  `--table` allowlist) reddens the PR (G9). `retention.sh` pruning is covered
+  by `backup-scripts.spec.ts` against fake aged archives.
 - **Nightly** — [`backup-verify.yml`](../../.github/workflows/backup-verify.yml)
   (cron + manual `workflow_dispatch`) runs the full `backup.sh` →
   `restore.sh` path against throwaway Postgres, Redis, and Qdrant service
-  containers: seeds all three stores, backs up, destroys the live data,
+  containers: provisions the real ENGRAM schema, seeds all three stores
+  (including the same WP2-4 tables), backs up, destroys the live data,
   restores, asserts every sentinel round-trips, and exercises the
   `retention.sh` GFS policy. A red run means the restore path is broken —
   treat it like a production incident, not a flaky test.

--- a/docs/plans/2026-07-memory-platform/GAPS.md
+++ b/docs/plans/2026-07-memory-platform/GAPS.md
@@ -10,6 +10,13 @@ agent-memory import, primary-memory integration, developer docs) leave uncovered
 Each gap states why it matters and where it should land. Treat these as candidate
 WP7+ items or as sections to fold into existing WPs at execution time.
 
+> **Medium gaps G5–G9 remediated 2026-07-09.** After WP2–5 shipped, most of the
+> medium tier was already satisfied by merged code; the genuine remainder was
+> closed on branch `feat/gaps-medium-g5-g9`. Each gap below carries a
+> **Status (2026-07-09)** line. Net: G5/G6/G9-backup closed with code; G8 already
+> shipped (DRY cleanup only); G7 substantially closed (two optional-hardening
+> sub-items deferred with rationale); G9 hosted-TLS remains WP6-owned.
+
 ## G1 — Per-user/per-agent authentication and authorization (critical)
 
 Today the only auth is `MCP_ADMIN_TOKEN` for admin tools; regular memory tools trust
@@ -50,6 +57,15 @@ other agents depend on. Needs: `MemoryRevision` table (or soft-delete + `deleted
 restore path, and the audit trail WP2 mentions made queryable from the UI.
 Lands in: WP2 schema section; export (WP3) should optionally include history.
 
+**Status (2026-07-09): CLOSED.** Recoverability was already delivered by WP2's
+`MemoryAudit` trail (update/delete/bulk-delete/promote/reembed/restore) + a working
+restore-by-original-id path + a UI History panel with per-entry restore. A
+`deletedAt`/`MemoryRevision` column was deliberately NOT added — hard-delete +
+audit-snapshot is the documented mechanism (`prisma/schema.prisma` MemoryAudit
+comment), so a soft-delete column would be redundant. The sole open sub-requirement,
+"export (WP3) optionally includes history", was implemented as the opt-in
+`includeHistory` export flag (audit sidecar under `_history/`).
+
 ## G6 — Export→import round-trip guarantee (medium)
 
 WP3 (export) and WP4 (import) define the same frontmatter/wikilink contract from two
@@ -57,6 +73,16 @@ sides. Without a single canonical schema module + a CI round-trip test
 (export N memories → import into clean DB → diff), the two will drift. Needs: shared
 contract package (e.g. `packages/memory-interchange`) + e2e round-trip test.
 Lands in: prerequisite task shared by WP3/WP4.
+
+**Status (2026-07-09): CLOSED.** The shared contract package
+(`packages/memory-interchange`, Prisma/NestJS-free), the parse-side round-trip proof,
+and the `MemoryLink` idempotency constraint (SHARED-1) were all already shipped. The
+open piece — a real DB-backed round-trip test — was implemented: `export-roundtrip.e2e-spec.ts`
+now seeds a durable edge, exports a vault, re-imports into a clean tenant, and asserts
+content/type/durable-link topology round-trip + import idempotency (it also asserts
+≥1 durable edge survives, so it cannot pass vacuously). The test surfaced and fixed a
+real fidelity bug: the markdown importer accreted ENGRAM's `## Related` mirror into
+stored content; it now strips it at `RELATED_MARKER`.
 
 ## G7 — Embedding cost and rate control on bulk operations (medium)
 
@@ -66,6 +92,18 @@ batch embedding API usage, rate limiting, cost estimate in dry-run output, and a
 documented "import with EMBEDDING_PROVIDER=local, then reindex" path (reindex is
 cursor-resumable already). Lands in: WP4 tasks + docs (WP6 operations section).
 
+**Status (2026-07-09): SUBSTANTIALLY CLOSED — two sub-items deferred.** The cost
+estimate in dry-run output (`estimateEmbeddingCost`) and the documented
+"import with `EMBEDDING_PROVIDER=local`, then reindex" path (`docs/IMPORT.md`
+"closes G7", `docs/agent-memory-migration.md`) shipped with WP4 — this is the
+codebase's chosen rate-control story. **Deferred (optional throughput hardening,
+not correctness):** (a) batch embedding API and (b) a proactive tokens/min limiter.
+Rationale: import embeds one memory at a time via `ltm.create`, so only the
+cursor-resumable reindex path would benefit; OpenAI's embedding rate limits are high;
+and the mitigation path already bounds cost. Revisit only if a real years-of-history
+bulk import empirically shows an embedding-throughput bottleneck (target the reindex
+loop as the batching seam; no migration needed).
+
 ## G8 — Recall quality regression gate (medium)
 
 `packages/eval` already scores retrieval quality (precision@k, recall@k, MRR, nDCG).
@@ -74,6 +112,16 @@ every agent gets dumber silently. Needs: seeded eval dataset from real (sanitize
 memories, eval run in CI, thresholds as release gate (RELEASE_GATES.md precedent exists).
 Lands in: WP5 acceptance criteria + CI task.
 
+**Status (2026-07-09): CLOSED (shipped with WP5) — fixture-provenance deferred.** The
+threshold-enforcing gate (`packages/eval` `thresholds.ts`/`gate.ts`), the CI job
+(`ci.yml` runs `pnpm eval` + `pnpm eval:gate` in the required `test` job), and the
+`docs/RELEASE_GATES.md` "Recall quality gate" section all landed with WP5 (#227). This
+PR only did a DRY cleanup: `run.ts` now reuses `RECALL_GATE_THRESHOLDS`/`evaluateGate`
+instead of duplicating the floors, so the two CI checks share one source of truth.
+**Deferred:** sourcing the eval dataset from real (sanitized) memories instead of the
+hand-authored fixtures — optional, privacy-sensitive, and would risk re-pinning a gate
+that already catches regressions today.
+
 ## G9 — Server reachability and deployment story for "primary memory" (medium)
 
 WP5 assumes every agent on every machine can reach one Engram server. Local-only
@@ -81,6 +129,18 @@ WP5 assumes every agent on every machine can reach one Engram server. Local-only
 The nightly backup/restore verification exists — new tables from WP2-4 (links, revisions,
 provenance) must be added to that verification. Lands in: WP5 risks + ops docs (WP6);
 backup coverage check as an explicit task.
+
+**Status (2026-07-09): backup coverage CLOSED; hosted-TLS remains WP6-owned.**
+`scripts/backup.sh` already does a whole-DB `pg_dump` (no table allowlist), so the new
+WP2-4 tables are physically captured. The gap was a missing test _assertion_: the
+backup-restore verification only checked a synthetic sentinel table. Both legs now seed
+and assert `memory_links` / `memory_audits` / `memory_import_sources` round-trip through
+backup→restore — the PR-gated `backup-restore.spec.ts` and the nightly
+`backup-verify.yml` (which now provisions the real schema first) — so a future dump
+narrowing that drops them reddens CI. The single-server reachability + backup/DR ops
+docs already exist; the **hosted/cross-host TLS reachability** substance stays deferred
+to WP6 by design (`docs/agent-memory-server.md` "do not widen the bind" note), not
+buildable now.
 
 ## G10 — Observability of memory operations (low)
 

--- a/docs/plans/2026-07-memory-platform/STATE.md
+++ b/docs/plans/2026-07-memory-platform/STATE.md
@@ -10,8 +10,13 @@ built + verified?).** The [`README.md`](./README.md) "Status" table tracks a dif
 axis — whether each _plan document_ was authored. A WP can be "plan: done" there and
 "execution: not started" here.
 
-- **Last updated:** 2026-07-08 (WP2 T3/T6 residual follow-ups remediated; earlier: 2026-07-06 verified WP2 + merged the suite to `main`).
-- **Last run:** WP2 residual follow-ups (T3 TTL-preserve input, T6 client cap + failure list, plan-mandated tests, T9 client polish, D3) — on a follow-up branch.
+- **Last updated:** 2026-07-09 (cross-cutting **medium gaps G5–G9 remediated** — see
+  [`GAPS.md`](./GAPS.md); WP5 row corrected to shipped. Earlier: 2026-07-08 WP2 T3/T6
+  residual follow-ups; 2026-07-06 verified WP2 + merged the suite to `main`).
+- **Last run:** Medium gaps G5–G9 (branch `feat/gaps-medium-g5-g9`): G5 export
+  `includeHistory` sidecar, G6 DB-backed round-trip e2e + importer `## Related`-mirror
+  fix, G8 eval-threshold DRY cleanup, G9 backup coverage of the WP2-4 tables. G7 batch
+  embedding + G8 real-memory fixtures + G9 hosted-TLS deferred with rationale in GAPS.md.
 
 ## Branch / worktree topology (resolved)
 
@@ -38,7 +43,7 @@ Legend: ✅ done+verified · 🟨 partial · ⬜ not started · 📄 plan author
 | **WP2** | **Memory management UI (SHARED-2 + T1–T9)**    | ✅   | ✅ **done — verified** (T1–T9 + SHARED-2; T3/T6 follow-ups remediated 2026-07-08) | **merged `main` @109e0d8 (PR #222)** + follow-up branch |
 | WP3     | Rich markdown export (SHARED-1 + T1–T9)        | ✅   | ✅ **done — verified** (T1–T9; SHARED-1 deferred)                                 | branch `feat/markdown-export-wp3`                       |
 | WP4     | Agentic memory import (SHARED-1 + T1–T16)      | ✅   | ✅ **done — verified** (SHARED-1 + T1–T16)                                        | worktree `worktree-wp4-agent-memory-import`             |
-| WP5     | Engram as primary agent memory (D1–D8, T1–T13) | ✅   | ⬜ not started                                                                    | plan only                                               |
+| WP5     | Engram as primary agent memory (D1–D8, T1–T13) | ✅   | ✅ **shipped** (agent-bridge, per-agent config, recall gate, file-watcher sync)   | merged `main` (PR #227, `1d63dd6`)                      |
 | WP6     | Developer docs app (Starlight, D1–D10, T1–T14) | ✅   | 🟨 **foundation done** (T1,T3,T4,T5,T2,T6)                                        | branch `feat/developer-docs-wp6`                        |
 
 ¹ WP1 is a findings report (R1–R13 remediation tasks), not shipped code. One adjacent

--- a/packages/eval/src/run.ts
+++ b/packages/eval/src/run.ts
@@ -4,19 +4,7 @@ import { recallFixtures } from './fixtures/recall-fixtures.js';
 import { createKeywordRetriever } from './retrievers/keyword-retriever.js';
 import { createEmbeddingRetriever } from './retrievers/embedding-retriever.js';
 import { createFusionRetriever } from './retrievers/fusion-retriever.js';
-import type { HarnessReport } from './types.js';
-
-/**
- * Minimum acceptable aggregate metrics for the keyword baseline. The CI `eval`
- * step fails when a change regresses recall quality below these floors. Floors
- * sit just under the recorded baseline (recall@5 91.7%, MRR 1.000, nDCG@5
- * 0.922) to allow for noise while still catching real regressions.
- */
-const BASELINE_FLOORS = {
-  recallAtK: 0.9,
-  mrr: 0.95,
-  ndcgAtK: 0.9,
-} as const;
+import { evaluateGate } from './thresholds.js';
 
 const HASH_DIMENSIONS = 64;
 
@@ -43,24 +31,6 @@ function embedText(text: string): number[] {
     return vector;
   }
   return vector.map((value) => value / norm);
-}
-
-function findRegressions(report: HarnessReport): string[] {
-  const breaches: string[] = [];
-  if (report.recallAtK < BASELINE_FLOORS.recallAtK) {
-    breaches.push(
-      `recall@${report.k} ${report.recallAtK.toFixed(3)} < floor ${BASELINE_FLOORS.recallAtK}`
-    );
-  }
-  if (report.mrr < BASELINE_FLOORS.mrr) {
-    breaches.push(`MRR ${report.mrr.toFixed(3)} < floor ${BASELINE_FLOORS.mrr}`);
-  }
-  if (report.ndcgAtK < BASELINE_FLOORS.ndcgAtK) {
-    breaches.push(
-      `nDCG@${report.k} ${report.ndcgAtK.toFixed(3)} < floor ${BASELINE_FLOORS.ndcgAtK}`
-    );
-  }
-  return breaches;
 }
 
 /**
@@ -93,9 +63,12 @@ async function main(): Promise<void> {
   console.log('');
   console.log(formatReport(reports.fusion, 'hybrid fusion retriever'));
 
-  const regressions = findRegressions(reports.fusion);
-  if (regressions.length > 0) {
-    console.error(`\nFusion regression detected:\n  - ${regressions.join('\n  - ')}`);
+  // Single source of truth for the floors: RECALL_GATE_THRESHOLDS in
+  // thresholds.ts (also used by the `eval:gate` step). Keeps the two CI checks
+  // from drifting apart.
+  const { breaches } = evaluateGate(reports.fusion);
+  if (breaches.length > 0) {
+    console.error(`\nFusion regression detected:\n  - ${breaches.join('\n  - ')}`);
     process.exitCode = 1;
   }
 }

--- a/packages/memory-import/src/adapters/adapter-utils.ts
+++ b/packages/memory-import/src/adapters/adapter-utils.ts
@@ -3,10 +3,29 @@
 // default; the common "split frontmatter → chunk-or-atomic → build facts with
 // links + sourceKey" flow lives here so all adapters stay byte-consistent.
 
+import { RELATED_MARKER } from '@engram/memory-interchange';
 import { splitFrontmatter } from '../parse/frontmatter.js';
 import { extractLinks } from '../parse/links.js';
 import { chunkByHeadings, shouldSplitAtomic } from '../parse/chunk.js';
 import type { ImportedFact, SourceTool } from '../ir/types.js';
+
+/**
+ * Drop ENGRAM's `## Related` mirror when re-importing a canonical export (G6).
+ * The serializer appends a human-readable wikilink mirror of `frontmatter.links`
+ * behind the `RELATED_MARKER` sentinel; the authoritative edges live in the
+ * frontmatter, so the mirror is lossy and MUST NOT accrete into stored content
+ * (else a second export would double it). Mirrors `parseDocument`, which strips
+ * the same marker.
+ *
+ * Gated on `isCanonical` (frontmatter carries `schemaVersion`) so this only ever
+ * touches ENGRAM's own exports — a plain note that merely happens to contain the
+ * sentinel string is left byte-for-byte intact.
+ */
+function stripRelatedMirror(body: string, isCanonical: boolean): string {
+  if (!isCanonical) return body;
+  const idx = body.indexOf(RELATED_MARKER);
+  return idx >= 0 ? body.slice(0, idx).replace(/\s+$/, '') : body;
+}
 
 /** How a file becomes facts (D6). */
 export type ChunkMode =
@@ -77,7 +96,9 @@ export interface BuildFactsInput {
  */
 export function buildFacts(input: BuildFactsInput): ImportedFact[] {
   const { content, sourcePath, sourceTool, tags, chunkMode } = input;
-  const { frontmatter, body } = splitFrontmatter(content);
+  const { frontmatter, body: rawBody } = splitFrontmatter(content);
+  const isCanonical = typeof frontmatter?.['schemaVersion'] === 'string';
+  const body = stripRelatedMirror(rawBody, isCanonical);
 
   const doSplit = chunkMode === 'split' || (chunkMode === 'auto' && shouldSplitAtomic(body));
 


### PR DESCRIPTION
Remediates the **medium-severity cross-cutting gaps G5–G9** from `docs/plans/2026-07-memory-platform/GAPS.md`. After WP2–5 shipped, most of the medium tier was already satisfied by merged code — so this closes the genuine remainder and updates the (partly stale) registry to reflect reality.

## ⚠️ One production behavior change (read first)

`packages/memory-import/src/adapters/adapter-utils.ts` now **strips ENGRAM's `## Related` mirror** (behind the `RELATED_MARKER` sentinel) from stored content on the shared import path used by **every** adapter. Surfaced by the new G6 round-trip test: re-importing an ENGRAM export was accreting the lossy `## Related` wikilink mirror into the memory's content, so a second export would drift/duplicate it. The marker is ENGRAM-specific and escaped in user content, so plain (non-ENGRAM) notes are unaffected. This mirrors what `parseDocument` already does. Everything else in this PR is additive (opt-in flags, tests, docs).

## What each gap needed vs. what this PR did

| Gap | Already shipped | This PR |
| --- | --- | --- |
| **G5** Edit history / soft-delete | Audit trail + restore-by-id + UI history panel (WP2) | Add opt-in `includeHistory` export flag → per-memory audit sidecar under `_history/<id>.json` (MCP tool + CLI + web API + export-dialog toggle). Default false → byte-identical. **CLOSED** |
| **G6** Export↔import round-trip | Canonical `memory-interchange` schema, parse-side proof, `MemoryLink` idempotency | Promote the `it.todo` stub to a real DB-backed e2e (export → import into clean tenant → assert content/type/durable-link topology + idempotency; guards ≥1 durable edge so it can't pass vacuously). **+ the importer fix above.** **CLOSED** |
| **G7** Embedding cost/rate control | Dry-run cost estimate + documented `EMBEDDING_PROVIDER=local`-then-reindex path ("closes G7") | Registry update only. Batch-embedding + proactive rate-limiter **deferred** (optional throughput hardening; import embeds one-at-a-time so only reindex benefits; OpenAI limits are high). **SUBSTANTIALLY CLOSED** |
| **G8** Recall regression gate | Threshold gate + CI job + `RELEASE_GATES.md` (shipped with WP5 #227) | DRY cleanup: `eval/run.ts` reuses `RECALL_GATE_THRESHOLDS`/`evaluateGate` instead of duplicating the floors. Real-memory fixtures **deferred** (privacy-sensitive; risks re-pinning a working gate). **CLOSED** |
| **G9** Reachability + backup coverage | Whole-DB `pg_dump` (auto-covers new tables); reachability/DR ops docs | Add round-trip assertions for `memory_links` / `memory_audits` / `memory_import_sources` to the PR-gated `backup-restore.spec.ts` **and** the nightly `backup-verify.yml` (now provisions the real schema first) + runbook note. Hosted-TLS reachability stays **WP6-owned** by design. **backup coverage CLOSED** |

Also corrects the stale "WP5 ⬜ not started" row in the suite `STATE.md` (WP5 shipped in #227).

## Verification

- Full gate green: `build` 19/19 · `typecheck` 18/18 · `lint` 19/19 · `test` 31/31 (mcp-server 767 passed) · `docs:check` ✅.
- G6 e2e validated end-to-end against the dockerized test stack in CI's exact mode (`--runInBand --forceExit`): **21/21 e2e passed**.
- G9 backup SQL (FK-valid seed, camelCase columns, array literals, delete ordering) validated against a real migrated schema copy.
- **No Prisma migration** — all WP2–5 migrations already merged, so there's no shared-dev-DB serialization concern.

### Note on `backup-verify.yml` (nightly, not a PR check)
That workflow runs on `schedule` + `workflow_dispatch` only, so it is **not** exercised by PR checks. Its new schema-provisioning + new-table steps are validated by a manual `workflow_dispatch` run on this branch (watched separately). The PR-gated `backup-restore.spec.ts` leg is the real regression guard and *is* PR-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
