### PR TITLE
fix(embeddings): truncated-prefix fallback for Ollama context rejections + simplification closeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ENGRAM is a TypeScript monorepo for an MCP (Model Context Protocol) memory server. The main runtime is a NestJS app (`apps/mcp-server`) backed by PostgreSQL (with pgvector) and, on the enterprise profile, Redis. Turborepo orchestrates builds across pnpm workspaces.
+ENGRAM is a TypeScript monorepo for an MCP (Model Context Protocol) memory server. The main runtime is a NestJS app (`apps/mcp-server`) backed by PostgreSQL (with pgvector) — the only backing service in both deployment profiles (`standard`, `lite`). Turborepo orchestrates builds across pnpm workspaces.
 
 ## Commands
 
@@ -20,7 +20,7 @@ All commands run from the repository root. Use `pnpm <command>` if pnpm is insta
 ```bash
 pnpm install
 cp .env.example .env           # then edit as needed
-pnpm docker:up                 # starts PostgreSQL (pgvector), Redis
+pnpm docker:up                 # starts PostgreSQL (pgvector); optional Ollama via --profile ollama
 pnpm db:generate               # generate Prisma client
 pnpm db:migrate                # run migrations
 pnpm build
@@ -80,7 +80,7 @@ The single `Memory` Prisma model (in `prisma/schema.prisma`) serves both memory 
 
 ### Memory Tiers
 
-- **STM** (`packages/memory-stm`): Postgres-backed with TTL on database-bearing profiles — `PostgresStmAdapter` stores rows in the shared `memories` table (`type='short-term'`, `expiresAt`; expiry filtered on read + swept by `StmSweepService`, `STM_SWEEP_INTERVAL_MS`). Profile-memory uses the in-process `InMemoryStmAdapter`. Both bind to `STM_PROVIDER` and the `MemoryStmService` class token.
+- **STM** (`packages/memory-stm`): Postgres-backed with TTL — `PostgresStmAdapter` stores rows in the shared `memories` table (`type='short-term'`, `expiresAt`; expiry filtered on read + swept by `StmSweepService`, `STM_SWEEP_INTERVAL_MS`). Consumers inject it via the `STM_PROVIDER` token.
 - **LTM** (`packages/memory-ltm`): Postgres-backed via Prisma. `MemoryLtmService` handles create/read/update/delete and cursor-resumable `reindex()` for rebuilding vector embeddings.
 
 ### Vector Storage (`packages/vector-store`)
@@ -97,7 +97,7 @@ Each tool exports: a strict Zod input schema, a typed handler function, and a to
 
 ### NestJS Module Wiring (`apps/mcp-server/src/app.module.ts`)
 
-Root imports: `ConfigModule` (global, validates env via `@engram/config`), `LoggingModule`, `McpModule`, `PrismaModule` (global), `RedisModule` (enterprise), `HealthModule`, `MemoryModule`.
+Root imports: `ConfigModule` (global, validates env via `@engram/config`), `LoggingModule`, `McpModule`, `PrismaModule` (global), `AuthModule` (multi-tenant stack gated on profile), `HealthModule`, `MemoryModule`.
 
 ### Reindex / Backfill
 
@@ -124,7 +124,6 @@ Key variables (full list in `.env.example`):
 | Variable                      | Purpose                                              |
 | ----------------------------- | ---------------------------------------------------- |
 | `DATABASE_URL`                | PostgreSQL connection string                         |
-| `REDIS_URL`                   | Redis connection string                              |
 | `EMBEDDING_PROVIDER`          | `ollama` (default), `openai`, `local`, or `disabled` |
 | `EMBEDDING_MODEL`             | Model id; defaults per provider (`nomic-embed-text`) |
 | `OLLAMA_URL`                  | Ollama server URL (default `http://localhost:11434`) |

--- a/docs/plans/2026-07-arch-simplification/STATE.md
+++ b/docs/plans/2026-07-arch-simplification/STATE.md
@@ -19,3 +19,7 @@ Read PLAN.md first. Update this file in every WP PR.
 
 - 2026-07-19: profile names `lite` + `standard` (default). Redis+Qdrant
   removed from all profiles. Embedding cache deleted (was inert — DI bug).
+- 2026-07-19: Ollama context-length rejections degrade to a truncated-prefix
+  embedding (provider retries at 1/2 then 1/4 of the text) — long memories
+  were previously silently unindexable with nomic-embed-text's 2048-token
+  GGUF context.

--- a/packages/embeddings/src/providers/ollama-embedding.provider.spec.ts
+++ b/packages/embeddings/src/providers/ollama-embedding.provider.spec.ts
@@ -8,6 +8,7 @@ function mockFetchResponse(body: unknown, ok = true, status = 200): Response {
     ok,
     status,
     json: async () => body,
+    text: async () => JSON.stringify(body),
   } as unknown as Response;
 }
 
@@ -39,6 +40,7 @@ describe('OllamaEmbeddingProvider', () => {
     expect(JSON.parse(init.body as string)).toEqual({
       model: 'nomic-embed-text',
       input: 'hello world',
+      truncate: true,
     });
   });
 
@@ -57,6 +59,52 @@ describe('OllamaEmbeddingProvider', () => {
     const provider = new OllamaEmbeddingProvider();
 
     expect(await provider.generate('hi', 'missing-model')).toBeNull();
+  });
+
+  it('retries a context-length rejection with a halved input and flags truncation', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockFetchResponse({ error: 'the input length exceeds the context length' }, false, 500)
+      )
+      .mockResolvedValueOnce(mockFetchResponse({ embeddings: [VECTOR_768] }));
+    const provider = new OllamaEmbeddingProvider();
+    const text = 'x'.repeat(6000);
+
+    const result = await provider.generate(text, 'nomic-embed-text');
+
+    expect(result).toEqual(VECTOR_768);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse((fetchMock.mock.calls[1]![1] as RequestInit).body as string) as {
+      input: string;
+      truncate: boolean;
+    };
+    expect(secondBody.input.length).toBe(3000);
+    expect(secondBody.truncate).toBe(true);
+  });
+
+  it('gives up on persistent context-length rejections', async () => {
+    fetchMock.mockResolvedValue(
+      mockFetchResponse({ error: 'the input length exceeds the context length' }, false, 500)
+    );
+    const provider = new OllamaEmbeddingProvider();
+
+    const result = await provider.generate('x'.repeat(8000), 'nomic-embed-text');
+
+    expect(result).toBeNull();
+    // full → 1/2 → 1/4, then stop.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry below the minimum useful prefix', async () => {
+    fetchMock.mockResolvedValue(
+      mockFetchResponse({ error: 'the input length exceeds the context length' }, false, 500)
+    );
+    const provider = new OllamaEmbeddingProvider();
+
+    const result = await provider.generate('x'.repeat(1500), 'nomic-embed-text');
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns null on network errors', async () => {

--- a/packages/embeddings/src/providers/ollama-embedding.provider.spec.ts
+++ b/packages/embeddings/src/providers/ollama-embedding.provider.spec.ts
@@ -88,11 +88,18 @@ describe('OllamaEmbeddingProvider', () => {
     );
     const provider = new OllamaEmbeddingProvider();
 
+    const warnSpy = vi
+      .spyOn((provider as unknown as { logger: { warn: (msg: string) => void } }).logger, 'warn')
+      .mockImplementation(() => {});
     const result = await provider.generate('x'.repeat(8000), 'nomic-embed-text');
 
     expect(result).toBeNull();
     // full → 1/2 → 1/4, then stop.
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    // Degradation contract: giving up must not be silent.
+    expect(
+      warnSpy.mock.calls.some((call) => String(call[0]).includes('context_length_give_up'))
+    ).toBe(true);
   });
 
   it('does not retry below the minimum useful prefix', async () => {

--- a/packages/embeddings/src/providers/ollama-embedding.provider.ts
+++ b/packages/embeddings/src/providers/ollama-embedding.provider.ts
@@ -4,12 +4,23 @@ import type { EmbeddingProvider } from './embedding-provider.interface.js';
 
 const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
 const OLLAMA_TIMEOUT_MS = 30_000;
+/** Shortest prefix worth embedding when retrying an over-long input. */
+const MIN_TRUNCATED_CHARS = 1_000;
+/** Halving retries for context-length rejections (full → 1/2 → 1/4). */
+const MAX_TRUNCATION_RETRIES = 2;
 
 /**
  * Embedding provider backed by a local Ollama server (default provider).
  * Talks to the native `/api/embed` endpoint via fetch — no SDK dependency.
  * Follows the degradation contract: every failure returns null with a
  * warning so memory workflows continue without a vector.
+ *
+ * Context-length degradation: some embedding GGUFs (e.g. nomic-embed-text)
+ * are packaged with a trained context smaller than our character-based input
+ * cap, and Ollama rejects over-long inputs even with `truncate` set. A
+ * truncated-content embedding is far better for recall than none, so a
+ * context-length rejection retries with the first half, then the first
+ * quarter, of the text before giving up.
  */
 @Injectable()
 export class OllamaEmbeddingProvider implements EmbeddingProvider {
@@ -21,6 +32,39 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
   }
 
   async generate(text: string, model: EmbeddingModel): Promise<number[] | null> {
+    let input = text;
+    for (let attempt = 0; attempt <= MAX_TRUNCATION_RETRIES; attempt += 1) {
+      const outcome = await this.requestEmbedding(input, model);
+      if (outcome.kind === 'ok') {
+        if (attempt > 0) {
+          this.logger.warn(
+            JSON.stringify({
+              event: 'embedding.provider.ollama.truncated_input',
+              model,
+              originalChars: text.length,
+              embeddedChars: input.length,
+              hint: 'Input exceeded the model context; embedded a prefix instead.',
+            })
+          );
+        }
+        return outcome.vector;
+      }
+      if (outcome.kind !== 'context_length') {
+        return null;
+      }
+      const next = Math.floor(input.length / 2);
+      if (next < MIN_TRUNCATED_CHARS) {
+        return null;
+      }
+      input = input.slice(0, next);
+    }
+    return null;
+  }
+
+  private async requestEmbedding(
+    text: string,
+    model: EmbeddingModel
+  ): Promise<{ kind: 'ok'; vector: number[] } | { kind: 'context_length' } | { kind: 'error' }> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), OLLAMA_TIMEOUT_MS);
 
@@ -28,11 +72,15 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
       const response = await fetch(`${this.baseUrl}/api/embed`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ model, input: text }),
+        body: JSON.stringify({ model, input: text, truncate: true }),
         signal: controller.signal,
       });
 
       if (!response.ok) {
+        const errorBody = await response.text().catch(() => '');
+        if (/context length/i.test(errorBody)) {
+          return { kind: 'context_length' };
+        }
         this.logger.warn(
           JSON.stringify({
             event: 'embedding.provider.ollama.http_error',
@@ -44,7 +92,7 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
                 : undefined,
           })
         );
-        return null;
+        return { kind: 'error' };
       }
 
       const body = (await response.json()) as { embeddings?: unknown };
@@ -57,10 +105,10 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
         this.logger.warn(
           JSON.stringify({ event: 'embedding.provider.ollama.malformed_response', model })
         );
-        return null;
+        return { kind: 'error' };
       }
 
-      return first as number[];
+      return { kind: 'ok', vector: first as number[] };
     } catch (err) {
       const timedOut = err instanceof Error && err.name === 'AbortError';
       this.logger.warn(
@@ -74,7 +122,7 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
           hint: timedOut ? undefined : `Is Ollama running at ${this.baseUrl}?`,
         })
       );
-      return null;
+      return { kind: 'error' };
     } finally {
       clearTimeout(timer);
     }

--- a/packages/embeddings/src/providers/ollama-embedding.provider.ts
+++ b/packages/embeddings/src/providers/ollama-embedding.provider.ts
@@ -54,11 +54,30 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
       }
       const next = Math.floor(input.length / 2);
       if (next < MIN_TRUNCATED_CHARS) {
+        this.warnContextGiveUp(model, text.length, input.length);
         return null;
       }
       input = input.slice(0, next);
     }
+    this.warnContextGiveUp(model, text.length, input.length);
     return null;
+  }
+
+  /** Degradation contract: every failure path logs a warning. */
+  private warnContextGiveUp(
+    model: EmbeddingModel,
+    originalChars: number,
+    lastAttemptChars: number
+  ): void {
+    this.logger.warn(
+      JSON.stringify({
+        event: 'embedding.provider.ollama.context_length_give_up',
+        model,
+        originalChars,
+        lastAttemptChars,
+        hint: 'Input exceeds the model context even after truncation retries; no vector produced.',
+      })
+    );
   }
 
   private async requestEmbedding(


### PR DESCRIPTION
## Summary

Closes out the architecture simplification (`docs/plans/2026-07-arch-simplification/`).

- **Ollama context-length degradation** (found migrating the local deployment in WP5): the packaged `nomic-embed-text` GGUF has a 2048-token trained context and Ollama 0.23 rejects longer inputs even with `truncate: true`, so long memories silently got **no vector** and were invisible to semantic recall (pre-existing — predates the simplification). The provider now detects the rejection and retries with the first half, then first quarter, of the text (floor 1,000 chars), logging a `truncated_input` warning.
- **CLAUDE.md residuals**: last Redis mentions removed (stack line, docker:up, module wiring, env table, STM tier description).
- **STATE.md closeout**: WP4 merged (#274); WP5 done — the port-3100 systemd service runs `standard` profile on Postgres alone, fully reindexed at 768 dims.

## Test plan

- `pnpm build` / `typecheck` / `lint` / `test` (29/29) / `docs:check` green
- New provider specs: retry-with-halved-input (asserts body + truncate flag), persistent-rejection gives up after 3 attempts, no retry below the minimum prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)