### PR TITLE
fix(gaps): G1-G4 batch 2 — import-scan completion + auth engage-ready

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,9 @@ MCP_ADMIN_TOKEN=replace-with-a-long-random-token
 # Half-life in days for the recency component of importance scoring (default: 14)
 # MEMORY_IMPORTANCE_HALF_LIFE_DAYS=14
 
+# Absolute directory import_agent_memory paths must resolve into (symlinks resolved); default: server home directory
+# IMPORT_ALLOWED_ROOT=/srv/engram/imports
+
 # Logging
 LOG_LEVEL=debug
 

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,11 @@ JWT_EXPIRES_IN=7d
 # existing trusted-caller behaviour. Only enforced over the streamable-http transport.
 # AUTH_REQUIRED=false
 
+# A multi-tenant (enterprise) streamable-http server WITHOUT AUTH_REQUIRED refuses
+# to boot in EVERY NODE_ENV unless you explicitly acknowledge the trusted-network
+# posture with this flag. Prefer AUTH_REQUIRED=true (see docs/security/agent-keys.md).
+# ALLOW_UNAUTHENTICATED_HTTP=false
+
 # OAuth login (enterprise). Set a provider's id AND secret to enable it.
 # Callback URLs are <OAUTH_REDIRECT_BASE_URL>/auth/<provider>/callback —
 # register exactly those with the provider.

--- a/apps/docs/src/content/docs/reference/configuration.md
+++ b/apps/docs/src/content/docs/reference/configuration.md
@@ -44,6 +44,7 @@ codebase.
 | `JWT_SECRET` | string | — | no | when `AUTH_REQUIRED=true` | HMAC secret for issuing/verifying session JWTs. Required (≥32 chars) when `AUTH_REQUIRED=true`; otherwise optional. Never logged. |
 | `JWT_EXPIRES_IN` | string | `7d` | no | all | JWT lifetime as a duration string (`7d`, `24h`, `30m`, `3600s`) or seconds. |
 | `AUTH_REQUIRED` | boolean | `false` | no | all | When true, `/mcp` tool calls must present a valid JWT or API key, and the acting `userId` is derived from that credential — the `userId` in tool input is ignored. Default false preserves the trusted-caller behaviour. Only enforced over the streamable-http transport. |
+| `ALLOW_UNAUTHENTICATED_HTTP` | boolean | `false` | no | all | Explicit operator acknowledgement to run a multi-tenant streamable-http server WITHOUT auth (trusted-network posture). Without it such a server refuses to boot in every NODE_ENV. |
 | `OAUTH_REDIRECT_BASE_URL` | string | — | no | all | Base URL used to build OAuth callback URLs, e.g. `https://api.example.com`. |
 | `GITHUB_CLIENT_ID` | string | — | no | all | GitHub OAuth app credentials. Both must be set to enable GitHub login. |
 | `GITHUB_CLIENT_SECRET` | string | — | no | all | GitHub OAuth client secret (pairs with `GITHUB_CLIENT_ID`). Never logged. |
@@ -74,7 +75,6 @@ appears here automatically (add a description in the generator).
 
 | Variable | Description |
 | -------- | ----------- |
-| `ALLOW_UNAUTHENTICATED_HTTP` | Dev-only override that allows unauthenticated streamable-http calls. Never set in production. |
 | `AUTH_GITHUB_ID` | GitHub OAuth client id for the dashboard (Auth.js). |
 | `AUTH_GITHUB_SECRET` | GitHub OAuth client secret for the dashboard (Auth.js). |
 | `AUTH_GOOGLE_ID` | Google OAuth client id for the dashboard (Auth.js). |

--- a/apps/docs/src/content/docs/reference/configuration.md
+++ b/apps/docs/src/content/docs/reference/configuration.md
@@ -36,6 +36,7 @@ codebase.
 | `MEMORY_CONTRADICTION_THRESHOLD` | number | `0.8` | no | all | Lower bound of the contradiction similarity band. Defaults to 0.8. |
 | `MEMORY_CONTRADICTION_THRESHOLD_MAX` | number | `0.97` | no | all | Upper bound (exclusive) of the contradiction band, below the duplicate zone. Defaults to 0.97. |
 | `MEMORY_IMPORTANCE_HALF_LIFE_DAYS` | number | `14` | no | all | Half-life in days for the recency component of importance scoring. Defaults to 14. |
+| `IMPORT_ALLOWED_ROOT` | string | — | no | all | Absolute directory the `import_agent_memory` server-side path must resolve into (symlinks resolved). Defaults to the server process home directory when unset. |
 | `PGVECTOR_HNSW_M` | number | — | no | all | Optional pgvector HNSW build-time `m` (max connections per layer). |
 | `PGVECTOR_HNSW_EF_CONSTRUCTION` | number | — | no | all | Optional pgvector HNSW build-time `ef_construction` (candidate list size). |
 | `PGVECTOR_HNSW_EF_SEARCH` | number | — | no | all | Optional pgvector HNSW query-time `ef_search` (recall/latency tuning). |

--- a/apps/mcp-server/src/http-auth-posture.spec.ts
+++ b/apps/mcp-server/src/http-auth-posture.spec.ts
@@ -1,0 +1,69 @@
+import { unauthenticatedHttpRefusal } from './http-auth-posture';
+
+const base = {
+  multiTenant: true,
+  transport: 'streamable-http',
+  authRequired: false,
+  allowUnauthenticatedHttp: undefined as string | undefined,
+};
+
+describe('unauthenticatedHttpRefusal (G1-T1 boot fail-safe)', () => {
+  it('refuses a multi-tenant streamable-http boot without auth or an explicit ack', () => {
+    const refusal = unauthenticatedHttpRefusal({ ...base });
+    expect(refusal).toMatch(/Refusing to start/);
+    expect(refusal).toMatch(/AUTH_REQUIRED=true/);
+    expect(refusal).toMatch(/ALLOW_UNAUTHENTICATED_HTTP=true/);
+  });
+
+  it('is environment-independent by construction: the decision takes no NODE_ENV input', () => {
+    // The pre-G1-T1 guard only fired when NODE_ENV === 'production'. The
+    // refusal must not vary with the environment label, so the input shape
+    // itself excludes it — this test pins that contract.
+    for (const nodeEnv of ['development', 'test', 'production', undefined]) {
+      const prev = process.env.NODE_ENV;
+      try {
+        if (nodeEnv === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = nodeEnv;
+        expect(unauthenticatedHttpRefusal({ ...base })).toMatch(
+          /Refusing to start/,
+        );
+      } finally {
+        if (prev === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = prev;
+      }
+    }
+  });
+
+  it('allows boot when the operator explicitly acknowledges the posture', () => {
+    expect(
+      unauthenticatedHttpRefusal({ ...base, allowUnauthenticatedHttp: 'true' }),
+    ).toBeNull();
+  });
+
+  it('does not treat a falsy flag value as an ack', () => {
+    expect(
+      unauthenticatedHttpRefusal({
+        ...base,
+        allowUnauthenticatedHttp: 'false',
+      }),
+    ).toMatch(/Refusing to start/);
+  });
+
+  it('allows boot when auth is required', () => {
+    expect(
+      unauthenticatedHttpRefusal({ ...base, authRequired: true }),
+    ).toBeNull();
+  });
+
+  it('allows single-tenant profiles (memory/lite) unauthenticated', () => {
+    expect(
+      unauthenticatedHttpRefusal({ ...base, multiTenant: false }),
+    ).toBeNull();
+  });
+
+  it('allows the stdio transport (trusted local) unauthenticated', () => {
+    expect(
+      unauthenticatedHttpRefusal({ ...base, transport: 'stdio' }),
+    ).toBeNull();
+  });
+});

--- a/apps/mcp-server/src/http-auth-posture.ts
+++ b/apps/mcp-server/src/http-auth-posture.ts
@@ -1,0 +1,46 @@
+import { isFlagEnabled } from './auth/auth.config';
+
+export interface HttpAuthPostureInput {
+  /** From the resolved deployment-profile capabilities. */
+  multiTenant: boolean;
+  /** Effective MCP transport (`stdio` | `streamable-http`). */
+  transport: string;
+  /** Effective auth enforcement (already transport-scoped by the caller). */
+  authRequired: boolean;
+  /** Raw `ALLOW_UNAUTHENTICATED_HTTP` env value (boot-validated flag). */
+  allowUnauthenticatedHttp: string | undefined;
+}
+
+/**
+ * Fail-safe against the most dangerous misconfiguration: an HTTP transport
+ * serving every tenant unauthenticated (userId taken from tool input, not a
+ * credential). Only meaningful on a multi-tenant profile — memory/lite are
+ * single-user, so there is no cross-tenant data to expose.
+ *
+ * G1-T1: applies in EVERY NODE_ENV, not just production — the tenant boundary
+ * does not depend on the environment label, so running unauthenticated must
+ * always be an explicit operator acknowledgement
+ * (`ALLOW_UNAUTHENTICATED_HTTP=true`).
+ *
+ * @returns the refusal message when boot must be aborted, `null` otherwise.
+ */
+export function unauthenticatedHttpRefusal(
+  input: HttpAuthPostureInput,
+): string | null {
+  const { multiTenant, transport, authRequired, allowUnauthenticatedHttp } =
+    input;
+  if (
+    !multiTenant ||
+    transport !== 'streamable-http' ||
+    authRequired ||
+    isFlagEnabled(allowUnauthenticatedHttp)
+  ) {
+    return null;
+  }
+  return (
+    'Refusing to start: multi-tenant streamable-http without AUTH_REQUIRED=true. ' +
+    'This would serve all tenants unauthenticated with a client-controlled userId. ' +
+    'Set AUTH_REQUIRED=true (recommended), or set ALLOW_UNAUTHENTICATED_HTTP=true to ' +
+    'acknowledge a trusted-network deployment.'
+  );
+}

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -19,7 +19,8 @@ import {
   type AuthedRequest,
 } from './auth/mcp-auth.middleware';
 import { McpRateLimitMiddleware } from './auth/mcp-rate-limit.middleware';
-import { isAuthRequired, isFlagEnabled } from './auth/auth.config';
+import { isAuthRequired } from './auth/auth.config';
+import { unauthenticatedHttpRefusal } from './http-auth-posture';
 import { helmetOptions } from './security/security-headers.util';
 
 type ExpressMiddleware = (
@@ -90,30 +91,21 @@ async function bootstrap(): Promise<void> {
   mcpHandler.setAuthPolicy({ required: authRequired });
 
   // Fail-safe against the most dangerous misconfiguration: an HTTP transport
-  // serving every tenant unauthenticated (userId taken from tool input, not a
-  // credential). Only meaningful on a multi-tenant profile — memory/lite are
-  // single-user, so there is no cross-tenant data to expose. In production this
-  // must be a deliberate choice, so refuse to boot unless the operator
-  // explicitly acknowledges the trusted-network posture.
+  // serving every tenant unauthenticated. Applies in EVERY NODE_ENV (G1-T1) —
+  // see unauthenticatedHttpRefusal for the rationale and conditions.
   const capabilities = resolveCapabilities(
     coerceDeploymentProfile(process.env.DEPLOYMENT_PROFILE),
   );
-  if (
-    capabilities.multiTenant &&
-    mcpTransport === 'streamable-http' &&
-    !authRequired &&
-    process.env.NODE_ENV === 'production' &&
-    !isFlagEnabled(process.env.ALLOW_UNAUTHENTICATED_HTTP)
-  ) {
-    logger.error(
-      'Refusing to start: streamable-http in production without AUTH_REQUIRED=true. ' +
-        'This would serve all tenants unauthenticated with a client-controlled userId. ' +
-        'Set AUTH_REQUIRED=true (recommended), or set ALLOW_UNAUTHENTICATED_HTTP=true to ' +
-        'acknowledge a trusted-network deployment.',
-      'Bootstrap',
-    );
+  const refusal = unauthenticatedHttpRefusal({
+    multiTenant: capabilities.multiTenant,
+    transport: mcpTransport,
+    authRequired,
+    allowUnauthenticatedHttp: process.env.ALLOW_UNAUTHENTICATED_HTTP,
+  });
+  if (refusal) {
+    logger.error(refusal, 'Bootstrap');
     throw new Error(
-      'Unauthenticated streamable-http in production requires explicit ALLOW_UNAUTHENTICATED_HTTP=true',
+      'Unauthenticated multi-tenant streamable-http requires explicit ALLOW_UNAUTHENTICATED_HTTP=true',
     );
   }
 

--- a/apps/mcp-server/src/memory/import-path-guard.spec.ts
+++ b/apps/mcp-server/src/memory/import-path-guard.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the `import_agent_memory` path allowlist guard (A18).
+ *
+ * Uses REAL temp directories, files, and symlinks (no fs mocking) so the
+ * realpath-based traversal / symlink-escape detection is exercised for real.
+ */
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import {
+  assertImportPathAllowed,
+  resolveAllowedImportRoot,
+} from './import-path-guard';
+import { ClientFacingError } from '../security/client-error.util';
+
+describe('resolveAllowedImportRoot', () => {
+  const prev = process.env.IMPORT_ALLOWED_ROOT;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.IMPORT_ALLOWED_ROOT;
+    else process.env.IMPORT_ALLOWED_ROOT = prev;
+  });
+
+  it('defaults to the server process home directory when the env var is unset', () => {
+    delete process.env.IMPORT_ALLOWED_ROOT;
+    expect(resolveAllowedImportRoot()).toBe(homedir());
+  });
+
+  it('treats a blank env value as unset', () => {
+    process.env.IMPORT_ALLOWED_ROOT = '   ';
+    expect(resolveAllowedImportRoot()).toBe(homedir());
+  });
+
+  it('returns IMPORT_ALLOWED_ROOT when set', () => {
+    process.env.IMPORT_ALLOWED_ROOT = '/srv/engram/imports';
+    expect(resolveAllowedImportRoot()).toBe('/srv/engram/imports');
+  });
+});
+
+describe('assertImportPathAllowed', () => {
+  let base: string;
+  let root: string;
+  let insideDir: string;
+  let insideFile: string;
+  let outsideFile: string;
+
+  beforeAll(async () => {
+    base = await mkdtemp(join(tmpdir(), 'engram-import-guard-'));
+    root = join(base, 'allowed-root');
+    insideDir = join(root, 'vault');
+    insideFile = join(insideDir, 'notes.md');
+    outsideFile = join(base, 'secret.txt');
+    await mkdir(insideDir, { recursive: true });
+    await writeFile(insideFile, '# notes\n');
+    await writeFile(outsideFile, 'outside the root\n');
+  });
+
+  afterAll(async () => {
+    await rm(base, { recursive: true, force: true });
+  });
+
+  it('accepts a path inside the root and returns its resolved real path', async () => {
+    await expect(assertImportPathAllowed(insideFile, root)).resolves.toContain(
+      'notes.md',
+    );
+  });
+
+  it('accepts the root itself', async () => {
+    await expect(assertImportPathAllowed(root, root)).resolves.toBeTruthy();
+  });
+
+  it('accepts a `..` path that still resolves inside the root', async () => {
+    const zigzag = join(insideDir, '..', 'vault', 'notes.md');
+    await expect(assertImportPathAllowed(zigzag, root)).resolves.toContain(
+      'notes.md',
+    );
+  });
+
+  it('rejects a `..` traversal escaping the root, naming the allowed root', async () => {
+    const traversal = join(root, '..', basename(outsideFile));
+    await expect(assertImportPathAllowed(traversal, root)).rejects.toThrow(
+      ClientFacingError,
+    );
+    await expect(assertImportPathAllowed(traversal, root)).rejects.toThrow(
+      /outside the allowed import root/,
+    );
+    await expect(assertImportPathAllowed(traversal, root)).rejects.toThrow(
+      basename(root),
+    );
+  });
+
+  it('rejects an out-of-root absolute path', async () => {
+    await expect(assertImportPathAllowed(outsideFile, root)).rejects.toThrow(
+      /outside the allowed import root/,
+    );
+  });
+
+  it('rejects a symlink inside the root that points outside it', async () => {
+    const link = join(insideDir, 'sneaky-link');
+    await symlink(outsideFile, link);
+    await expect(assertImportPathAllowed(link, root)).rejects.toThrow(
+      /outside the allowed import root/,
+    );
+  });
+
+  it('follows a symlink that points back inside the root', async () => {
+    const link = join(root, 'friendly-link');
+    await symlink(insideFile, link);
+    await expect(assertImportPathAllowed(link, root)).resolves.toContain(
+      'notes.md',
+    );
+  });
+
+  it('does not treat a sibling directory sharing the root prefix as inside (no naive prefixing)', async () => {
+    // root = .../allowed-root ; sibling = .../allowed-root2 — a string-prefix
+    // check would wrongly admit the sibling.
+    const sibling = `${root}2`;
+    await mkdir(sibling, { recursive: true });
+    const siblingFile = join(sibling, 'file.md');
+    await writeFile(siblingFile, 'prefix trap\n');
+    await expect(assertImportPathAllowed(siblingFile, root)).rejects.toThrow(
+      /outside the allowed import root/,
+    );
+  });
+
+  it('reports a clear error when the requested path does not exist', async () => {
+    await expect(
+      assertImportPathAllowed(join(root, 'no-such-file.md'), root),
+    ).rejects.toThrow(/does not exist on the server/);
+  });
+
+  it('reports a clear error when the allowed root does not exist', async () => {
+    await expect(
+      assertImportPathAllowed(insideFile, join(base, 'missing-root')),
+    ).rejects.toThrow(/Import root .* does not exist/);
+  });
+
+  it('uses the IMPORT_ALLOWED_ROOT env default when no explicit root is passed', async () => {
+    const prev = process.env.IMPORT_ALLOWED_ROOT;
+    process.env.IMPORT_ALLOWED_ROOT = root;
+    try {
+      await expect(assertImportPathAllowed(insideFile)).resolves.toContain(
+        'notes.md',
+      );
+      await expect(assertImportPathAllowed(outsideFile)).rejects.toThrow(
+        /outside the allowed import root/,
+      );
+    } finally {
+      if (prev === undefined) delete process.env.IMPORT_ALLOWED_ROOT;
+      else process.env.IMPORT_ALLOWED_ROOT = prev;
+    }
+  });
+});

--- a/apps/mcp-server/src/memory/import-path-guard.ts
+++ b/apps/mcp-server/src/memory/import-path-guard.ts
@@ -1,0 +1,77 @@
+/**
+ * Server-side path allowlist for the `import_agent_memory` MCP tool (A18).
+ *
+ * The admin token authorizes WHO may run an import, not WHICH paths the
+ * server will read — without this guard an admin token could point the
+ * import adapters at arbitrary server files (`/etc/passwd`, other tenants'
+ * exports, …). Every import — including `dryRun` — must resolve its `path`
+ * inside an allowed root:
+ *
+ *   - `IMPORT_ALLOWED_ROOT` (validated by `@engram/config` to be an absolute
+ *     path) when set;
+ *   - the server process home directory (`os.homedir()`) otherwise.
+ *
+ * Both the root and the requested path are resolved with `fs.realpath`, so
+ * `..` traversal AND symlink escapes are caught. Containment is decided with
+ * `path.relative`, never naive string prefixing (`/home/qp2` must not pass
+ * for root `/home/qp`).
+ */
+import { realpath } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { isAbsolute, relative, sep } from 'node:path';
+import { ClientFacingError } from '../security/client-error.util';
+
+/**
+ * Effective allowlist root: `IMPORT_ALLOWED_ROOT` when set (non-blank),
+ * otherwise the server process home directory.
+ */
+export function resolveAllowedImportRoot(): string {
+  const configured = process.env.IMPORT_ALLOWED_ROOT;
+  if (typeof configured === 'string' && configured.trim().length > 0) {
+    return configured;
+  }
+  return homedir();
+}
+
+/**
+ * Assert that `requestedPath` resolves (symlinks included) to a location
+ * inside `allowedRoot`. Throws a {@link ClientFacingError} — the same error
+ * surface as the controller's other tool-validation failures — when the path
+ * does not exist, the root does not exist, or the path escapes the root.
+ *
+ * @returns the fully resolved real path (useful for logging).
+ */
+export async function assertImportPathAllowed(
+  requestedPath: string,
+  allowedRoot: string = resolveAllowedImportRoot(),
+): Promise<string> {
+  let resolvedRoot: string;
+  try {
+    resolvedRoot = await realpath(allowedRoot);
+  } catch {
+    throw new ClientFacingError(
+      `Import root '${allowedRoot}' does not exist on the server; set IMPORT_ALLOWED_ROOT to an existing absolute directory`,
+    );
+  }
+
+  let resolvedPath: string;
+  try {
+    resolvedPath = await realpath(requestedPath);
+  } catch {
+    throw new ClientFacingError(
+      `Import path '${requestedPath}' does not exist on the server`,
+    );
+  }
+
+  // `relative()` containment check: an escaping path yields `..`(+separator)
+  // or, across drives on Windows, an absolute path. A result of '' means the
+  // path IS the root, which is allowed.
+  const rel = relative(resolvedRoot, resolvedPath);
+  if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new ClientFacingError(
+      `Import path '${requestedPath}' resolves outside the allowed import root '${resolvedRoot}'; only paths under that root can be imported (configure IMPORT_ALLOWED_ROOT to change it)`,
+    );
+  }
+
+  return resolvedPath;
+}

--- a/apps/mcp-server/src/memory/import-tool-wiring.spec.ts
+++ b/apps/mcp-server/src/memory/import-tool-wiring.spec.ts
@@ -1,12 +1,16 @@
 /**
  * Wiring test for the `import_agent_memory` MCP tool (WP4 T13). Proves the tool
  * is registered admin-gated, hidden when the (Postgres-only) import service is
- * absent, that the handler enforces the admin token, and that the input schema
- * is `.strict()`. Mirrors export-tool-wiring.spec.ts.
+ * absent, that the handler enforces the admin token AND the server-side path
+ * allowlist (A18 — including on `dryRun`), and that the input schema is
+ * `.strict()`. Mirrors export-tool-wiring.spec.ts.
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Provider } from '@nestjs/common';
 import { MemoryImportService } from '@engram/memory-import';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { MemoryController } from './memory.controller';
 import { MemoryService } from './memory.service';
 import { ReindexQueueService } from './reindex-queue.service';
@@ -87,13 +91,32 @@ describe('import_agent_memory registration', () => {
 });
 
 describe('import_agent_memory handler', () => {
-  const prev = process.env.MCP_ADMIN_TOKEN;
-  beforeAll(() => {
+  const prevToken = process.env.MCP_ADMIN_TOKEN;
+  const prevRoot = process.env.IMPORT_ALLOWED_ROOT;
+  // Real directories: `base` holds the allowed root plus an out-of-root file,
+  // so the A18 path-allowlist wiring is exercised against the actual fs.
+  let base: string;
+  let allowedRoot: string;
+  let vaultDir: string;
+  let outsideFile: string;
+
+  beforeAll(async () => {
     process.env.MCP_ADMIN_TOKEN = ADMIN_TOKEN;
+    base = await mkdtemp(join(tmpdir(), 'engram-import-wiring-'));
+    allowedRoot = join(base, 'allowed');
+    vaultDir = join(allowedRoot, 'vault');
+    outsideFile = join(base, 'outside.md');
+    await mkdir(vaultDir, { recursive: true });
+    await writeFile(join(vaultDir, 'notes.md'), '# notes\n');
+    await writeFile(outsideFile, 'not importable\n');
+    process.env.IMPORT_ALLOWED_ROOT = allowedRoot;
   });
-  afterAll(() => {
-    if (prev === undefined) delete process.env.MCP_ADMIN_TOKEN;
-    else process.env.MCP_ADMIN_TOKEN = prev;
+  afterAll(async () => {
+    if (prevToken === undefined) delete process.env.MCP_ADMIN_TOKEN;
+    else process.env.MCP_ADMIN_TOKEN = prevToken;
+    if (prevRoot === undefined) delete process.env.IMPORT_ALLOWED_ROOT;
+    else process.env.IMPORT_ALLOWED_ROOT = prevRoot;
+    await rm(base, { recursive: true, force: true });
   });
 
   it('rejects a wrong admin token', async () => {
@@ -110,20 +133,20 @@ describe('import_agent_memory handler', () => {
     expect(importService.run).not.toHaveBeenCalled();
   });
 
-  it('runs a dry-run import with a valid admin token and returns the summary', async () => {
+  it('runs a dry-run import of an in-root path with a valid admin token and returns the summary', async () => {
     const importService = makeImport();
     const controller = await buildController(importService);
     const res = await controller.importAgentMemory({
       adminToken: ADMIN_TOKEN,
       source: 'markdown',
-      path: '/vault',
+      path: vaultDir,
       userId: KEY_TENANT,
       dryRun: true,
     });
     expect(importService.run).toHaveBeenCalledWith(
       expect.objectContaining({
         source: 'markdown',
-        path: '/vault',
+        path: vaultDir,
         userId: KEY_TENANT,
         dryRun: true,
       }),
@@ -131,6 +154,77 @@ describe('import_agent_memory handler', () => {
     const payload = JSON.parse(res.content[0]?.text ?? '{}');
     expect(payload.parsed).toBe(3);
     expect(payload.dryRun).toBe(true);
+  });
+
+  it('accepts an in-root path on a non-dry run', async () => {
+    const importService = makeImport();
+    const controller = await buildController(importService);
+    await controller.importAgentMemory({
+      adminToken: ADMIN_TOKEN,
+      source: 'markdown',
+      path: vaultDir,
+      userId: KEY_TENANT,
+    });
+    expect(importService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ path: vaultDir }),
+    );
+  });
+
+  it('rejects an out-of-root path with an error naming the allowed root (A18)', async () => {
+    const importService = makeImport();
+    const controller = await buildController(importService);
+    await expect(
+      controller.importAgentMemory({
+        adminToken: ADMIN_TOKEN,
+        source: 'markdown',
+        path: outsideFile,
+        userId: KEY_TENANT,
+      }),
+    ).rejects.toThrow(/outside the allowed import root/);
+    expect(importService.run).not.toHaveBeenCalled();
+  });
+
+  it('enforces the path allowlist on dryRun too (A18)', async () => {
+    const importService = makeImport();
+    const controller = await buildController(importService);
+    await expect(
+      controller.importAgentMemory({
+        adminToken: ADMIN_TOKEN,
+        source: 'markdown',
+        path: outsideFile,
+        userId: KEY_TENANT,
+        dryRun: true,
+      }),
+    ).rejects.toThrow(/outside the allowed import root/);
+    expect(importService.run).not.toHaveBeenCalled();
+  });
+
+  it('rejects a traversal path that escapes the root (A18)', async () => {
+    const importService = makeImport();
+    const controller = await buildController(importService);
+    await expect(
+      controller.importAgentMemory({
+        adminToken: ADMIN_TOKEN,
+        source: 'markdown',
+        path: join(allowedRoot, '..', 'outside.md'),
+        userId: KEY_TENANT,
+      }),
+    ).rejects.toThrow(/outside the allowed import root/);
+    expect(importService.run).not.toHaveBeenCalled();
+  });
+
+  it('rejects a nonexistent path with a clear error (A18)', async () => {
+    const importService = makeImport();
+    const controller = await buildController(importService);
+    await expect(
+      controller.importAgentMemory({
+        adminToken: ADMIN_TOKEN,
+        source: 'markdown',
+        path: join(vaultDir, 'nope'),
+        userId: KEY_TENANT,
+      }),
+    ).rejects.toThrow(/does not exist on the server/);
+    expect(importService.run).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -84,6 +84,7 @@ import {
   importAgentMemoryToolSchema,
   ImportAgentMemoryToolInput,
 } from './dto/import-agent-memory.dto';
+import { assertImportPathAllowed } from './import-path-guard';
 import { TOOL_MANIFEST } from './tools-manifest';
 import { ReindexQueueService } from './reindex-queue.service';
 import { ConsolidationService } from './consolidation.service';
@@ -1604,6 +1605,10 @@ export class MemoryController {
           'Agentic memory import is unavailable in this deployment profile (requires Postgres)',
         );
       }
+      // A18: the admin token authorizes WHO, not WHICH paths — the server-side
+      // path (dryRun included) must resolve inside the allowed import root
+      // (IMPORT_ALLOWED_ROOT, defaulting to the server home directory).
+      await assertImportPathAllowed(validated.path);
       const summary = await this.memoryImport.run({
         source: validated.source,
         path: validated.path,

--- a/docs/IMPORT.md
+++ b/docs/IMPORT.md
@@ -77,25 +77,25 @@ them.
 
 ## Secrets (`--secrets`, closes G2)
 
-Every fact is scanned before persistence. Under the default `redact` (and under
-`skip` / `fail`) no raw secret reaches an external embedding provider. `flag` is
-the exception: it deliberately keeps the raw content, so see the caveat below.
+Every fact is scanned before persistence — content, title, and all string
+values in frontmatter. Under **every** policy no raw secret reaches Postgres
+or an external embedding provider.
 
-| Policy   | Behavior                                                           |
-| -------- | ------------------------------------------------------------------ |
-| `redact` | replace matches with `[REDACTED]` and record the pattern (default) |
-| `flag`   | keep content, set `metadata.embeddingExcluded`, tag `has-secret`   |
-| `skip`   | drop the whole fact (counted `secretsSkipped`)                     |
-| `fail`   | abort the run before any write                                     |
+| Policy   | Behavior                                                                       |
+| -------- | ------------------------------------------------------------------------------ |
+| `redact` | replace matches with `[REDACTED]` in place and record the pattern (default)    |
+| `flag`   | redact like `redact`, plus set `metadata.embeddingExcluded` + tag `has-secret` |
+| `skip`   | drop the whole fact (counted `secretsSkipped`)                                 |
+| `fail`   | abort the run before any write, naming the matched surfaces                    |
 
-`flag` marks a fact `embeddingExcluded` and omits it from the embedding-cost
-estimate, but persistence still embeds inline when an external provider is
-configured. To keep flagged raw content out of an external provider at import
-time, run `flag` together with `--no-embed` (or `EMBEDDING_PROVIDER=disabled`),
-then backfill with `reindex` — which honors `embeddingExcluded`. Per-fact
-embedding suppression inside `create()` is a tracked follow-up.
+`flag` differs from `redact` only by the review markers: the `has-secret` tag
+surfaces the fact for human follow-up, and `embeddingExcluded` keeps it out of
+embedding entirely — both `create()` and `reindex` honor the flag (a flagged
+fact stores an empty vector and reindex counts it `skipped`). No `--no-embed`
+workaround is needed for secret handling; `--no-embed` remains the bulk-import
+cost control (next section).
 
-Dry-run lists the files + matched pattern names.
+Dry-run lists the files + matched pattern names, identical to a real run.
 
 ## Embedding cost (`--no-embed`, closes G7)
 

--- a/docs/plans/2026-07-memory-platform/STATE-G1-G4.md
+++ b/docs/plans/2026-07-memory-platform/STATE-G1-G4.md
@@ -57,24 +57,24 @@ batch, orchestration + resume protocol there.
 
 Legend: ✅ done+verified · 🟨 in progress · ⬜ not started.
 
-| Order | Task                                                       | Size | Level | Status | Commit / note                                                                |
-| ----- | ---------------------------------------------------------- | ---- | ----- | ------ | ---------------------------------------------------------------------------- |
-| 1     | **G3-T1** recall drops/flags superseded                    | S    | crit  | ✅     | default-exclude in semanticSearch + transient path; keys on supersededBy     |
-| 2     | **G3-T5** validate+document lifecycle config               | S    | high  | ✅     | 9 MEMORY\_\* vars in env.schema (boot-validated) + .env.example + docs table |
-| 3     | **G4-T1** concurrency policy ADR (doc)                     | S    | high  | ✅     | docs/concurrency-policy.md + GAPS.md G4 status; pins Dec 12/13/14            |
-| 4     | **G2-T1** enforce `embeddingExcluded` (create+reindex)     | M    | high  | ✅     | create+reindex honor the flag; `flag` now redacts (Dec 3). Spy-count tests   |
-| 5     | **G2-T2** scan frontmatter + title                         | M    | high  | ⬜     | Decision 6                                                                   |
-| 6     | **G2-T3** correct IMPORT.md flag/reindex claims            | S    | high  | ⬜     | after G2-T1                                                                  |
-| 7     | **G1-T1** engage-ready auth + extend boot fail-safe + docs | S    | crit  | ⬜     | adapted: no default flip                                                     |
-| 8     | **G3-T3** lifecycle writes → version CAS + audit           | M    | crit  | ⬜     | shared CAS helper + ToolCallContext                                          |
-| 9     | **G4-T2** enforce/observe optimistic concurrency on update | M    | high  | ⬜     | conservative = reject blind; shares actor seam                               |
-| 10    | **G1-T2** per-agent key provisioning + docs                | M    | high  | ⬜     | after G1-T1; owns actor-signature shape                                      |
-| 11    | **G1-T3** import path allowlist/traversal guard (A18)      | S    | high  | ⬜     | Decision 5 ownership (assign to G1)                                          |
-| 12    | **G3-T4** both-kept-flagged contradiction policy           | M    | high  | ⬜     | conservative default = flag                                                  |
-| 13    | **G4-T3** import-vs-agent-edit concurrency policy          | M    | high  | ⬜     | after G4-T1; maybe new migration                                             |
-| 14    | **G3-T6** stronger contradiction detection                 | M    | high  | ⬜     | after G3-T4; Decision 11 (LLM?)                                              |
-| 15    | **G4-T4** STM atomic Lua CAS                               | M    | high  | ⬜     | Decision 14 (optional)                                                       |
-| 16    | **G3-T2** periodic corpus consolidation (dry-run gated)    | L    | crit  | ⬜     | LAST; after G3-T1+G3-T4                                                      |
+| Order | Task                                                       | Size | Level | Status | Commit / note                                                                                                                                                                               |
+| ----- | ---------------------------------------------------------- | ---- | ----- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | **G3-T1** recall drops/flags superseded                    | S    | crit  | ✅     | default-exclude in semanticSearch + transient path; keys on supersededBy                                                                                                                    |
+| 2     | **G3-T5** validate+document lifecycle config               | S    | high  | ✅     | 9 MEMORY\_\* vars in env.schema (boot-validated) + .env.example + docs table                                                                                                                |
+| 3     | **G4-T1** concurrency policy ADR (doc)                     | S    | high  | ✅     | docs/concurrency-policy.md + GAPS.md G4 status; pins Dec 12/13/14                                                                                                                           |
+| 4     | **G2-T1** enforce `embeddingExcluded` (create+reindex)     | M    | high  | ✅     | create+reindex honor the flag; `flag` now redacts (Dec 3). Spy-count tests                                                                                                                  |
+| 5     | **G2-T2** scan frontmatter + title                         | M    | high  | ✅     | B2: redact-in-place incl. nested values; flag = redact+exclude+tag. Residual (new, out of scope): adapter-derived tags/link locators computed pre-scan could echo a frontmatter secret slug |
+| 6     | **G2-T3** correct IMPORT.md flag/reindex claims            | S    | high  | ✅     | B2: policy table matches enforced behavior; --no-embed workaround dropped                                                                                                                   |
+| 7     | **G1-T1** engage-ready auth + extend boot fail-safe + docs | S    | crit  | ✅     | B2: fail-safe now every NODE_ENV; ALLOW_UNAUTHENTICATED_HTTP boot-validated; ⚠ local unit needs the ack before restart (WRAPUP-PLAN §H3)                                                    |
+| 8     | **G3-T3** lifecycle writes → version CAS + audit           | M    | crit  | ⬜     | shared CAS helper + ToolCallContext                                                                                                                                                         |
+| 9     | **G4-T2** enforce/observe optimistic concurrency on update | M    | high  | ⬜     | conservative = reject blind; shares actor seam                                                                                                                                              |
+| 10    | **G1-T2** per-agent key provisioning + docs                | M    | high  | ⬜     | after G1-T1; owns actor-signature shape                                                                                                                                                     |
+| 11    | **G1-T3** import path allowlist/traversal guard (A18)      | S    | high  | ✅     | B2: IMPORT_ALLOWED_ROOT (default $HOME), realpath containment, dryRun too                                                                                                                   |
+| 12    | **G3-T4** both-kept-flagged contradiction policy           | M    | high  | ⬜     | conservative default = flag                                                                                                                                                                 |
+| 13    | **G4-T3** import-vs-agent-edit concurrency policy          | M    | high  | ⬜     | after G4-T1; maybe new migration                                                                                                                                                            |
+| 14    | **G3-T6** stronger contradiction detection                 | M    | high  | ⬜     | after G3-T4; Decision 11 (LLM?)                                                                                                                                                             |
+| 15    | **G4-T4** STM atomic Lua CAS                               | M    | high  | ⬜     | Decision 14 (optional)                                                                                                                                                                      |
+| 16    | **G3-T2** periodic corpus consolidation (dry-run gated)    | L    | crit  | ⬜     | LAST; after G3-T1+G3-T4                                                                                                                                                                     |
 
 ## Shared seams (must not fork — from plan §2.5)
 

--- a/docs/plans/2026-07-memory-platform/WRAPUP-PLAN.md
+++ b/docs/plans/2026-07-memory-platform/WRAPUP-PLAN.md
@@ -78,19 +78,19 @@ Any session (any model) resumes by reading §0 + §1 and picking the first non-�
 
 Legend: ✅ merged · 🟨 in progress · ⬜ not started.
 
-| Batch | Branch                       | Tasks                                      | Status | PR  |
-| ----- | ---------------------------- | ------------------------------------------ | ------ | --- |
-| B0    | `docs/wrapup-plan-2026-07`   | this plan + tracker updates                | 🟨     |     |
-| BH    | (no branch — local ops)      | §H housekeeping items                      | ⬜     |     |
-| B2    | `feat/gaps-g1-g4-b2`         | G2-T2, G2-T3, G1-T3, G1-T1                 | ⬜     |     |
-| B3    | `feat/gaps-g1-g4-b3`         | G3-T3, G4-T2, G1-T2                        | ⬜     |     |
-| B4    | `feat/gaps-g1-g4-b4`         | G3-T4, G3-T6, G4-T3, G4-T4 deferral note   | ⬜     |     |
-| B5    | `feat/gaps-g1-g4-b5`         | G3-T2 (corpus consolidation, L)            | ⬜     |     |
-| B6    | `feat/wp6-docs-content-1`    | WP6 T7a, T7b, T8, T13                      | ⬜     |     |
-| B7    | `feat/wp6-docs-content-2`    | WP6 T9, T10, T11, T12, T14                 | ⬜     |     |
-| B8    | `fix/wp1-marketing-b8`       | R2, R3, R7, R5, R6, R13, R4, R11, R1-CNAME | ⬜     |     |
-| B9    | `fix/wp1-marketing-b9`       | R8, R12, R10 (best-effort)                 | ⬜     |     |
-| BOps  | (no branch — GitHub/DNS ops) | R1/R9 Pages TLS + HTTPS enforce            | ⬜     |     |
+| Batch | Branch                       | Tasks                                      | Status                      | PR   |
+| ----- | ---------------------------- | ------------------------------------------ | --------------------------- | ---- |
+| B0    | `docs/wrapup-plan-2026-07`   | this plan + tracker updates                | ✅                          | #256 |
+| BH    | (no branch — local ops)      | §H housekeeping items                      | 🟨 1–2 done; 3–5 post-merge |      |
+| B2    | `feat/gaps-g1-g4-b2`         | G2-T2, G2-T3, G1-T3, G1-T1                 | ✅                          | #257 |
+| B3    | `feat/gaps-g1-g4-b3`         | G3-T3, G4-T2, G1-T2                        | ⬜                          |      |
+| B4    | `feat/gaps-g1-g4-b4`         | G3-T4, G3-T6, G4-T3, G4-T4 deferral note   | ⬜                          |      |
+| B5    | `feat/gaps-g1-g4-b5`         | G3-T2 (corpus consolidation, L)            | ⬜                          |      |
+| B6    | `feat/wp6-docs-content-1`    | WP6 T7a, T7b, T8, T13                      | ⬜                          |      |
+| B7    | `feat/wp6-docs-content-2`    | WP6 T9, T10, T11, T12, T14                 | ⬜                          |      |
+| B8    | `fix/wp1-marketing-b8`       | R2, R3, R7, R5, R6, R13, R4, R11, R1-CNAME | ⬜                          |      |
+| B9    | `fix/wp1-marketing-b9`       | R8, R12, R10 (best-effort)                 | ⬜                          |      |
+| BOps  | (no branch — GitHub/DNS ops) | R1/R9 Pages TLS + HTTPS enforce            | ⬜                          |      |
 
 ## 2. Batch details — G1–G4 (B2–B5)
 

--- a/docs/security/agent-keys.md
+++ b/docs/security/agent-keys.md
@@ -20,6 +20,12 @@ The mitigation is non-negotiable for a multi-agent host:
 - **One least-privilege API key per agent** (below).
 - **Loopback bind** (`127.0.0.1`) so the port is not exposed off-host.
 
+The server enforces this posture at boot: a multi-tenant streamable-http
+server without `AUTH_REQUIRED=true` refuses to start in **every** `NODE_ENV`
+unless the operator explicitly sets `ALLOW_UNAUTHENTICATED_HTTP=true` — the
+trusted-network acknowledgement for a deliberately open deployment (e.g. a
+loopback-bound single-operator host).
+
 With auth on, the server **injects the key's `userId`** over any client-supplied
 `userId` for identity tools — the tenant is the token, not the body — and
 enforces per-key **scopes** (`memories:read`, `memories:write`,

--- a/packages/config/src/env.schema.spec.ts
+++ b/packages/config/src/env.schema.spec.ts
@@ -38,6 +38,7 @@ describe('envSchema', () => {
         MEMORY_IMPORTANCE_HALF_LIFE_DAYS: 14,
         JWT_EXPIRES_IN: '7d',
         AUTH_REQUIRED: false,
+        ALLOW_UNAUTHENTICATED_HTTP: false,
         RATE_LIMIT_ENABLED: false,
         RATE_LIMIT_WINDOW_SEC: 60,
         RATE_LIMIT_USER_RPM: 120,

--- a/packages/config/src/env.schema.spec.ts
+++ b/packages/config/src/env.schema.spec.ts
@@ -384,6 +384,40 @@ describe('envSchema', () => {
     });
   });
 
+  describe('import path allowlist (IMPORT_ALLOWED_ROOT, A18)', () => {
+    const base = {
+      DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+      REDIS_URL: 'redis://localhost:6379',
+      QDRANT_URL: 'http://localhost:6333',
+    };
+
+    it('is optional and stays undefined when unset (runtime falls back to the home dir)', () => {
+      const result = envSchema.parse(base);
+      expect(result.IMPORT_ALLOWED_ROOT).toBeUndefined();
+    });
+
+    it('accepts an absolute POSIX path', () => {
+      const result = envSchema.parse({ ...base, IMPORT_ALLOWED_ROOT: '/srv/engram/imports' });
+      expect(result.IMPORT_ALLOWED_ROOT).toBe('/srv/engram/imports');
+    });
+
+    it('accepts an absolute Windows drive path', () => {
+      const result = envSchema.parse({ ...base, IMPORT_ALLOWED_ROOT: 'C:\\engram\\imports' });
+      expect(result.IMPORT_ALLOWED_ROOT).toBe('C:\\engram\\imports');
+    });
+
+    it('rejects a relative path', () => {
+      expect(() => envSchema.parse({ ...base, IMPORT_ALLOWED_ROOT: 'imports' })).toThrow(ZodError);
+      expect(() => envSchema.parse({ ...base, IMPORT_ALLOWED_ROOT: './imports' })).toThrow(
+        ZodError
+      );
+    });
+
+    it('rejects an empty string', () => {
+      expect(() => envSchema.parse({ ...base, IMPORT_ALLOWED_ROOT: '' })).toThrow(ZodError);
+    });
+  });
+
   describe('validateEnv', () => {
     it('should validate valid configuration', () => {
       const config = {

--- a/packages/config/src/env.schema.ts
+++ b/packages/config/src/env.schema.ts
@@ -130,6 +130,8 @@ export const baseSchema = z.object({
    * enforced over the streamable-http transport.
    */
   AUTH_REQUIRED: booleanFlag(false),
+  /** Explicit operator acknowledgement to run a multi-tenant streamable-http server WITHOUT auth (trusted-network posture). Without it such a server refuses to boot in every NODE_ENV. */
+  ALLOW_UNAUTHENTICATED_HTTP: booleanFlag(false),
   /** Base URL used to build OAuth callback URLs, e.g. `https://api.example.com`. */
   OAUTH_REDIRECT_BASE_URL: z.string().url().optional(),
   /** GitHub OAuth app credentials. Both must be set to enable GitHub login. */
@@ -353,6 +355,7 @@ export type Env = {
   JWT_SECRET?: string;
   JWT_EXPIRES_IN: string;
   AUTH_REQUIRED: boolean;
+  ALLOW_UNAUTHENTICATED_HTTP: boolean;
   OAUTH_REDIRECT_BASE_URL?: string;
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;

--- a/packages/config/src/env.schema.ts
+++ b/packages/config/src/env.schema.ts
@@ -91,6 +91,8 @@ export const baseSchema = z.object({
   MEMORY_CONTRADICTION_THRESHOLD_MAX: z.coerce.number().min(0).max(1).optional().default(0.97),
   /** Half-life in days for the recency component of importance scoring. Defaults to 14. */
   MEMORY_IMPORTANCE_HALF_LIFE_DAYS: z.coerce.number().positive().optional().default(14),
+  /** Absolute directory the `import_agent_memory` server-side path must resolve into (symlinks resolved). Defaults to the server process home directory when unset. */
+  IMPORT_ALLOWED_ROOT: z.string().min(1).optional(),
   /** Optional pgvector HNSW build-time `m` (max connections per layer). */
   PGVECTOR_HNSW_M: z.coerce.number().int().min(2).max(100).optional(),
   /** Optional pgvector HNSW build-time `ef_construction` (candidate list size). */
@@ -247,6 +249,20 @@ export const envSchema: z.ZodType<Env> = baseSchema.transform((value, ctx) => {
     }
   }
 
+  // A relative import root would silently depend on the process CWD, making
+  // the import path allowlist (A18) unpredictable — reject it at boot.
+  if (
+    typeof value.IMPORT_ALLOWED_ROOT === 'string' &&
+    !isAbsolutePathLike(value.IMPORT_ALLOWED_ROOT)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['IMPORT_ALLOWED_ROOT'],
+      message: 'IMPORT_ALLOWED_ROOT must be an absolute filesystem path',
+    });
+    return z.NEVER;
+  }
+
   // When auth enforcement is on, a real JWT secret is mandatory.
   if (value.AUTH_REQUIRED) {
     if (typeof value.JWT_SECRET !== 'string' || value.JWT_SECRET.length < 32) {
@@ -290,6 +306,12 @@ function isValidToolOverrides(raw: string): boolean {
   });
 }
 
+function isAbsolutePathLike(value: string): boolean {
+  // POSIX absolute (`/…`), Windows drive (`C:\…` / `C:/…`), or UNC (`\\…`).
+  // A regex keeps this package free of `node:path` (no `@types/node` here).
+  return /^(\/|[A-Za-z]:[\\/]|\\\\)/.test(value);
+}
+
 function isLikelyUrl(value: string): boolean {
   // Permissive URL check that matches `z.string().url()` without requiring
   // the `URL` constructor (which needs `@types/node`). We only need to
@@ -324,6 +346,7 @@ export type Env = {
   MEMORY_CONTRADICTION_THRESHOLD: number;
   MEMORY_CONTRADICTION_THRESHOLD_MAX: number;
   MEMORY_IMPORTANCE_HALF_LIFE_DAYS: number;
+  IMPORT_ALLOWED_ROOT?: string;
   PGVECTOR_HNSW_M?: number;
   PGVECTOR_HNSW_EF_CONSTRUCTION?: number;
   PGVECTOR_HNSW_EF_SEARCH?: number;

--- a/packages/memory-import/src/adapters/__fixtures__/copilot-secrets/.github/instructions/deploy.instructions.md
+++ b/packages/memory-import/src/adapters/__fixtures__/copilot-secrets/.github/instructions/deploy.instructions.md
@@ -1,0 +1,7 @@
+---
+description: Deploy rotation notes
+name: rotate ghp_1234567890abcdefghijklmnopqrstuvwxyzAB monthly
+applyTo: deploy/**
+---
+
+Rotate the deploy token monthly and record the rotation date in the runbook.

--- a/packages/memory-import/src/adapters/__fixtures__/cursor-secrets/.cursor/rules/deploy.mdc
+++ b/packages/memory-import/src/adapters/__fixtures__/cursor-secrets/.cursor/rules/deploy.mdc
@@ -1,0 +1,11 @@
+---
+description: Deploy uses key AKIAIOSFODNN7EXAMPLE for the registry
+globs:
+  - "deploy/**"
+alwaysApply: false
+retries: 3
+---
+
+# Deploy rules
+
+Run the deploy checklist and verify the health endpoint before shipping.

--- a/packages/memory-import/src/index.ts
+++ b/packages/memory-import/src/index.ts
@@ -58,8 +58,12 @@ export {
   SecretScanner,
   ImportSecretPolicyError,
   type SecretPolicy,
+  type SecretField,
   type SecretMatch,
   type ScanResult,
+  type FrontmatterScanResult,
+  type SecretScanTarget,
+  type SecretPolicyResult,
 } from './secrets/secret-scanner.js';
 
 // ── Embedding cost estimator (T14) ──────────────────────────────────────────

--- a/packages/memory-import/src/ir/types.ts
+++ b/packages/memory-import/src/ir/types.ts
@@ -70,7 +70,11 @@ export interface ImportedFact {
   title?: string;
   content: string;
   tags: string[];
-  /** Preserved verbatim (sanitized) source frontmatter, when present. */
+  /**
+   * Source frontmatter as parsed (shape preserved). Adapters do NOT sanitize
+   * it — the pipeline's secret scan (`scanFacts`) redacts string values under
+   * the import secret policy before anything is persisted.
+   */
   frontmatter?: Record<string, unknown>;
   links: ImportedLink[];
 }

--- a/packages/memory-import/src/memory-import.secrets.spec.ts
+++ b/packages/memory-import/src/memory-import.secrets.spec.ts
@@ -1,0 +1,150 @@
+// Wiring-level G2-T2 acceptance: full imports over real adapters + fixtures
+// whose secrets live ONLY in YAML frontmatter (and the title derived from it)
+// — the fact bodies are clean. Proves the persisted metadata (buildMetadata's
+// `frontmatter` + `title`) never carries a raw secret under any policy.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { MemoryImportService, type ImportRunInput } from './memory-import.service.js';
+import { ImportSecretPolicyError, SecretScanner } from './secrets/secret-scanner.js';
+import { buildAdapterRegistry } from './adapters/registry.js';
+
+const CURSOR_ROOT = fileURLToPath(
+  new URL('./adapters/__fixtures__/cursor-secrets', import.meta.url)
+);
+const COPILOT_ROOT = fileURLToPath(
+  new URL('./adapters/__fixtures__/copilot-secrets', import.meta.url)
+);
+
+/** Raw secrets planted in the fixtures — must never appear in a persisted row. */
+const AWS_SECRET = 'AKIAIOSFODNN7EXAMPLE';
+const GH_SECRET = 'ghp_1234567890abcdefghijklmnopqrstuvwxyzAB';
+
+function makeLedger() {
+  return {
+    find: vi.fn(async () => null),
+    findByContentHash: vi.fn(async () => [] as unknown[]),
+    upsert: vi.fn(async (e: Record<string, unknown>) => ({ ...e })),
+  };
+}
+
+function makeLtm() {
+  let n = 0;
+  return {
+    create: vi.fn(async (input: { content: string }) => ({
+      id: `mem-${++n}`,
+      content: input.content,
+      metadata: {},
+    })),
+    update: vi.fn(async (_u: string, id: string) => ({ id, content: '', metadata: {} })),
+  };
+}
+
+function makeResolver() {
+  return {
+    resolveBatch: vi.fn(async () => ({ resolved: 0, deferred: 0, total: 0 })),
+    resolveDeferred: vi.fn(async () => 0),
+  };
+}
+
+type CreateArg = { content: string; tags: string[]; metadata: Record<string, unknown> };
+
+describe('import wiring — secrets in fixture frontmatter/title (G2-T2)', () => {
+  let ltm: ReturnType<typeof makeLtm>;
+  let ledger: ReturnType<typeof makeLedger>;
+  let resolver: ReturnType<typeof makeResolver>;
+  let service: MemoryImportService;
+
+  beforeEach(() => {
+    ltm = makeLtm();
+    ledger = makeLedger();
+    resolver = makeResolver();
+    service = new MemoryImportService(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ltm as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ledger as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      resolver as any,
+      new SecretScanner(),
+      buildAdapterRegistry()
+    );
+  });
+
+  function createdArg(index = 0): CreateArg {
+    return ltm.create.mock.calls[index]?.[0] as unknown as CreateArg;
+  }
+
+  const cursorInput: ImportRunInput = { source: 'cursor', path: CURSOR_ROOT, userId: 'qp' };
+  const copilotInput: ImportRunInput = { source: 'copilot', path: COPILOT_ROOT, userId: 'qp' };
+
+  it('cursor .mdc, redact: stored frontmatter is redacted in place, shape intact', async () => {
+    const summary = await service.run(cursorInput); // default policy: redact
+    expect(summary.created).toBe(1);
+
+    const created = createdArg();
+    expect(JSON.stringify(created)).not.toContain(AWS_SECRET);
+    expect(created.metadata['frontmatter']).toEqual({
+      description: 'Deploy uses key [REDACTED] for the registry',
+      globs: ['deploy/**'],
+      alwaysApply: false,
+      retries: 3,
+    });
+    expect(summary.secrets).toEqual([{ path: '.cursor/rules/deploy.mdc', patterns: ['aws-key'] }]);
+  });
+
+  it('copilot .instructions.md, redact: stored title + frontmatter carry no raw secret', async () => {
+    const summary = await service.run(copilotInput);
+    expect(summary.created).toBe(1);
+
+    const created = createdArg();
+    expect(JSON.stringify(created)).not.toContain(GH_SECRET);
+    expect(created.metadata['title']).toBe('rotate [REDACTED] monthly');
+    expect(created.metadata['frontmatter']).toEqual({
+      description: 'Deploy rotation notes',
+      name: 'rotate [REDACTED] monthly',
+      applyTo: 'deploy/**',
+    });
+    expect(summary.secrets).toEqual([
+      {
+        path: '.github/instructions/deploy.instructions.md',
+        patterns: ['github-token'],
+      },
+    ]);
+  });
+
+  it('flag: frontmatter-only hit embedding-excludes the row and tags has-secret', async () => {
+    await service.run({ ...cursorInput, secretsPolicy: 'flag' });
+    const created = createdArg();
+    expect(JSON.stringify(created)).not.toContain(AWS_SECRET);
+    expect(created.metadata['embeddingExcluded']).toBe(true);
+    expect(created.tags).toContain('has-secret');
+  });
+
+  it('skip: a frontmatter-only hit drops the whole fact', async () => {
+    const summary = await service.run({ ...copilotInput, secretsPolicy: 'skip' });
+    expect(summary.secretsSkipped).toBe(1);
+    expect(summary.created).toBe(0);
+    expect(ltm.create).not.toHaveBeenCalled();
+    expect(ledger.upsert).not.toHaveBeenCalled();
+  });
+
+  it('fail: a frontmatter hit aborts the import, naming the surface', async () => {
+    const promise = service.run({ ...cursorInput, secretsPolicy: 'fail' });
+    await expect(promise).rejects.toBeInstanceOf(ImportSecretPolicyError);
+    await expect(promise).rejects.toThrow(/in frontmatter/);
+    expect(ltm.create).not.toHaveBeenCalled();
+  });
+
+  it('dry run reports identically to the real run and writes nothing', async () => {
+    const dry = await service.run({ ...copilotInput, dryRun: true, secretsPolicy: 'skip' });
+    expect(ltm.create).not.toHaveBeenCalled();
+    expect(ledger.upsert).not.toHaveBeenCalled();
+
+    const real = await service.run({ ...copilotInput, secretsPolicy: 'skip' });
+    expect(dry.parsed).toBe(real.parsed);
+    expect(dry.secretsSkipped).toBe(real.secretsSkipped);
+    expect(dry.secrets).toEqual(real.secrets);
+    expect(dry.embeddingCostEstimate).toEqual(real.embeddingCostEstimate);
+  });
+});

--- a/packages/memory-import/src/memory-import.service.spec.ts
+++ b/packages/memory-import/src/memory-import.service.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { LtmMemoryQuotaExceededError } from '@engram/memory-ltm';
 import { MemoryImportService, type ImportRunInput } from './memory-import.service.js';
-import { SecretScanner } from './secrets/secret-scanner.js';
+import { ImportSecretPolicyError, SecretScanner } from './secrets/secret-scanner.js';
 import { computeContentHash } from './content-hash.js';
 import type { ImportIR, ImportedFact } from './ir/types.js';
 import type { SourceAdapter } from './ir/source-adapter.interface.js';
@@ -257,5 +257,95 @@ describe('MemoryImportService.run', () => {
   it('unknown source: throws a clear error', async () => {
     const svc = build(makeIR([]), makeLedger(), ltm, resolver);
     await expect(svc.run({ ...baseInput, source: 'codex' })).rejects.toThrow(/No import adapter/);
+  });
+
+  describe('frontmatter/title secrets (G2-T2)', () => {
+    const dirtyFrontmatter = () => ({
+      description: 'token ghp_1234567890abcdefghijklmnopqrstuvwxyzAB here',
+      nested: { hosts: ['10.0.0.5', 'example.com'], port: 5432 },
+      alwaysApply: true,
+    });
+
+    function dirtyIR() {
+      return makeIR([
+        fact({
+          sourceKey: 'markdown:leaky.md',
+          content: 'clean body about deploys',
+          title: 'rotate AKIAIOSFODNN7EXAMPLE monthly',
+          frontmatter: dirtyFrontmatter(),
+        }),
+      ]);
+    }
+
+    function createdArg(index = 0) {
+      return ltm.create.mock.calls[index]?.[0] as unknown as {
+        content: string;
+        metadata?: Record<string, unknown>;
+        tags?: string[];
+      };
+    }
+
+    it('redact: stores sanitized title + frontmatter, structure and non-strings intact', async () => {
+      const summary = await build(dirtyIR(), makeLedger(), ltm, resolver).run(baseInput);
+      const created = createdArg();
+      expect(JSON.stringify(created)).not.toMatch(
+        /ghp_1234567890|AKIAIOSFODNN7EXAMPLE|10\.0\.0\.5/
+      );
+      expect(created.metadata?.['title']).toBe('rotate [REDACTED] monthly');
+      expect(created.metadata?.['frontmatter']).toEqual({
+        description: 'token [REDACTED] here',
+        nested: { hosts: ['[REDACTED]', 'example.com'], port: 5432 },
+        alwaysApply: true,
+      });
+      expect(summary.secrets).toEqual([
+        { path: 'leaky.md', patterns: expect.arrayContaining(['aws-key', 'github-token']) },
+      ]);
+    });
+
+    it('flag: a frontmatter-only hit redacts, embedding-excludes, and tags has-secret', async () => {
+      const ir = makeIR([
+        fact({
+          sourceKey: 'markdown:fm-only.md',
+          content: 'clean body',
+          frontmatter: { description: 'DB_PASSWORD=s3cr3tvalue' },
+        }),
+      ]);
+      await build(ir, makeLedger(), ltm, resolver).run({ ...baseInput, secretsPolicy: 'flag' });
+      const created = createdArg();
+      expect(created.content).toBe('clean body');
+      expect(created.metadata?.['embeddingExcluded']).toBe(true);
+      expect(created.tags).toContain('has-secret');
+      expect(JSON.stringify(created.metadata?.['frontmatter'])).not.toContain('s3cr3tvalue');
+    });
+
+    it('skip: a title-only hit drops the whole fact', async () => {
+      const ir = makeIR([
+        fact({ sourceKey: 'markdown:t.md', content: 'clean body', title: 'ssn 123-45-6789' }),
+      ]);
+      const summary = await build(ir, makeLedger(), ltm, resolver).run({
+        ...baseInput,
+        secretsPolicy: 'skip',
+      });
+      expect(summary.secretsSkipped).toBe(1);
+      expect(ltm.create).not.toHaveBeenCalled();
+    });
+
+    it('fail: a frontmatter hit aborts, naming the surface', async () => {
+      const svc = build(dirtyIR(), makeLedger(), ltm, resolver);
+      const promise = svc.run({ ...baseInput, secretsPolicy: 'fail' });
+      await expect(promise).rejects.toBeInstanceOf(ImportSecretPolicyError);
+      await expect(promise).rejects.toThrow(/in title, frontmatter/);
+      expect(ltm.create).not.toHaveBeenCalled();
+    });
+
+    it('dry run reports frontmatter/title hits identically to a real run', async () => {
+      const svc = build(dirtyIR(), makeLedger(), ltm, resolver);
+      const dry = await svc.run({ ...baseInput, dryRun: true, secretsPolicy: 'skip' });
+      expect(ltm.create).not.toHaveBeenCalled();
+      const real = await svc.run({ ...baseInput, secretsPolicy: 'skip' });
+      expect(dry.secretsSkipped).toBe(real.secretsSkipped);
+      expect(dry.secrets).toEqual(real.secrets);
+      expect(dry.embeddingCostEstimate).toEqual(real.embeddingCostEstimate);
+    });
   });
 });

--- a/packages/memory-import/src/memory-import.service.ts
+++ b/packages/memory-import/src/memory-import.service.ts
@@ -142,7 +142,7 @@ export class MemoryImportService {
             links: entry.fact.links,
           };
           if (entry.fact.anchor !== undefined) rf.anchor = entry.fact.anchor;
-          if (entry.fact.frontmatter !== undefined) rf.frontmatter = entry.fact.frontmatter;
+          if (entry.frontmatter !== undefined) rf.frontmatter = entry.frontmatter;
           resolverFacts.push(rf);
         }
       } catch (err) {
@@ -181,7 +181,7 @@ export class MemoryImportService {
     importedAt: string,
     summary: ImportSummary
   ): Promise<string | null> {
-    const { fact, content, embeddingExcluded, extraTags } = entry;
+    const { fact, content, extraTags } = entry;
     const userId = summary.userId;
     const contentHash = computeContentHash(content);
     const existing = await this.ledger.find(userId, fact.sourceKey);
@@ -201,15 +201,7 @@ export class MemoryImportService {
     let memoryId: string;
     if (existing) {
       // Ledger hit, hash changed → update the mapped memory (re-embeds, merges meta).
-      const meta = this.buildMetadata(
-        fact,
-        importBatchId,
-        importedAt,
-        ir,
-        contentHash,
-        embeddingExcluded,
-        [source]
-      );
+      const meta = this.buildMetadata(entry, importBatchId, importedAt, ir, contentHash, [source]);
       const updated = await this.ltm.update(
         userId,
         existing.memoryId,
@@ -228,15 +220,7 @@ export class MemoryImportService {
         scope,
         content,
         tags,
-        metadata: this.buildMetadata(
-          fact,
-          importBatchId,
-          importedAt,
-          ir,
-          contentHash,
-          embeddingExcluded,
-          [source]
-        ),
+        metadata: this.buildMetadata(entry, importBatchId, importedAt, ir, contentHash, [source]),
       });
       memoryId = created.id;
       if (priorSameContent.length > 0) {
@@ -283,14 +267,14 @@ export class MemoryImportService {
   }
 
   private buildMetadata(
-    fact: ImportedFact,
+    entry: ScannedFact,
     importBatchId: string,
     importedAt: string,
     ir: ImportIR,
     contentHash: string,
-    embeddingExcluded: boolean,
     sources: ProvenanceSource[]
   ): Record<string, unknown> {
+    const { fact } = entry;
     const metadata: Record<string, unknown> = {
       provenance: {
         sourceTool: ir.sourceTool,
@@ -303,9 +287,11 @@ export class MemoryImportService {
         sources,
       },
     };
-    if (fact.frontmatter !== undefined) metadata['frontmatter'] = fact.frontmatter;
-    if (fact.title !== undefined) metadata['title'] = fact.title;
-    if (embeddingExcluded) metadata['embeddingExcluded'] = true;
+    // Persist the SANITIZED title/frontmatter from the secret scan (G2-T2) —
+    // never fact.title / fact.frontmatter verbatim.
+    if (entry.frontmatter !== undefined) metadata['frontmatter'] = entry.frontmatter;
+    if (entry.title !== undefined) metadata['title'] = entry.title;
+    if (entry.embeddingExcluded) metadata['embeddingExcluded'] = true;
     return metadata;
   }
 
@@ -341,8 +327,14 @@ export class MemoryImportService {
     const out: ScannedFact[] = [];
     for (const fact of ir.facts) {
       // `fail` throws ImportSecretPolicyError up to run()'s caller (aborts).
+      // Title + frontmatter are scanned under the same policy as content (G2-T2).
       const result = this.secrets.apply(
-        { content: fact.content, sourcePath: fact.sourcePath },
+        {
+          content: fact.content,
+          sourcePath: fact.sourcePath,
+          ...(fact.title !== undefined ? { title: fact.title } : {}),
+          ...(fact.frontmatter !== undefined ? { frontmatter: fact.frontmatter } : {}),
+        },
         policy
       );
       if (result.matches.length > 0) {
@@ -354,6 +346,8 @@ export class MemoryImportService {
       out.push({
         fact,
         content: result.content,
+        ...(result.title !== undefined ? { title: result.title } : {}),
+        ...(result.frontmatter !== undefined ? { frontmatter: result.frontmatter } : {}),
         skip: result.action === 'skipped',
         embeddingExcluded: result.embeddingExcluded,
         extraTags: result.extraTags,
@@ -444,7 +438,10 @@ export class MemoryImportService {
 
 interface ScannedFact {
   fact: ImportedFact;
+  /** Sanitized surfaces from the secret scan — persist these, never `fact.*`. */
   content: string;
+  title?: string;
+  frontmatter?: Record<string, unknown>;
   skip: boolean;
   embeddingExcluded: boolean;
   extraTags: string[];

--- a/packages/memory-import/src/secrets/secret-scanner.spec.ts
+++ b/packages/memory-import/src/secrets/secret-scanner.spec.ts
@@ -191,3 +191,116 @@ describe('SecretScanner.apply — policy modes', () => {
     }
   });
 });
+
+describe('SecretScanner.scanFrontmatter', () => {
+  it('redacts string leaves in place, recursing into nested objects and arrays', () => {
+    const result = scanner.scanFrontmatter({
+      description: 'uses key AKIAIOSFODNN7EXAMPLE for deploys',
+      nested: { hosts: ['10.0.0.5', 'example.com'], note: 'clean' },
+    });
+    expect(result.hasSecret).toBe(true);
+    expect(patternNames(result.matches)).toEqual(
+      expect.arrayContaining(['aws-key', 'private-ipv4'])
+    );
+    expect(result.redacted).toEqual({
+      description: 'uses key [REDACTED] for deploys',
+      nested: { hosts: ['[REDACTED]', 'example.com'], note: 'clean' },
+    });
+  });
+
+  it('leaves non-string leaves (numbers, booleans, null) untouched', () => {
+    const result = scanner.scanFrontmatter({
+      password: 'password: hunter2secret',
+      alwaysApply: true,
+      retries: 3,
+      globs: null,
+    });
+    expect(result.redacted['alwaysApply']).toBe(true);
+    expect(result.redacted['retries']).toBe(3);
+    expect(result.redacted['globs']).toBeNull();
+    expect(result.redacted['password']).toContain('[REDACTED]');
+  });
+
+  it('aggregates match counts across leaves', () => {
+    const result = scanner.scanFrontmatter({ a: 'ip 10.0.0.1', b: { c: 'ip 10.0.0.2' } });
+    const ip = result.matches.find((m) => m.pattern === 'private-ipv4');
+    expect(ip?.count).toBe(2);
+  });
+
+  it('returns hasSecret false and an equal map for clean frontmatter', () => {
+    const clean = { description: 'ordinary rules', globs: ['src/**'], alwaysApply: false };
+    const result = scanner.scanFrontmatter(clean);
+    expect(result.hasSecret).toBe(false);
+    expect(result.matches).toEqual([]);
+    expect(result.redacted).toEqual(clean);
+  });
+});
+
+describe('SecretScanner.apply — title + frontmatter surfaces (G2-T2)', () => {
+  const dirty = {
+    content: 'body with no secrets at all',
+    sourcePath: 'rules/deploy.mdc',
+    title: 'rotate AKIAIOSFODNN7EXAMPLE monthly',
+    frontmatter: { description: 'server 10.0.0.5', nested: { port: 5432 } },
+  };
+
+  it('redact: sanitizes title and frontmatter in place, content untouched', () => {
+    const out = scanner.apply(dirty, 'redact');
+    expect(out.action).toBe('redacted');
+    expect(out.content).toBe(dirty.content);
+    expect(out.title).toBe('rotate [REDACTED] monthly');
+    expect(out.frontmatter).toEqual({
+      description: 'server [REDACTED]',
+      nested: { port: 5432 },
+    });
+    expect(patternNames(out.matches)).toEqual(expect.arrayContaining(['aws-key', 'private-ipv4']));
+  });
+
+  it('flag: a frontmatter-only hit redacts AND excludes embedding + tags has-secret', () => {
+    const out = scanner.apply(
+      {
+        content: 'clean body',
+        sourcePath: 'rules/a.mdc',
+        frontmatter: { description: 'DB_PASSWORD=s3cr3tvalue' },
+      },
+      'flag'
+    );
+    expect(out.action).toBe('flagged');
+    expect(out.embeddingExcluded).toBe(true);
+    expect(out.extraTags).toEqual(['has-secret']);
+    expect(out.frontmatter?.['description']).toBe('[REDACTED]');
+  });
+
+  it('skip: a title-only hit marks the fact skipped', () => {
+    const out = scanner.apply(
+      { content: 'clean body', sourcePath: 'rules/a.mdc', title: 'ssn 123-45-6789' },
+      'skip'
+    );
+    expect(out.action).toBe('skipped');
+    expect(out.matches.length).toBeGreaterThan(0);
+  });
+
+  it('fail: names the matching surfaces in the error', () => {
+    let error: unknown;
+    try {
+      scanner.apply(dirty, 'fail');
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ImportSecretPolicyError);
+    const typed = error as ImportSecretPolicyError;
+    expect(typed.fields).toEqual(['title', 'frontmatter']);
+    expect(typed.message).toMatch(/in title, frontmatter/);
+  });
+
+  it('kept: clean title + frontmatter pass through as the same values', () => {
+    const frontmatter = { description: 'ordinary rules', alwaysApply: true };
+    const out = scanner.apply(
+      { content: 'clean body', sourcePath: 'rules/a.mdc', title: 'ordinary title', frontmatter },
+      'redact'
+    );
+    expect(out.action).toBe('kept');
+    expect(out.title).toBe('ordinary title');
+    expect(out.frontmatter).toBe(frontmatter);
+  });
+});

--- a/packages/memory-import/src/secrets/secret-scanner.ts
+++ b/packages/memory-import/src/secrets/secret-scanner.ts
@@ -3,8 +3,9 @@ import { Injectable } from '@nestjs/common';
 const REDACTED = '[REDACTED]';
 
 /**
- * Policy applied when a fact's content matches one or more secret / PII
- * patterns during import.
+ * Policy applied when any of a fact's scannable surfaces — content, title, or
+ * frontmatter string values — matches one or more secret / PII patterns during
+ * import (G2-T2: all surfaces are scanned under the same policy).
  *
  * - `redact` — replace every match with `[REDACTED]`; the (safe) content is
  *   still embedded and stored.
@@ -14,6 +15,9 @@ const REDACTED = '[REDACTED]';
  * - `fail`   — abort the import with {@link ImportSecretPolicyError}.
  */
 export type SecretPolicy = 'redact' | 'flag' | 'skip' | 'fail';
+
+/** Fact surface a secret was found in (reported by the `fail` policy error). */
+export type SecretField = 'content' | 'title' | 'frontmatter';
 
 export interface SecretMatch {
   pattern: string;
@@ -29,17 +33,46 @@ export interface ScanResult {
   hasSecret: boolean;
 }
 
+export interface FrontmatterScanResult {
+  /** Structure-preserving copy with every matched string span `[REDACTED]`. */
+  redacted: Record<string, unknown>;
+  matches: SecretMatch[];
+  hasSecret: boolean;
+}
+
+/** One fact's scannable surfaces, handed to {@link SecretScanner.apply}. */
+export interface SecretScanTarget {
+  content: string;
+  sourcePath: string;
+  title?: string;
+  frontmatter?: Record<string, unknown>;
+}
+
+export interface SecretPolicyResult {
+  action: 'kept' | 'redacted' | 'flagged' | 'skipped';
+  content: string;
+  /** Sanitized title — present iff the input carried one. */
+  title?: string;
+  /** Sanitized frontmatter — present iff the input carried one. */
+  frontmatter?: Record<string, unknown>;
+  matches: SecretMatch[];
+  embeddingExcluded: boolean;
+  extraTags: string[];
+}
+
 /**
  * Thrown by {@link SecretScanner.apply} under the `fail` policy when a fact
- * contains one or more secrets.
+ * contains one or more secrets. `fields` names the surface(s) that matched.
  */
 export class ImportSecretPolicyError extends Error {
   constructor(
     public readonly path: string,
-    public readonly patterns: string[]
+    public readonly patterns: string[],
+    public readonly fields: SecretField[] = ['content']
   ) {
     super(
-      `Import blocked by secret policy: ${path} matched secret pattern(s): ${patterns.join(', ')}`
+      `Import blocked by secret policy: ${path} matched secret pattern(s): ` +
+        `${patterns.join(', ')} (in ${fields.join(', ')})`
     );
     this.name = 'ImportSecretPolicyError';
   }
@@ -87,6 +120,22 @@ const PATTERNS: ReadonlyArray<readonly [string, RegExp]> = [
   ['internal-host', /\b[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.(?:internal|local|corp)\b/gi],
 ];
 
+/** Plain data map (not a Date/Map/class instance) — the only object kind the frontmatter scan recurses into. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false;
+  const proto: unknown = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/** Merge per-surface match lists, summing counts per pattern (first-seen order). */
+function mergeMatches(...lists: Array<SecretMatch[] | undefined>): SecretMatch[] {
+  const tally = new Map<string, number>();
+  for (const list of lists) {
+    for (const m of list ?? []) tally.set(m.pattern, (tally.get(m.pattern) ?? 0) + m.count);
+  }
+  return [...tally].map(([pattern, count]) => ({ pattern, count }));
+}
+
 /**
  * First-class scan stage for the import pipeline.  Runs before facts are
  * embedded so that no raw secret ever reaches an external embedding provider.
@@ -116,36 +165,71 @@ export class SecretScanner {
   }
 
   /**
-   * Apply a {@link SecretPolicy} to one fact-like object, returning the
-   * (possibly redacted) content plus the side-effects the caller must honour.
+   * Scan every string leaf of a frontmatter map, recursing into nested plain
+   * objects and arrays. Keys and non-string leaves (numbers, booleans, dates…)
+   * pass through untouched, so the redacted map keeps the exact shape the WP3
+   * export round-trip depends on.
    */
-  apply(
-    input: { content: string; sourcePath: string },
-    policy: SecretPolicy
-  ): {
-    action: 'kept' | 'redacted' | 'flagged' | 'skipped';
-    content: string;
-    matches: SecretMatch[];
-    embeddingExcluded: boolean;
-    extraTags: string[];
-  } {
-    const { redacted, matches, hasSecret } = this.scan(input.content);
+  scanFrontmatter(frontmatter: Record<string, unknown>): FrontmatterScanResult {
+    const tally = new Map<string, number>();
+    const redacted = this.redactLeaves(frontmatter, tally) as Record<string, unknown>;
+    const matches = [...tally].map(([pattern, count]) => ({ pattern, count }));
+    return { redacted, matches, hasSecret: matches.length > 0 };
+  }
 
-    if (!hasSecret) {
+  private redactLeaves(value: unknown, tally: Map<string, number>): unknown {
+    if (typeof value === 'string') {
+      const { redacted, matches } = this.scan(value);
+      for (const m of matches) tally.set(m.pattern, (tally.get(m.pattern) ?? 0) + m.count);
+      return redacted;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.redactLeaves(item, tally));
+    }
+    if (isPlainObject(value)) {
+      const out: Record<string, unknown> = {};
+      for (const [key, item] of Object.entries(value)) out[key] = this.redactLeaves(item, tally);
+      return out;
+    }
+    return value;
+  }
+
+  /**
+   * Apply a {@link SecretPolicy} to one fact's surfaces (content + optional
+   * title/frontmatter), returning the (possibly redacted) surfaces plus the
+   * side-effects the caller must honour. A hit on ANY surface triggers the
+   * policy; redaction is always in place so shapes are preserved.
+   */
+  apply(input: SecretScanTarget, policy: SecretPolicy): SecretPolicyResult {
+    const content = this.scan(input.content);
+    const title = input.title !== undefined ? this.scan(input.title) : undefined;
+    const frontmatter =
+      input.frontmatter !== undefined ? this.scanFrontmatter(input.frontmatter) : undefined;
+    const matches = mergeMatches(content.matches, title?.matches, frontmatter?.matches);
+
+    if (matches.length === 0) {
       return {
         action: 'kept',
         content: input.content,
+        ...(input.title !== undefined ? { title: input.title } : {}),
+        ...(input.frontmatter !== undefined ? { frontmatter: input.frontmatter } : {}),
         matches,
         embeddingExcluded: false,
         extraTags: [],
       };
     }
 
+    const sanitized = {
+      content: content.redacted,
+      ...(title !== undefined ? { title: title.redacted } : {}),
+      ...(frontmatter !== undefined ? { frontmatter: frontmatter.redacted } : {}),
+    };
+
     switch (policy) {
       case 'redact':
         return {
           action: 'redacted',
-          content: redacted,
+          ...sanitized,
           matches,
           embeddingExcluded: false,
           extraTags: [],
@@ -156,24 +240,31 @@ export class SecretScanner {
         // `redact` only by holding the row out of the vector index + a review tag.
         return {
           action: 'flagged',
-          content: redacted,
+          ...sanitized,
           matches,
           embeddingExcluded: true,
           extraTags: ['has-secret'],
         };
       case 'skip':
+        // Dropped by the caller — still return redacted surfaces, never raw.
         return {
           action: 'skipped',
-          content: input.content,
+          ...sanitized,
           matches,
           embeddingExcluded: false,
           extraTags: [],
         };
-      case 'fail':
+      case 'fail': {
+        const fields: SecretField[] = [];
+        if (content.hasSecret) fields.push('content');
+        if (title?.hasSecret) fields.push('title');
+        if (frontmatter?.hasSecret) fields.push('frontmatter');
         throw new ImportSecretPolicyError(
           input.sourcePath,
-          matches.map((m) => m.pattern)
+          matches.map((m) => m.pattern),
+          fields
         );
+      }
     }
   }
 }


### PR DESCRIPTION
Wrap-up campaign batch B2 (see docs/plans/2026-07-memory-platform/WRAPUP-PLAN.md):

- **G1-T3** import_agent_memory path allowlist (IMPORT_ALLOWED_ROOT, realpath containment, dryRun covered) — A18
- **G2-T2** frontmatter + title secret scan under the import policy (redact-in-place; flag = redact + embeddingExcluded + review tag)
- **G2-T3** IMPORT.md flag/reindex claims corrected to enforced behavior
- **G1-T1** boot fail-safe for unauthenticated multiTenant streamable-http extended to ALL envs (explicit ALLOW_UNAUTHENTICATED_HTTP ack; no auth default flip per pinned Decision 1)

Tracker flips in final commit.

⚠️ Ops note: local engram-mcp.service needs ALLOW_UNAUTHENTICATED_HTTP=true before restarting onto this build (WRAPUP-PLAN §H item 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)