### PR TITLE
fix(docs): tidy splash landing layout

### DIFF
--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -23,7 +23,7 @@ long-term memories, embeds them for semantic recall, and exposes a suite of MCP
 tools that any compatible agent (Claude Desktop, Claude Code, and others) can
 call.
 
-<CardGrid stagger>
+<CardGrid>
   <Card title="Get started" icon="rocket">
     Pick a deployment profile and store your first memory in a few commands.
     [Getting started →](/docs/getting-started/)

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -47,13 +47,18 @@
  *
  * Cap the lead paragraph to the same 60ch measure as the hero copy and center
  * it, so the hero, the lead, and the card grid all share one centered axis.
- * Scoped to the splash via `.sl-container:has(.hero)` so the article pages that
- * reuse `.sl-markdown-content` are untouched. (The card grid is separately
- * aligned by dropping the `stagger` prop in index.mdx: with only four cards it
- * offset the right column downward and left no shared row baseline.)
+ *
+ * Guarded on the image-less hero (`:not(:has(img)):not(:has(.hero-html))`) and
+ * matched through the sibling `.sl-markdown-content`, exactly like the hero
+ * rules above. If a hero image is ever added the hero reverts to Starlight's
+ * stock two-column layout, and this centering reverts with it rather than
+ * stranding a centered paragraph under a now left-aligned hero. Article pages
+ * have no `.hero`, so they stay untouched. (The card grid is separately aligned
+ * by dropping the `stagger` prop in index.mdx: with only four cards it offset
+ * the right column downward and left no shared row baseline.)
  */
 @media (min-width: 50rem) {
-  .sl-container:has(.hero) .sl-markdown-content > p:first-child {
+  .hero:not(:has(img)):not(:has(.hero-html)) ~ .sl-markdown-content > p:first-child {
     max-width: 60ch;
     margin-inline: auto;
     text-align: center;

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -37,3 +37,25 @@
     justify-content: center;
   }
 }
+
+/* Homepage splash body — lead paragraph.
+ *
+ * Below the centered hero, the splash body (`.sl-markdown-content`) fills the
+ * full ~1080px content column. Directly under a tightly centered hero, the
+ * intro paragraph ran that entire width left-aligned (~150 characters per line —
+ * an uncomfortable measure whose left edge lined up with nothing above it).
+ *
+ * Cap the lead paragraph to the same 60ch measure as the hero copy and center
+ * it, so the hero, the lead, and the card grid all share one centered axis.
+ * Scoped to the splash via `.sl-container:has(.hero)` so the article pages that
+ * reuse `.sl-markdown-content` are untouched. (The card grid is separately
+ * aligned by dropping the `stagger` prop in index.mdx: with only four cards it
+ * offset the right column downward and left no shared row baseline.)
+ */
+@media (min-width: 50rem) {
+  .sl-container:has(.hero) .sl-markdown-content > p:first-child {
+    max-width: 60ch;
+    margin-inline: auto;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## What

The `/docs/` splash landing still read as *off* after the hero-centering fix (#266). Two desktop (≥50rem) issues remained:

1. **Staggered card grid** — `<CardGrid stagger>` offset the right column down ~80px. With only four cards of unequal height, nothing shared a row baseline, so it looked misaligned rather than intentional (cards at y = 648 / 728 / 858 / 938).
2. **Wide left-aligned lead** — directly under the tightly centered hero, the intro paragraph ran the full ~1080px column left-aligned (~150 chars/line), its left edge lining up with nothing above.

## Change

- **`index.mdx`** — drop the `stagger` prop → clean, aligned 2×2 grid (cards now at y = 704 / 704 / 914 / 914).
- **`custom.css`** — cap the splash lead paragraph to the hero's `60ch` measure and center it, so hero copy, lead, and cards share one centered axis. Scoped to the splash via `.sl-container:has(.hero) .sl-markdown-content` so article pages (which reuse `.sl-markdown-content`) are untouched.

Mobile (<50rem) is unchanged — both rules sit behind the `min-width: 50rem` guard.

## Verification

- Real `astro build` succeeds; all internal links valid; `pnpm docs:check` passes.
- Rendered the built `dist` at 1440px and 390px via headless Chromium (CDP device emulation): desktop shows the aligned grid + centered lead; mobile stacks cleanly with no horizontal overflow (`scrollWidth == clientWidth` at both widths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)