### PR TITLE
chore: remove stale engram MCP server entries

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,11 +1,3 @@
 {
-  "mcpServers": {
-    "engram": {
-      "type": "http",
-      "url": "http://127.0.0.1:3000/mcp",
-      "headers": {
-        "Authorization": "Bearer ${ENGRAM_API_KEY:-}"
-      }
-    }
-  }
+  "mcpServers": {}
 }


### PR DESCRIPTION
## Summary
- Removes the dead port-3000 `engram` entry from `.mcp.json` (project scope). It was defined in both user and project scope with different endpoints and failing to connect.
- The working local instance is `engram-local` (systemd user service on port 3100), unaffected.

## Test plan
- [x] `claude mcp list` after removal shows only `engram-local`, connected.