### PR TITLE
docs: generate agent-memory site mirrors from their canonical repo copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,16 +123,18 @@ jobs:
         run: pnpm build
 
       - name: Check generated docs are up to date (drift gate)
-        # The MCP-tool and configuration references are generated from source
-        # and committed (WP6 T3/T4). Regenerate and fail if the committed output
-        # is stale — runs after Build so the compiled tool manifest exists. The
-        # TypeDoc API reference is git-ignored (rebuilt every docs build), so it
-        # is intentionally not part of this diff.
+        # The MCP-tool, configuration, and agent-memory references are
+        # generated from source and committed (WP6 T3/T4; agent-memory mirror
+        # generator). Regenerate and fail if the committed output is stale —
+        # runs after Build so the compiled tool manifest exists. The TypeDoc
+        # API reference is git-ignored (rebuilt every docs build), so it is
+        # intentionally not part of this diff.
         run: |
           pnpm docs:generate
           git diff --exit-code -- \
             apps/docs/src/content/docs/reference/configuration.md \
             apps/docs/src/content/docs/reference/mcp-tools/ \
+            apps/docs/src/content/docs/agent-memory/ \
             || { echo "::error::Generated docs are stale. Run 'pnpm docs:generate' and commit the result."; exit 1; }
 
       - name: Lint

--- a/apps/docs/src/content/docs/agent-memory/clients.mdx
+++ b/apps/docs/src/content/docs/agent-memory/clients.mdx
@@ -11,11 +11,10 @@ sidebar:
 > agents read it from the repo at runtime. This page is a published mirror.
 
 How each of the five AI coding agents connects to the one persistent ENGRAM
-server ([server runbook](/docs/agent-memory/server/)) and follows the
-[agent memory contract](/docs/agent-memory/contract/). Every agent
-authenticates with its own API key
-([Provision agent API keys](/docs/how-to/provision-agent-keys/)) and uses
-`userId: "qp"`.
+server ([`agent-memory-server.md`](/docs/agent-memory/server/)) and follows the
+[Agent Memory Contract](/docs/agent-memory/contract/). Every agent authenticates
+with its own API key ([`security/agent-keys.md`](/docs/how-to/provision-agent-keys/)) and
+uses `userId: "qp"`.
 
 **Guarantee legend:** 🟢 deterministic (a hook forces recall/store) ·
 🔴 best-effort (the model must choose to follow the directive; the platform has
@@ -35,8 +34,7 @@ no memory hook). Only **Claude Code** is 🟢 today.
 > launched from — each agent gets its **own** key (mint the whole fleet in one
 > pass: `pnpm --filter mcp-server provision-agent-keys -- --agents
 claude-code,copilot,cursor,codex,gemini --user qp`, see
-> [Provision agent API keys](/docs/how-to/provision-agent-keys/)); never commit
-> a key.
+> [`security/agent-keys.md`](/docs/how-to/provision-agent-keys/)); never commit a key.
 
 ## Claude Code (CLI) — 🟢 deterministic
 
@@ -51,10 +49,9 @@ pieces, all checked in:
    recalled-memory block that Claude Code injects into context;
    `.claude/hooks/engram-capture.sh` (SessionEnd) distills the finished session
    into memories. Both shell out to the `engram` CLI
-   ([`packages/agent-bridge`](https://github.com/osirison/engram/tree/main/packages/agent-bridge))
-   and **always exit 0** — whether the CLI is missing or the server is down — so
-   a session is never blocked. `scripts/test-engram-hooks.sh` asserts this
-   contract.
+   ([`packages/agent-bridge`](https://github.com/osirison/engram/tree/main/packages/agent-bridge)) and **always exit 0** —
+   whether the CLI is missing or the server is down — so a session is never
+   blocked. `scripts/test-engram-hooks.sh` asserts this contract.
 3. **Directive** — the ENGRAM contract block is appended to `CLAUDE.md`.
 
 **This repo ships "live tools, hooks opt-in":** the `engram` MCP tools are
@@ -219,6 +216,5 @@ directive from `GEMINI.md`; ask Gemini to call `load_context` for the project.
 
 Claude Desktop is stdio-only, has no hooks, and does not read `CLAUDE.md`. It can
 only make the tools _available_ on demand via an `mcp-remote` stdio bridge in
-`claude_desktop_config.json` (see
-[MCP client setup](/docs/getting-started/mcp-client-setup/) for config-file
+`claude_desktop_config.json` (see [`SETUP.md`](/docs/getting-started/) for config-file
 locations). No automatic store/recall — not a WP5 acceptance target.

--- a/apps/docs/src/content/docs/agent-memory/contract.mdx
+++ b/apps/docs/src/content/docs/agent-memory/contract.mdx
@@ -31,9 +31,8 @@ value with a **hyphen or uppercase letter** (e.g. `engram-user`, `qp-global`) is
 live in `userId` — it lives entirely in the tool `scope` field (see below).
 
 Per-agent isolation is provided by **per-agent API keys** (see
-[Provision agent API keys](/docs/how-to/provision-agent-keys/)), not by distinct
-userIds. All agents share `userId: "qp"`; the key identifies which agent wrote a
-memory.
+[`security/agent-keys.md`](/docs/how-to/provision-agent-keys/)), not by distinct userIds.
+All agents share `userId: "qp"`; the key identifies which agent wrote a memory.
 
 ## Scope grammar
 

--- a/apps/docs/src/content/docs/agent-memory/migration.mdx
+++ b/apps/docs/src/content/docs/agent-memory/migration.mdx
@@ -21,9 +21,8 @@ cheap-first strategy: import with **local hash embeddings** (no API cost), then
 rebuild **real embeddings** with the admin reindex tool — free under the
 default local Ollama provider, or via the opt-in OpenAI provider. For the full importer
 reference (secrets policies, link resolution, provenance, ledger schema) see
-[Import agent memory](/docs/how-to/import-agent-memory/). For the identity/scope
-rules every command here relies on, see the
-[agent memory contract](/docs/agent-memory/contract/).
+[Agentic Memory Import](/docs/how-to/import-agent-memory/). For the identity/scope rules every command
+here relies on, see the [Agent Memory Contract](/docs/agent-memory/contract/).
 
 ## Overview
 
@@ -46,13 +45,13 @@ safely, and you can migrate one source at a time.
 ## How this differs from the file-watcher sync
 
 This is the **initial bulk load**, run by hand, once. It is distinct from the
-**ongoing [file-watcher sync bridge](/docs/agent-memory/sync/)** — a separate
-long-running component that watches those same native files and upserts edits
-into ENGRAM continuously (with newest-wins conflict handling). Both consume the
-same WP4 importer parsing and the same dedup/provenance model, so running this
-migration first and the watcher afterward does **not** create duplicates: the
-watcher reuses the ledger this migration populates. Use this runbook for the
-first import; the watcher takes over for everything after.
+**ongoing file-watcher sync bridge** — a separate long-running component that
+watches those same native files and upserts edits into ENGRAM continuously (with
+newest-wins conflict handling). Both consume the same WP4 importer parsing and
+the same dedup/provenance model, so running this migration first and the watcher
+afterward does **not** create duplicates: the watcher reuses the ledger this
+migration populates. Use this runbook for the first import; the watcher takes
+over for everything after.
 
 ## Prerequisites
 
@@ -70,7 +69,7 @@ first import; the watcher takes over for everything after.
 - **Decide scope before you run.** `userId` is always `qp` (it must be
   lowercase-alphanumeric; hyphens/uppercase are rejected). Project/agent
   separation lives entirely in `--scope`, per the
-  [agent memory contract](/docs/agent-memory/contract/#scope-grammar):
+  [Agent Memory Contract](/docs/agent-memory/contract/#scope-grammar):
 
   | Scope            | Use for                                                           |
   | ---------------- | ----------------------------------------------------------------- |
@@ -89,11 +88,11 @@ first import; the watcher takes over for everything after.
 - **Auth / keys.** The import CLI runs as a local NestJS process and needs no MCP
   bearer key. The **reindex step (Step 3)** uses the admin `reindex_memories`
   tool, which requires `MCP_ADMIN_TOKEN`. If you will run agents against a shared
-  authenticated server afterward, mint per-agent API keys as described in
-  [Provision agent API keys](/docs/how-to/provision-agent-keys/) and the
-  [persistent-server runbook](/docs/agent-memory/server/). Never place a secret
-  or token in a memory — the importer redacts, but confirm the advisories
-  (Step 1) first.
+  authenticated server afterward, mint per-agent API keys as described in the
+  [agent keys note](/docs/how-to/provision-agent-keys/) and the
+  [persistent-server runbook](/docs/agent-memory/server/). Never place a secret or
+  token in a memory — the importer redacts, but confirm the advisories (Step 1)
+  first.
 
 ## Step 1 — Dry-run every source
 
@@ -215,8 +214,7 @@ cursor.
 > running Ollama server with `nomic-embed-text` pulled — free, no API key),
 > or use `EMBEDDING_PROVIDER=openai` with a valid `OPENAI_API_KEY` (costs
 > tokens per the dry-run estimate). A third option is `--no-embed` (store
-> empty vectors) — see
-> [Import agent memory](/docs/how-to/import-agent-memory/#embedding-cost---no-embed-closes-g7);
+> empty vectors) — see [Agentic Memory Import](/docs/how-to/import-agent-memory/#embedding-cost---no-embed-closes-g7);
 > with empty vectors a **default** reindex backfills them, whereas the `local`
 > path below requires the regenerate flag.
 
@@ -342,8 +340,7 @@ safety net that catches a reused-hash-vector mistake.
 
 Where these verification facts overlap the recall-quality regression gate's seed
 dataset, the same queries feed that gate — keep them in sync with
-[Release gates](/docs/reference/release-gates/) so "primary memory" cannot
-silently regress.
+[Release Gates](/docs/reference/release-gates/) so "primary memory" cannot silently regress.
 
 ## Per-source command reference
 
@@ -352,15 +349,15 @@ All commands take the form
 (prefix `EMBEDDING_PROVIDER=local` for the real run; append `--dry-run` to
 preview).
 
-| Source        | Typical path                                     | Reads                                                                         | Recommended scope      |
-| ------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- | ---------------------- |
-| `claude-code` | repo root (e.g. `~/Cloud/Projects/engram`)       | `CLAUDE.md`/`CLAUDE.local.md` (H2-chunked)                                    | `project:<slug>`       |
-| `claude-code` | auto-memory dir (`~/.claude/projects/<encoded>`) | each `memory/*.md` atomic (`MEMORY.md` index excluded)                        | `global`               |
-| `copilot`     | repo root                                        | `.github/copilot-instructions.md` + `.github/instructions/*.instructions.md`  | `project:<slug>`       |
-| `cursor`      | repo root                                        | `.cursor/rules/*.mdc` + legacy `.cursorrules`                                 | `project:<slug>`       |
-| `codex`       | repo root                                        | `AGENTS.md` hierarchy (`--include-global` adds `~/.codex/AGENTS.md`)          | `project:<slug>`       |
-| `gemini`      | repo root                                        | `GEMINI.md` hierarchy (`--include-global` adds `~/.gemini/GEMINI.md`)         | `project:<slug>`       |
-| `markdown`    | a notes folder / Obsidian vault                  | any `.md` (index/MOC skipped; `--split-headings` chunks on H2)                | `global` (or per-repo) |
+| Source        | Typical path                                     | Reads                                                                        | Recommended scope      |
+| ------------- | ------------------------------------------------ | ---------------------------------------------------------------------------- | ---------------------- |
+| `claude-code` | repo root (e.g. `~/Cloud/Projects/engram`)       | `CLAUDE.md`/`CLAUDE.local.md` (H2-chunked)                                   | `project:<slug>`       |
+| `claude-code` | auto-memory dir (`~/.claude/projects/<encoded>`) | each `memory/*.md` atomic (`MEMORY.md` index excluded)                       | `global`               |
+| `copilot`     | repo root                                        | `.github/copilot-instructions.md` + `.github/instructions/*.instructions.md` | `project:<slug>`       |
+| `cursor`      | repo root                                        | `.cursor/rules/*.mdc` + legacy `.cursorrules`                                | `project:<slug>`       |
+| `codex`       | repo root                                        | `AGENTS.md` hierarchy (`--include-global` adds `~/.codex/AGENTS.md`)         | `project:<slug>`       |
+| `gemini`      | repo root                                        | `GEMINI.md` hierarchy (`--include-global` adds `~/.gemini/GEMINI.md`)        | `project:<slug>`       |
+| `markdown`    | a notes folder / Obsidian vault                  | any `.md` (index/MOC skipped; `--split-headings` chunks on H2)               | `global` (or per-repo) |
 
 Machine-global files pulled in by `--include-global` are cross-project — import
 them in a separate `--scope global` pass (see

--- a/apps/docs/src/content/docs/agent-memory/server.mdx
+++ b/apps/docs/src/content/docs/agent-memory/server.mdx
@@ -35,9 +35,9 @@ The server runs as a persistent process configured for shared HTTP access:
   the `/mcp` route. Store, recall, and the rest of the tool surface are MCP
   tools, not HTTP verbs.
 
-The rules every agent follows once connected live in the
-[agent memory contract](/docs/agent-memory/contract/); the per-agent client
-wiring lives in [client wiring](/docs/agent-memory/clients/).
+The rules every agent follows once connected live in
+[agent-memory-contract.md](/docs/agent-memory/contract/); the per-agent client
+wiring lives in [agent-memory-clients.md](/docs/agent-memory/clients/).
 
 ## Why one server
 
@@ -61,8 +61,8 @@ user service or Docker Compose) and how to verify it.
 
 The recommended way to run the persistent server on a single Linux machine is
 the systemd **user** unit that ships with the repository at
-[`deploy/systemd/engram-mcp.service`](https://github.com/osirison/engram/blob/main/deploy/systemd/engram-mcp.service).
-It fixes `MCP_TRANSPORT=streamable-http`, `PORT=3000`, and `HOST=127.0.0.1`; sets
+[deploy/systemd/engram-mcp.service](https://github.com/osirison/engram/blob/main/deploy/systemd/engram-mcp.service). It
+fixes `MCP_TRANSPORT=streamable-http`, `PORT=3000`, and `HOST=127.0.0.1`; sets
 `WorkingDirectory=%h/Cloud/Projects/engram` and
 `EnvironmentFile=%h/.engram/engram-mcp.env`; and hardens the process with
 `Restart=always`, `NoNewPrivileges=true`, and `PrivateTmp=true`.
@@ -130,7 +130,7 @@ QDRANT_URL=http://127.0.0.1:6333
 # Auth gate — every agent authenticates with a per-agent API key.
 AUTH_REQUIRED=true
 
-# Durability profile: memory | lite | enterprise (see the getting-started guides).
+# Durability profile: memory | lite | enterprise (see docs/SETUP.md).
 DEPLOYMENT_PROFILE=enterprise
 
 # Admin-only operations (reindex, backfill). Not an agent key.
@@ -147,25 +147,21 @@ EMBEDDING_PROVIDER=ollama
 ```
 
 Choose `DEPLOYMENT_PROFILE` for your durability and infrastructure needs — the
-profile table and per-profile setup live in
-[Getting started](/docs/getting-started/). A single-user machine can run
-`memory` (no external services, data lost on exit) or `lite` (Postgres only,
-encrypted at rest); the sample above shows the full-stack `enterprise`
-variables. Leaner profiles need fewer of the datastore URLs, so delete the ones
-that profile does not use.
+profile table and per-profile setup live in [SETUP.md](/docs/getting-started/). A single-user
+machine can run `memory` (no external services, data lost on exit) or `lite`
+(Postgres only, encrypted at rest); the sample above shows the full-stack
+`enterprise` variables. Leaner profiles need fewer of the datastore URLs, so
+delete the ones that profile does not use.
 
 Generating and rotating the per-agent API keys (and turning the `AUTH_REQUIRED`
-gate on) is covered in
-[Provision agent API keys](/docs/how-to/provision-agent-keys/).
+gate on) is covered in [security/agent-keys.md](/docs/how-to/provision-agent-keys/).
 
 ## Docker Compose alternative
 
 To run the server in a container instead of directly on the host, use the
-production image path:
-[`docker-compose.prod.yml`](https://github.com/osirison/engram/blob/main/docker-compose.prod.yml)
+production image path: [docker-compose.prod.yml](https://github.com/osirison/engram/blob/main/docker-compose.prod.yml)
 (which builds from `apps/mcp-server/Dockerfile`, listening on port `3000`). The
-full container build and release flow is documented in
-[Deploy to production](/docs/how-to/deploy-production/).
+full container build and release flow is documented in [deploy.md](/docs/how-to/deploy-production/).
 
 The container path serves the same shared MCP server, so it must run with the
 same environment as the systemd unit — in particular
@@ -176,8 +172,8 @@ per-machine, matching the `HOST=127.0.0.1` bind described above.
 ## Health and verification
 
 The repository ships a verification script at
-[`scripts/verify-engram-server.sh`](https://github.com/osirison/engram/blob/main/scripts/verify-engram-server.sh).
-It runs four checks against a running server:
+[scripts/verify-engram-server.sh](https://github.com/osirison/engram/blob/main/scripts/verify-engram-server.sh). It runs
+four checks against a running server:
 
 1. `/health` answers `200`.
 2. The MCP Streamable-HTTP handshake works — an `initialize` request returns an
@@ -216,13 +212,11 @@ port directly. Keep this server on loopback.
 
 ## See also
 
-- [Agent memory contract](/docs/agent-memory/contract/) — the one contract every
+- [agent-memory-contract.md](/docs/agent-memory/contract/) — the one contract every
   agent follows so ENGRAM behaves as shared primary memory.
-- [Client wiring](/docs/agent-memory/clients/) — per-agent client wiring
+- [agent-memory-clients.md](/docs/agent-memory/clients/) — per-agent client wiring
   for Claude Code, Copilot, Cursor, Codex, and Gemini.
-- [Provision agent API keys](/docs/how-to/provision-agent-keys/) — per-agent API
-  keys and enabling the `AUTH_REQUIRED` gate.
-- [Getting started](/docs/getting-started/) — profiles, local development, and
-  MCP client setup.
-- [Deploy to production](/docs/how-to/deploy-production/) — production Docker
-  image build and release flow.
+- [security/agent-keys.md](/docs/how-to/provision-agent-keys/) — per-agent API keys and
+  enabling the `AUTH_REQUIRED` gate.
+- [SETUP.md](/docs/getting-started/) — profiles, local development, and MCP client setup.
+- [deploy.md](/docs/how-to/deploy-production/) — production Docker image build and release flow.

--- a/apps/docs/src/content/docs/agent-memory/sync.mdx
+++ b/apps/docs/src/content/docs/agent-memory/sync.mdx
@@ -22,13 +22,13 @@ On a change under a watched root, the file is mapped to its WP4 importer source
 and that source is re-imported (the importer's ledger makes re-runs idempotent —
 only changed facts update):
 
-| File(s)                                                                      | Source        |
-| ---------------------------------------------------------------------------- | ------------- |
-| `CLAUDE.md`, `CLAUDE.local.md`, `.claude/**/memory/*.md`                     | `claude-code` |
-| `AGENTS.md`                                                                  | `codex`       |
-| `GEMINI.md`                                                                  | `gemini`      |
-| `.cursor/rules/*.mdc`, `.cursorrules`                                        | `cursor`      |
-| `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`  | `copilot`     |
+| File(s)                                                                     | Source        |
+| --------------------------------------------------------------------------- | ------------- |
+| `CLAUDE.md`, `CLAUDE.local.md`, `.claude/**/memory/*.md`                    | `claude-code` |
+| `AGENTS.md`                                                                 | `codex`       |
+| `GEMINI.md`                                                                 | `gemini`      |
+| `.cursor/rules/*.mdc`, `.cursorrules`                                       | `cursor`      |
+| `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | `copilot`     |
 
 Bursty writes (editor temp-file + rename) are debounced so one import runs after
 the writes settle, not one per raw filesystem event.
@@ -43,7 +43,7 @@ of clobbering — the file change waits for manual reconciliation. Run with
 `--force` to override. (This is one-way: files → ENGRAM. Exporting ENGRAM back to
 files is WP3's job, kept separate.)
 
-### Conflict copies — nothing is lost
+### Conflict copies — nothing is lost (#239)
 
 When the skip fires and the file has **genuinely diverged** (its content differs
 from both the last import and the memory's current content), the file's version
@@ -66,7 +66,7 @@ then re-run with `--force`. The importer detects the convergence (file content
 now equals the memory), refreshes the ledger without writing the memory
 (`reconciled` in the run summary), the conflict clears, and the copy is removed.
 
-### Multi-root ledger namespacing
+### Multi-root ledger namespacing (#236)
 
 Ledger keys are namespaced per import root
 (`<tool>@<12-hex-root-fingerprint>:<relpath>[#anchor]`), so watching two
@@ -90,7 +90,7 @@ pnpm --filter mcp-server watch -- "$PWD" --user qp --scope project:engram --once
 ```
 
 As a long-lived daemon (systemd user service, alongside the MCP server — see
-the [server runbook](/docs/agent-memory/server/)):
+[`agent-memory-server.md`](/docs/agent-memory/server/)):
 
 ```bash
 cp deploy/systemd/engram-sync.service ~/.config/systemd/user/

--- a/docs/agent-memory-clients.md
+++ b/docs/agent-memory-clients.md
@@ -46,7 +46,7 @@ pieces, all checked in:
    recalled-memory block that Claude Code injects into context;
    `.claude/hooks/engram-capture.sh` (SessionEnd) distills the finished session
    into memories. Both shell out to the `engram` CLI
-   ([`packages/agent-bridge`](./agent-memory-contract.md)) and **always exit 0** —
+   ([`packages/agent-bridge`](../packages/agent-bridge)) and **always exit 0** —
    whether the CLI is missing or the server is down — so a session is never
    blocked. `scripts/test-engram-hooks.sh` asserts this contract.
 3. **Directive** — the ENGRAM contract block is appended to `CLAUDE.md`.

--- a/docs/agent-memory-migration.md
+++ b/docs/agent-memory-migration.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Memory Migration Runbook
-description: One-time bulk import of qp's existing native agent-memory files (Claude Code, Copilot, Cursor, Codex, Gemini, markdown) into ENGRAM using WP4's importer CLI, with local-embedding cost control and a real-embedding reindex.
+description: One-time bulk import of existing native agent-memory files (Claude Code, Copilot, Cursor, Codex, Gemini, markdown) into ENGRAM using the WP4 importer CLI, with local-embedding cost control and a real-embedding reindex.
 ---
 
 > Also published at [engram.events/docs/agent-memory/migration/](https://engram.events/docs/agent-memory/migration/). This repository copy is canonical — agents read it at runtime.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bench:baseline:fetch": "node scripts/fetch-benchmark-baseline.mjs --out artifacts/bench-baseline.json",
     "bench:trend:check": "node scripts/compare-benchmark-trend.mjs --current artifacts/bench-results.json --baseline artifacts/bench-baseline.json --out artifacts/bench-trend-summary.json --max-p95-delta 20",
     "docs:check": "node .github/check-docs.mjs",
-    "docs:generate": "node scripts/gen-env-table.mjs && node scripts/gen-mcp-tools.mjs",
+    "docs:generate": "node scripts/gen-env-table.mjs && node scripts/gen-mcp-tools.mjs && node scripts/gen-agent-memory-docs.mjs",
     "clean": "turbo run clean && rm -rf node_modules",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "inspector": "MCP_AUTO_OPEN_ENABLED=false npx --yes @modelcontextprotocol/inspector",

--- a/scripts/gen-agent-memory-docs.mjs
+++ b/scripts/gen-agent-memory-docs.mjs
@@ -9,11 +9,12 @@
 // in the repo (`./security/agent-keys.md`) has no meaning on the site, so it
 // is mapped to the page it now lives on, or to a GitHub blob/tree URL when
 // there is no site page for it. Everything else — frontmatter title, prose,
-// tables — is reused verbatim.
+// tables — is reused verbatim, except the meta description gains a trailing
+// period (Starlight/SEO convention) if the source is missing one.
 //
 // Determinism (D3): output must be byte-for-byte identical across runs.
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve, posix } from 'node:path';
 
@@ -36,6 +37,8 @@ const DOCS = [
   { slug: 'migration', file: 'agent-memory-migration.md', kind: 'runbook', sidebar: { order: 5, label: 'Migration' } },
 ];
 const SIBLING_SLUGS = new Set(DOCS.map((d) => d.slug));
+
+mkdirSync(outDir, { recursive: true });
 
 // Repo-relative link targets that were themselves migrated to the docs site
 // (WP6) under a path the mechanical `agent-memory-X.md -> /docs/agent-memory/X/`

--- a/scripts/gen-agent-memory-docs.mjs
+++ b/scripts/gen-agent-memory-docs.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// AUTO-GENERATOR — writes apps/docs/src/content/docs/agent-memory/*.mdx
+//
+// The five agent-memory docs are canonical at docs/agent-memory-*.md — AI
+// agents (AGENTS.md, CLAUDE.md) read that repo copy directly at runtime, so
+// it cannot move. This script derives the published site mirror from that
+// source so the two can never drift out of sync by hand-editing. The only
+// real transformation is link rewriting: a relative link that resolves fine
+// in the repo (`./security/agent-keys.md`) has no meaning on the site, so it
+// is mapped to the page it now lives on, or to a GitHub blob/tree URL when
+// there is no site page for it. Everything else — frontmatter title, prose,
+// tables — is reused verbatim.
+//
+// Determinism (D3): output must be byte-for-byte identical across runs.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve, posix } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const srcDir = join(repoRoot, 'docs');
+const outDir = join(repoRoot, 'apps/docs/src/content/docs/agent-memory');
+
+const GITHUB_BLOB_BASE = 'https://github.com/osirison/engram/blob/main/';
+const GITHUB_TREE_BASE = 'https://github.com/osirison/engram/tree/main/';
+
+// One entry per mirrored doc. `kind` fills the "canonical copy of this ___
+// lives in the repository at" banner sentence; `sidebar` matches the site's
+// existing nav order/labels for this section.
+const DOCS = [
+  { slug: 'contract', file: 'agent-memory-contract.md', kind: 'contract', sidebar: { order: 1, label: 'Contract' } },
+  { slug: 'server', file: 'agent-memory-server.md', kind: 'runbook', sidebar: { order: 2, label: 'Server' } },
+  { slug: 'clients', file: 'agent-memory-clients.md', kind: 'guide', sidebar: { order: 3, label: 'Clients' } },
+  { slug: 'sync', file: 'agent-memory-sync.md', kind: 'guide', sidebar: { order: 4, label: 'Sync' } },
+  { slug: 'migration', file: 'agent-memory-migration.md', kind: 'runbook', sidebar: { order: 5, label: 'Migration' } },
+];
+const SIBLING_SLUGS = new Set(DOCS.map((d) => d.slug));
+
+// Repo-relative link targets that were themselves migrated to the docs site
+// (WP6) under a path the mechanical `agent-memory-X.md -> /docs/agent-memory/X/`
+// rule below cannot derive. SETUP.md now redirects to several site pages
+// depending on which part of it is referenced; every reference here maps to
+// the general getting-started index rather than guessing the specific one.
+const INTERNAL_LINK_MAP = {
+  'security/agent-keys.md': '/docs/how-to/provision-agent-keys/',
+  'IMPORT.md': '/docs/how-to/import-agent-memory/',
+  'RELEASE_GATES.md': '/docs/reference/release-gates/',
+  'deploy.md': '/docs/how-to/deploy-production/',
+  'SETUP.md': '/docs/getting-started/',
+};
+
+function isExternalOrSameDoc(target) {
+  return /^[a-z][a-z0-9+.-]*:/i.test(target) || target.startsWith('#');
+}
+
+function rewriteLink(target) {
+  if (isExternalOrSameDoc(target)) return target;
+
+  const [pathPart, hash = ''] = target.split('#');
+  const anchor = hash ? `#${hash}` : '';
+  const clean = pathPart.replace(/^\.\//, '');
+
+  const siblingMatch = clean.match(/^agent-memory-([a-z]+)\.md$/);
+  if (siblingMatch && SIBLING_SLUGS.has(siblingMatch[1])) {
+    return `/docs/agent-memory/${siblingMatch[1]}/${anchor}`;
+  }
+
+  if (clean in INTERNAL_LINK_MAP) return `${INTERNAL_LINK_MAP[clean]}${anchor}`;
+
+  // Fallback: anything else repo-relative (scripts, compose files, package
+  // dirs, systemd units) has no site page — link to it on GitHub instead.
+  const resolved = posix.normalize(posix.join('docs', pathPart));
+  const base = /\.[a-z0-9]+$/i.test(resolved) ? GITHUB_BLOB_BASE : GITHUB_TREE_BASE;
+  return `${base}${resolved}${anchor}`;
+}
+
+function transformLinks(body) {
+  return body.replace(/(\]\()([^)\s]+)(\))/g, (full, open, target, close) => {
+    return `${open}${rewriteLink(target)}${close}`;
+  });
+}
+
+for (const doc of DOCS) {
+  const raw = readFileSync(join(srcDir, doc.file), 'utf8');
+  const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!fmMatch) throw new Error(`gen-agent-memory-docs: ${doc.file} is missing frontmatter`);
+
+  const frontmatter = fmMatch[1];
+  const title = frontmatter.match(/^title:\s*(.+)$/m)?.[1];
+  const description = frontmatter.match(/^description:\s*(.+)$/m)?.[1]?.replace(/\.?$/, '.');
+  if (!title || !description) {
+    throw new Error(`gen-agent-memory-docs: ${doc.file} is missing title/description frontmatter`);
+  }
+
+  // The root file opens its body with its own "Also published at ..." banner
+  // and an `# H1` heading. The site derives the page title from frontmatter
+  // and needs the opposite-direction banner, so both are dropped here.
+  const openingPattern = /^\n> Also published at [^\n]*\n\n# [^\n]+\n\n/;
+  if (!openingPattern.test(raw.slice(fmMatch[0].length))) {
+    throw new Error(`gen-agent-memory-docs: ${doc.file} does not match the expected opening banner/heading shape`);
+  }
+  const body = raw.slice(fmMatch[0].length).replace(openingPattern, '');
+
+  const banner =
+    `> The canonical copy of this ${doc.kind} lives in the repository at\n` +
+    `> [\`docs/${doc.file}\`](${GITHUB_BLOB_BASE}docs/${doc.file}) —\n` +
+    `> agents read it from the repo at runtime. This page is a published mirror.\n`;
+
+  const out =
+    `---\n` +
+    `title: ${title}\n` +
+    `description: ${description}\n` +
+    `sidebar:\n` +
+    `  order: ${doc.sidebar.order}\n` +
+    `  label: ${doc.sidebar.label}\n` +
+    `---\n\n` +
+    `${banner}\n` +
+    transformLinks(body);
+
+  writeFileSync(join(outDir, `${doc.slug}.mdx`), out);
+}


### PR DESCRIPTION
## Summary
- `docs/agent-memory-{contract,clients,server,sync,migration}.md` are canonical — AGENTS.md/CLAUDE.md point agents at them by relative path at runtime, so they can't move. The `apps/docs` Starlight pages for these were a hand-maintained copy and had already drifted from the source.
- Adds `scripts/gen-agent-memory-docs.mjs`, which derives each site `.mdx` page from its root `.md` source (frontmatter + prose reused verbatim; only links that can't resolve on the site are rewritten — to a sibling site page, a curated internal-page map, or a GitHub blob/tree URL as a fallback). Wired into `docs:generate` and the CI drift gate alongside the existing MCP-tools/config generators.
- Fixes a pre-existing bad link in `docs/agent-memory-clients.md` (`packages/agent-bridge` was pointing at the contract doc) and de-personalizes the migration doc's public-facing meta description.
- Everything else previously living in root `docs/` (CAPACITY, RELEASE_GATES, concurrency-policy, security docs, SETUP, deploy, IMPORT, roadmap) was already consolidated into `apps/docs` in an earlier pass, with the root file reduced to a redirect stub — this PR closes the one remaining gap.

## Test plan
- [x] `pnpm build && pnpm docs:generate` — clean, idempotent (no diff against committed output)
- [x] `pnpm docs:check` — passes
- [x] `astro build` (production config, typedoc included) — 407 pages, `starlight-links-validator`: "All internal links are valid"
- [x] `npx eslint scripts/gen-agent-memory-docs.mjs` — clean