### PR TITLE
fix(docs): center splash hero and link docs from marketing nav

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -40,6 +40,7 @@ export default defineConfig({
       title: 'Engram Docs',
       description:
         'Developer documentation for Engram — an MCP memory server for AI agents.',
+      customCss: ['./src/styles/custom.css'],
       social: [
         {
           icon: 'github',

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -1,0 +1,39 @@
+/* Engram docs — custom overrides layered on top of Starlight core styles.
+ *
+ * customCss is loaded unlayered, so these rules win over Starlight's
+ * `@layer starlight.core` defaults without needing `!important`.
+ */
+
+/* Homepage splash hero.
+ *
+ * The landing page ships no hero image, but Starlight's splash hero reserves a
+ * two-column grid (`7fr` copy / `4fr` image) at >=50rem. With the image column
+ * empty the copy is stranded in the left ~55% of the page and the actions sit
+ * against a large blank right half, while `padding-block` up to `10rem` opens a
+ * cavernous gap before the content below.
+ *
+ * When (and only when) the hero has no image, collapse it to a single centered
+ * column and tighten the vertical padding so it reads as an intentional,
+ * balanced hero. The `:has()` guard means this reverts to the stock two-column
+ * layout automatically if a hero image is ever added.
+ */
+@media (min-width: 50rem) {
+  .hero:not(:has(img)):not(:has(.hero-html)) {
+    grid-template-columns: 1fr;
+    padding-block: clamp(2.5rem, 6vmin, 5rem);
+  }
+
+  .hero:not(:has(img)):not(:has(.hero-html)) .stack {
+    max-width: 60ch;
+    margin-inline: auto;
+    text-align: center;
+  }
+
+  .hero:not(:has(img)):not(:has(.hero-html)) .copy {
+    align-items: center;
+  }
+
+  .hero:not(:has(img)):not(:has(.hero-html)) .actions {
+    justify-content: center;
+  }
+}

--- a/apps/marketing-site/app.jsx
+++ b/apps/marketing-site/app.jsx
@@ -42,6 +42,8 @@ function Chrome() {
         <span className="mark-word">engram</span>
       </div>
       <nav className="chrome-nav">
+        <a href="/docs/">docs</a>
+        <span className="chrome-sep">/</span>
         <a href="https://github.com/osirison/engram" target="_blank" rel="noopener">source</a>
         <span className="chrome-sep">/</span>
         <a href="#install">connect</a>


### PR DESCRIPTION
## Summary

Fixes the docs homepage layout and adds a link from the marketing site to the docs.

**Docs homepage layout** — Starlight's `splash` hero uses a two-column grid (`7fr` copy / `4fr` image) at ≥800px, but this page ships no hero image, so the copy was stranded in the left ~55% with a large blank right half and a cavernous vertical gap. Added a scoped `apps/docs/src/styles/custom.css` (wired via `customCss`) that collapses the empty column to a **centered single column** and tightens the padding. Gated to `≥50rem` (mobile untouched) and guarded with `:has()` so it reverts to the stock layout automatically if a hero image is ever added.

**Marketing → docs link** — Added `docs` to the top-right nav (`docs / source / connect`), linking to `/docs/` where the docs are merged at deploy.

## Verification
- `docs` build ✅ (starlight-links-validator runs in-build), `docs:check` ✅
- marketing `eslint` ✅ 0 errors, marketing `vite build` + prerender ✅
- Confirmed the fix via computed styles with cache disabled (`grid-template-columns: 1080px`, `text-align: center`) and verified the link end-to-end through the CI-style `/docs` merge (`/docs/` → 200)
- No mobile horizontal overflow (verified via real CDP device emulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)