### PR TITLE
perf(marketing-site): WP1 batch B9 — haze perf + build-time prerender

### DIFF
--- a/apps/marketing-site/.gitignore
+++ b/apps/marketing-site/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+dist-ssr/

--- a/apps/marketing-site/README.md
+++ b/apps/marketing-site/README.md
@@ -19,10 +19,14 @@ a slowly cycling sacred-geometry backdrop.
 
 | File               | Role                                                                                                                                                                        |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `index.html`       | Shell, styles, and copy. Entry point.                                                                                                                                       |
-| `app.jsx`          | React app: hero input, memory panels, the four verbs, install section, and the Tweaks panel.                                                                                |
+| `index.html`       | Shell, styles, and copy. Loads `main.jsx`.                                                                                                                                  |
+| `main.jsx`         | Browser entry: hydrates the prerendered `#root` (production) or falls back to a plain client render (dev); pulls in `smooth-scroll.js`.                                     |
+| `app.jsx`          | React app (exported `<App/>`, no module side effects): hero input, memory panels, the four verbs, install section.                                                          |
+| `entry-server.jsx` | Build-time prerender entry: `renderToString(<App/>)` for `prerender.mjs`.                                                                                                   |
+| `prerender.mjs`    | Post-build script (`postbuild`): SSR-bundles `entry-server.jsx` via Vite, renders the app, injects the markup into `dist/index.html`'s `#root`.                             |
 | `memory-haze.js`   | The depth-of-field engine: fragment field, lantern, idle drift, and the sacred-geometry backdrop (Flower of Life, Metatron's Cube, Sri Yantra, Hexagram, Pentagram, Torus). |
 | `smooth-scroll.js` | Eased momentum scrolling that keeps the real scroll position authoritative.                                                                                                 |
+| `dev-tweaks.jsx`   | Dev-only lazy wrapper that mounts the Tweaks panel (dropped from production builds).                                                                                        |
 | `tweaks-panel.jsx` | In-page Tweaks panel (haze, lantern, float, geometry shape, idle drift).                                                                                                    |
 
 ## Running
@@ -40,7 +44,7 @@ npm run dev      # Vite dev server with hot reload
 Production build and local preview:
 
 ```bash
-npm run build    # emits dist/
+npm run build    # emits dist/, then prerenders <App/> into dist/index.html (postbuild)
 npm run preview  # serve the built dist/ locally
 ```
 

--- a/apps/marketing-site/app.jsx
+++ b/apps/marketing-site/app.jsx
@@ -1,8 +1,10 @@
-/* app.jsx — Engram marketing site */
+/* app.jsx — Engram marketing site.
+ * Exports <App/> with no module-level side effects so it can render in two
+ * places: the browser (main.jsx) and the build-time prerender (entry-server.jsx
+ * via prerender.mjs). Everything browser-only (MemoryHaze, scroll listeners,
+ * dev tweaks) stays effect-scoped and never runs during renderToString. */
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { createRoot } from 'react-dom/client';
 import { MemoryHaze } from './memory-haze.js';
-import './smooth-scroll.js';
 
 // Dev-only tweaks UI. `import.meta.env.DEV` is statically false in production
 // builds, so Rollup drops the dynamic import and the panel never ships to
@@ -304,5 +306,5 @@ function App() {
   );
 }
 
-createRoot(document.getElementById("root")).render(<App />);
+export default App;
 

--- a/apps/marketing-site/entry-server.jsx
+++ b/apps/marketing-site/entry-server.jsx
@@ -1,0 +1,12 @@
+/* entry-server.jsx — build-time prerender entry (R12).
+ * Bundled by prerender.mjs via `vite build --ssr` so app.jsx's raw JSX and
+ * import.meta.env get the same production transforms as the client bundle.
+ * Renders the exact tree main.jsx hydrates; all browser-only work in the app
+ * is effect-scoped, so renderToString is safe under Node. */
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import App from './app.jsx';
+
+export function render() {
+  return renderToString(<App />);
+}

--- a/apps/marketing-site/eslint.config.js
+++ b/apps/marketing-site/eslint.config.js
@@ -10,7 +10,7 @@ import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 
 export default [
-  { ignores: ['dist/**', 'node_modules/**'] },
+  { ignores: ['dist/**', 'dist-ssr/**', 'node_modules/**'] },
   js.configs.recommended,
   {
     files: ['**/*.{js,jsx}'],
@@ -43,8 +43,8 @@ export default [
     },
   },
   {
-    // Node-side config files (not shipped to the browser).
-    files: ['vite.config.js', 'eslint.config.js'],
+    // Node-side config/build files (not shipped to the browser).
+    files: ['vite.config.js', 'eslint.config.js', 'prerender.mjs'],
     languageOptions: {
       globals: {
         ...globals.node,

--- a/apps/marketing-site/index.html
+++ b/apps/marketing-site/index.html
@@ -18,7 +18,7 @@
 <meta name="theme-color" content="#0a0b0f" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@300;400;500&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 <style>
   :root {
     --void: #0a0b0f;
@@ -306,6 +306,6 @@
   <div id="haze" aria-hidden="true"></div>
   <div id="root"></div>
 
-  <script type="module" src="./app.jsx"></script>
+  <script type="module" src="./main.jsx"></script>
 </body>
 </html>

--- a/apps/marketing-site/main.jsx
+++ b/apps/marketing-site/main.jsx
@@ -1,0 +1,16 @@
+/* main.jsx — browser entry.
+ * The build prerenders <App/> into #root (see prerender.mjs), so production
+ * hydrates the existing markup; in dev, index.html ships an empty #root and
+ * we fall back to a plain client render. smooth-scroll.js runs at import time
+ * (matchMedia + wheel listeners), so it lives here, out of the SSR path. */
+import React from 'react';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import App from './app.jsx';
+import './smooth-scroll.js';
+
+const rootEl = document.getElementById('root');
+if (rootEl.hasChildNodes()) {
+  hydrateRoot(rootEl, <App />);
+} else {
+  createRoot(rootEl).render(<App />);
+}

--- a/apps/marketing-site/memory-haze.js
+++ b/apps/marketing-site/memory-haze.js
@@ -60,6 +60,24 @@
     g.stroke();
   }
 
+  // Pre-rendered mote sprites: one blurred disc per tone, drawn once at init.
+  // Replaces per-mote ctx.shadowBlur in the frame loop (canvas shadow
+  // rendering is notoriously slow); _render just drawImage-scales these.
+  const MOTE_SPRITE = { size: 64, core: 16, glow: 16 };
+  function makeMoteSprite(rgb) {
+    const c = document.createElement("canvas");
+    c.width = c.height = MOTE_SPRITE.size;
+    const g = c.getContext("2d");
+    const col = `rgba(${rgb[0]},${rgb[1]},${rgb[2]},1)`;
+    g.shadowColor = col;
+    g.shadowBlur = MOTE_SPRITE.glow;
+    g.fillStyle = col;
+    g.beginPath();
+    g.arc(MOTE_SPRITE.size / 2, MOTE_SPRITE.size / 2, MOTE_SPRITE.core, 0, TAU);
+    g.fill();
+    return c;
+  }
+
   const GEO_SHAPES = [
     { name: "flower", draw(g, R) {
       const r = R / 4, N = 3, span = r * (N + 0.5);
@@ -161,11 +179,20 @@
       this.fragCount = opts.fragments || 26;
       this.moteCount = opts.motes || 90;
 
-      // foreground text whose footprint must stay clear of readable memories
+      // foreground text whose footprint must stay clear of readable memories.
+      // Rect reads force layout, so they are gated (see _updateExclusions):
+      // _exclRects caches viewport rects + the scroll offset they were read at.
       this.exclSel = opts.exclude || null;
       this._exclNodes = null;
       this._exclTick = 0;
+      this._exclRects = null;
+      this._exclScrollX = 0;
+      this._exclScrollY = 0;
+      this._exclDirty = true;
       this.excl = null;
+
+      this.moteSprites = {};
+      for (const tone in TONES) this.moteSprites[tone] = makeMoteSprite(TONES[tone]);
 
       this.focal = { x: window.innerWidth * 0.5, y: window.innerHeight * 0.42, tx: 0, ty: 0 };
       this.focal.tx = this.focal.x; this.focal.ty = this.focal.y;
@@ -184,12 +211,24 @@
         this.lastPointerT = this.t;
       }, { passive: true });
 
+      // pause the rAF loop entirely while the tab is hidden (background-tab
+      // throttling still ticks ~1/s; this drops it to zero)
+      this._onVisibility = () => {
+        if (document.hidden) {
+          if (this._raf) { cancelAnimationFrame(this._raf); this._raf = 0; }
+        } else if (this.running && !this.reduced && !this._raf) {
+          this._raf = requestAnimationFrame(this._frame);
+        }
+      };
+      document.addEventListener("visibilitychange", this._onVisibility);
+
       this._resize();
       this._seed();
     }
 
     _resize() {
       this.w = window.innerWidth; this.h = window.innerHeight;
+      this._exclDirty = true; // cached exclusion rects are stale after reflow
       for (const c of [this.canvas, this.geo]) {
         c.width = Math.floor(this.w * this.dpr);
         c.height = Math.floor(this.h * this.dpr);
@@ -275,7 +314,7 @@
     setProgress(p) { this.progress = clamp(p, 0, 1); this.Ftarget = lerp(0.14, 1.0, this.progress); }
 
     // merge runtime tweak values
-    set(params) { Object.assign(this.tweak, params || {}); }
+    set(params) { Object.assign(this.tweak, params || {}); this._dirty = true; }
 
     // how much a point sits over foreground text (0 = clear, 1 = fully covered).
     // feathered so memories fade out as they drift toward the words, never popping.
@@ -298,16 +337,37 @@
       return hide;
     }
 
-    // refresh the rects of foreground text near the viewport (cached, cheap to re-read)
+    // refresh the rects of foreground text near the viewport.
+    // getBoundingClientRect() forces a synchronous reflow after the previous
+    // frame's style writes, so the layout reads are gated to every 30th frame
+    // (plus resize, via _exclDirty). Between refreshes the cached rects are
+    // shifted by the scroll delta — pure arithmetic, no layout access.
     _updateExclusions() {
       if (!this.exclSel) return;
-      if (!this._exclNodes || (this._exclTick++ % 30 === 0)) {
+      if (this._exclDirty || !this._exclRects || (this._exclTick++ % 30 === 0)) {
+        this._exclDirty = false;
         this._exclNodes = Array.prototype.slice.call(document.querySelectorAll(this.exclSel));
+        const rects = [];
+        for (let i = 0; i < this._exclNodes.length; i++) {
+          const r = this._exclNodes[i].getBoundingClientRect();
+          if (r.width > 1 && r.height > 1) {
+            rects.push({ left: r.left, right: r.right, top: r.top, bottom: r.bottom });
+          }
+        }
+        this._exclRects = rects;
+        this._exclScrollX = window.scrollX;
+        this._exclScrollY = window.scrollY;
       }
+      // scroll-adjust the cached rects; viewport filter runs on the cheap copies
+      const dx = this._exclScrollX - window.scrollX;
+      const dy = this._exclScrollY - window.scrollY;
       const arr = [];
-      for (let i = 0; i < this._exclNodes.length; i++) {
-        const r = this._exclNodes[i].getBoundingClientRect();
-        if (r.width > 1 && r.height > 1 && r.bottom > -160 && r.top < this.h + 160) arr.push(r);
+      for (let i = 0; i < this._exclRects.length; i++) {
+        const r = this._exclRects[i];
+        const top = r.top + dy, bottom = r.bottom + dy;
+        if (bottom > -160 && top < this.h + 160) {
+          arr.push({ left: r.left + dx, right: r.right + dx, top, bottom });
+        }
       }
       this.excl = arr;
     }
@@ -336,6 +396,7 @@
         const dead = this.frags.shift();
         dead.el.remove();
       }
+      this._dirty = true;
       return f;
     }
 
@@ -348,7 +409,7 @@
         const score = -d + (f.tone !== "neutral" ? 120 : 0) + Math.random() * 80;
         if (score > bestScore) { bestScore = score; best = f; }
       }
-      if (best) { best.recallPull = 1; best.clarity = 1; }
+      if (best) { best.recallPull = 1; best.clarity = 1; this._dirty = true; }
       return best;
     }
 
@@ -358,16 +419,28 @@
       if (this.reduced) { this.F = this.Ftarget; this._render(); return; }
       this._raf = requestAnimationFrame(this._frame);
     }
-    stop() { this.running = false; if (this._raf) cancelAnimationFrame(this._raf); }
+    stop() { this.running = false; if (this._raf) { cancelAnimationFrame(this._raf); this._raf = 0; } }
 
     // rAF driver — note: rAF passes a timestamp arg, so the loop body must NOT
     // treat its first argument as a "render once" flag (that was the original bug).
     _frame() {
-      this._render();
+      if (!this._settled()) this._render();
       if (this.running) this._raf = requestAnimationFrame(this._frame);
     }
 
+    // With idle drift off there is nothing left to animate once the lantern
+    // easing lands: skip the whole render (no layout reads, no style writes,
+    // no canvas) until an input moves a target or _dirty is set (set(),
+    // addMemory(), recall()). With idleDrift on (the default) never skip.
+    _settled() {
+      if (this.tweak.idleDrift || this._dirty) return false;
+      return Math.abs(this.focal.tx - this.focal.x) < 0.1 &&
+             Math.abs(this.focal.ty - this.focal.y) < 0.1 &&
+             Math.abs(this.Ftarget - this.F) < 0.0005;
+    }
+
     _render() {
+      this._dirty = false;
       this.t += 1 / 60;
 
       // Idle: before the user moves (or after ~2.4s still), the lantern drifts
@@ -466,7 +539,8 @@
       const ctx = this.ctx;
       ctx.clearRect(0, 0, this.w, this.h);
 
-      // motes
+      // motes — pre-blurred per-tone sprites, scaled per mote (no per-draw
+      // shadowBlur; the baked glow stands in for the old (1-clar)*4 halo)
       for (const m of this.motes) {
         m.ph += 0.006 * m.sp;
         const travel = (prog * 0.9) * (0.3 + m.z);
@@ -479,15 +553,13 @@
         const clar = clamp(Math.max(depthClar, curClar), 0, 1);
         const r = (0.5 + m.z * 1.6) * (0.7 + clar);
         const a = (0.05 + clar * 0.5) * (1 - this._hideAt(mx, my));
-        const col = TONES[m.tone];
         m.sx = mx; m.sy = my; m.clar = clar;
-        const blurFar = (1 - clar) * 4;
-        ctx.shadowBlur = blurFar;
-        ctx.shadowColor = `rgba(${col[0]},${col[1]},${col[2]},${a})`;
-        ctx.fillStyle = `rgba(${col[0]},${col[1]},${col[2]},${a})`;
-        ctx.beginPath(); ctx.arc(mx, my, r, 0, Math.PI * 2); ctx.fill();
+        if (a < 0.004) continue; // fully hidden behind foreground text
+        const s = (r / MOTE_SPRITE.core) * MOTE_SPRITE.size;
+        ctx.globalAlpha = a;
+        ctx.drawImage(this.moteSprites[m.tone], mx - s / 2, my - s / 2, s, s);
       }
-      ctx.shadowBlur = 0;
+      ctx.globalAlpha = 1;
 
       // connective lines between fragments that are near & in focus (familiar, connected)
       ctx.lineWidth = 1;

--- a/apps/marketing-site/package.json
+++ b/apps/marketing-site/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "postbuild": "node prerender.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/apps/marketing-site/prerender.mjs
+++ b/apps/marketing-site/prerender.mjs
@@ -1,0 +1,54 @@
+/* prerender.mjs — post-build prerender (R12).
+ *
+ * Runs automatically after `vite build` (npm "postbuild" hook), including the
+ * CI Pages deploy in .github/workflows/node.js.yml which calls `npm run build`.
+ *
+ * Approach: app.jsx is raw JSX, so it cannot be imported by Node directly.
+ * We bundle entry-server.jsx with Vite's SSR build (same config/plugins as
+ * the client build → identical transforms and a statically-false
+ * import.meta.env.DEV), import the resulting bundle, renderToString <App/>,
+ * and inject the markup into dist/index.html's empty #root. The client entry
+ * (main.jsx) hydrates when #root has children and falls back to createRoot in
+ * dev, where #root ships empty.
+ */
+import { readFileSync, writeFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'vite';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const distIndex = path.join(here, 'dist', 'index.html');
+const ssrOutDir = path.join(here, 'dist-ssr');
+
+// 1. Bundle the SSR entry (react/react-dom stay external and resolve from
+//    node_modules when the bundle is imported below).
+await build({
+  configFile: path.join(here, 'vite.config.js'),
+  root: here,
+  logLevel: 'warn',
+  build: {
+    ssr: path.join(here, 'entry-server.jsx'),
+    outDir: ssrOutDir,
+    emptyOutDir: true,
+  },
+});
+
+try {
+  // 2. Render and inject.
+  const bundle = pathToFileURL(path.join(ssrOutDir, 'entry-server.js')).href;
+  const { render } = await import(bundle);
+  const appHtml = render();
+  if (!appHtml || appHtml.length < 1000) {
+    throw new Error(`prerender produced suspiciously small markup (${appHtml.length} chars)`);
+  }
+  const marker = '<div id="root"></div>';
+  const html = readFileSync(distIndex, 'utf8');
+  if (!html.includes(marker)) {
+    throw new Error(`marker ${marker} not found in ${distIndex}`);
+  }
+  writeFileSync(distIndex, html.replace(marker, `<div id="root">${appHtml}</div>`));
+  console.log(`[prerender] injected ${appHtml.length} chars of markup into dist/index.html`);
+} finally {
+  // 3. The SSR bundle is a build-tool artifact, not a deployable asset.
+  rmSync(ssrOutDir, { recursive: true, force: true });
+}

--- a/docs/plans/2026-07-memory-platform/STATE.md
+++ b/docs/plans/2026-07-memory-platform/STATE.md
@@ -42,7 +42,7 @@ Legend: ✅ done+verified · 🟨 partial · ⬜ not started · 📄 plan author
 
 | WP      | Deliverable                                    | Plan | Execution                                                                         | Where                                                   |
 | ------- | ---------------------------------------------- | ---- | --------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| WP1     | Marketing-site validation + R1–R13 remediation | ✅   | 🟨 **B8 done** (R2–R7, R11, R13, R1-CNAME — PR #259); B9 = R8/R12/R10; R1/R9 ops in flight | WRAPUP-PLAN.md B8/B9/BOps                               |
+| WP1     | Marketing-site validation + R1–R13 remediation | ✅   | ✅ **code done** (B8 #259 + B9 #261; R10 Lighthouse blocked — no Chrome on host, re-run cmd in REPORT); R1/R9 Pages-TLS ops in flight | WRAPUP-PLAN.md B8/B9/BOps                               |
 | **WP2** | **Memory management UI (SHARED-2 + T1–T9)**    | ✅   | ✅ **done — verified** (T1–T9 + SHARED-2; T3/T6 follow-ups remediated 2026-07-08) | **merged `main` @109e0d8 (PR #222)** + follow-up branch |
 | WP3     | Rich markdown export (SHARED-1 + T1–T9)        | ✅   | ✅ **done — verified** (T1–T9; SHARED-1 deferred)                                 | branch `feat/markdown-export-wp3`                       |
 | WP4     | Agentic memory import (SHARED-1 + T1–T16)      | ✅   | ✅ **done — verified** (SHARED-1 + T1–T16)                                        | worktree `worktree-wp4-agent-memory-import`             |

--- a/docs/plans/2026-07-memory-platform/WP1-marketing-site-validation/REPORT.md
+++ b/docs/plans/2026-07-memory-platform/WP1-marketing-site-validation/REPORT.md
@@ -228,3 +228,32 @@ Independent tasks, each executable in parallel with no other context. Where two 
 - **Exact steps:** (1) `CLAUDE.md:16` says `pnpm@11.4.0`; root `package.json:60` pins `packageManager: pnpm@11.5.0` and root `README.md:16,19` say 11.5.0 — update CLAUDE.md to 11.5.0. (2) Root `README.md:36` says "19-tool MCP surface"; the controller implements 20 (`apps/mcp-server/src/memory/memory.controller.ts:74-96`) — recount and fix (20 memory tools; 21 including the public `ping` from `packages/core/src/mcp/tools/index.ts:160`). Decide the canonical count and state it with the same basis in both places.
 - **Acceptance criteria:** No occurrence of `11.4.0` in CLAUDE.md; the tool count in README matches a comment-referenced source of truth; `pnpm docs:check` passes.
 - **Size:** S. **Depends-on:** none. (Out of marketing-site scope but blocks honest tool-count copy in R7's optional footnote.)
+
+## R10 results (2026-07-13)
+
+Measured during WP1 batch B9 (R8 + R12) in the `fix/wp1-marketing-b9` worktree.
+
+**Lighthouse: BLOCKED.** No Chrome/Chromium binary exists on the measurement host (`which chromium chromium-browser google-chrome` → nothing; only Firefox is installed) and Lighthouse cannot drive Firefox, so `lighthouse.json` was not produced and LCP/TBT/CLS/perf-score remain unmeasured. Re-run in a Chrome-capable environment: `cd apps/marketing-site && npm ci && npm run build && npm run preview -- --port 4173 &` then `npx --yes lighthouse http://localhost:4173 --output=json --output-path=docs/plans/2026-07-memory-platform/WP1-marketing-site-validation/lighthouse.json --chrome-flags="--headless"`. Everything measurable without Chrome follows.
+
+### Page weight (fresh builds, gzip via `gzip -c | wc -c`)
+
+| Asset                          | Before B9 (post-B8) raw / gzip | After B9 (R8+R12) raw / gzip | Delta raw / gzip                                            |
+| ------------------------------ | ------------------------------ | ---------------------------- | ----------------------------------------------------------- |
+| `dist/index.html`              | 13,409 / 3,826                 | 17,864 / 5,242               | +4,455 / +1,416 — prerendered `#root` markup (R12)          |
+| `dist/assets/index-*.js`       | 164,529 / 53,869               | 165,882 / 54,280             | +1,353 / +411 — hydrate path + haze sprite/rect-cache code  |
+| **Total first-load (HTML+JS)** | **177,938 / 57,695**           | **183,746 / 59,522**         | **+5,808 / +1,827**                                          |
+
+The +1.8 kB gzip buys content-before-JS: all hero/panel/verbs/install copy is now in the static HTML, so first paint of real content no longer waits on 165 kB of JS, and non-JS crawlers index the page.
+
+### Google Fonts transfer size (curl with a Chrome UA; Lighthouse network items unavailable)
+
+| Fonts URL                                  | CSS     | woff2 inventory (all unicode-range subsets) |
+| ------------------------------------------ | ------- | ------------------------------------------- |
+| Before — JetBrains Mono `300;400;500`      | 8,635 B | 153,392 B                                   |
+| After (R8) — JetBrains Mono `400;500`      | 6,764 B | 133,440 B                                   |
+
+Dropping the unused 300 weight removes 19,952 B of woff2 inventory + 1,871 B of CSS. A browser fetches only the subsets it needs, so real per-visit savings are the latin/latin-ext 300-weight files (~20 kB at most, less on latin-only pages).
+
+### Runtime smoke (headless Firefox, 1440×900 — FPS profiling still needs Chrome)
+
+After R8 (tick-gated `getBoundingClientRect`, per-tone pre-blurred mote sprites replacing per-draw `shadowBlur`, visibilitychange pause, settled-skip when `idleDrift` is off): `npm run preview` (hydrated prerender) and `npm run dev` (createRoot fallback) both render hero, sacred-geometry backdrop, motes, lantern glow, and lantern-revealed fragments; dev server output clean. Frame-cost/long-task before/after numbers require a Chrome DevTools trace — carried as the same blocker as Lighthouse above.

--- a/docs/plans/2026-07-memory-platform/WRAPUP-PLAN.md
+++ b/docs/plans/2026-07-memory-platform/WRAPUP-PLAN.md
@@ -89,7 +89,7 @@ Legend: ✅ merged · 🟨 in progress · ⬜ not started.
 | B6    | `feat/wp6-docs-content-1`    | WP6 T7a, T7b, T8, T13                      | ⬜                          |      |
 | B7    | `feat/wp6-docs-content-2`    | WP6 T9, T10, T11, T12, T14                 | ⬜                          |      |
 | B8    | `fix/wp1-marketing-b8`       | R2, R3, R7, R5, R6, R13, R4, R11, R1-CNAME | ✅                          | #259 |
-| B9    | `fix/wp1-marketing-b9`       | R8, R12, R10 (best-effort)                 | ⬜                          |      |
+| B9    | `fix/wp1-marketing-b9`       | R8, R12, R10 (best-effort)                 | ✅ (R10 blocked: no Chrome) | #261 |
 | BOps  | (no branch — GitHub/DNS ops) | R1/R9 Pages TLS + HTTPS enforce            | 🟨 domain re-added 07-13; cert poller up |      |
 
 ## 2. Batch details — G1–G4 (B2–B5)


### PR DESCRIPTION
Wrap-up campaign batch B9 (WRAPUP-PLAN §4; cards in WP1 REPORT.md):

- **R8** haze engine: rect reads tick-gated (no per-frame forced layout), visibilitychange pause, settled-skip, pre-blurred mote sprites (no per-mote shadowBlur), unused font weight dropped (−20 kB font transfer)
- **R12** build-time prerender: `vite build --ssr` postbuild injects static markup; client hydrates (`hydrateRoot`) with createRoot dev fallback. Hero copy now in static HTML for SEO/LCP. CI Pages deploy picks it up automatically (postbuild)
- **R10** Lighthouse blocked — no Chrome/Chromium on host; blocker + re-run command + substitute font-transfer measurements appended to REPORT.md

Follow-up worth 30s after merge: eyeball browser console for hydration warnings (headless Firefox couldn't surface it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)