### PR TITLE
feat(onboarding): one-command installer + user-friendly README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,243 +1,68 @@
 ---
 title: ENGRAM
-description: Developer setup and project entry points for the ENGRAM MCP memory server
+description: Durable, searchable long-term memory for AI agents, over the Model Context Protocol (MCP).
 ---
 
-## Overview
+# ENGRAM
 
-ENGRAM is a TypeScript monorepo for an MCP memory server. The main runtime is a
-NestJS app that connects to PostgreSQL (with the pgvector extension) for agent
-memory, semantic search, and health checks. Postgres is the only backing
-service — vectors, short-term memory, auth sessions, and rate limits all live
-there.
+**Give your AI agents a memory that outlives a single chat — over the [Model Context Protocol](https://modelcontextprotocol.io).**
 
-## Prerequisites
+ENGRAM is a memory server for Claude and any other MCP-compatible assistant. It
+remembers facts, decisions, and context across sessions and hands the right ones
+back on demand — so your agents stop re-learning what they already knew.
 
-- Node.js 20 or newer with npm
-- Git
-- Optional: pnpm 11.5.0 on your `PATH`
-- Optional: Docker and Docker Compose v2 (to run the bundled PostgreSQL
-  container — image `pgvector/pgvector:pg16+`)
+- 🧠 **Remembers across sessions** — short-term and long-term memory, with automatic promotion and expiry.
+- 🔎 **Semantic recall** — hybrid keyword + vector search surfaces the memory that matters, not just exact matches.
+- 🔌 **Works with your tools** — Claude Desktop, Claude Code, and any MCP client get a `remember` / `recall` tool set that just works.
+- 📦 **One dependency** — PostgreSQL (with pgvector). No Redis, no separate vector database.
+- 🔒 **Private by default** — runs on your machine; embeddings come from a local Ollama model, no API keys required.
 
-ENGRAM pins `pnpm@11.5.0` in [package.json](package.json). The quick start
-uses npm to run that pinned pnpm version, so it works even when `pnpm` is not
-installed globally.
+## Quick start
 
-## Choose Your Profile
-
-ENGRAM ships two deployment profiles. Both run on Postgres alone — the same
-storage, vectors (pgvector), and durability — and both expose the full MCP tool
-set, including the queued reindex / cancel / retry maintenance tools. The MCP
-server reads `DEPLOYMENT_PROFILE` to decide which modules, health checks, and
-tools to expose; when it is unset, `standard` is the default.
-
-| Profile    | Default | Tenancy                                                   | Backing services      |
-| ---------- | ------- | --------------------------------------------------------- | --------------------- |
-| `lite`     | No      | Single user — auth/organization stack not wired           | PostgreSQL (pgvector) |
-| `standard` | Yes     | Multi-tenant — auth, API keys, organizations, rate limits | PostgreSQL (pgvector) |
-
-The legacy value `enterprise` is accepted as an alias for `standard`; the old
-`memory` profile was removed (every profile now runs on Postgres).
-
-The full MCP surface is defined in
-[apps/mcp-server/src/memory/tools-manifest.ts](apps/mcp-server/src/memory/tools-manifest.ts)
-(the single source of truth for the tool registry). Both profiles expose the
-same tools — memory CRUD, promotion, hybrid recall, the
-`remember`/`forget`/`reflect`/`compress_context` helpers, and the reindex /
-queue / cancel / retry maintenance tools (admin tools additionally require
-`MCP_ADMIN_TOKEN`).
-
-### lite — single-user local
-
-Postgres-backed single-user profile. Same durable storage as `standard`, but
-the multi-tenant auth/organization stack is not wired, so there is no login or
-API-key surface to configure. Best for a personal machine running a local
-memory server.
+You need [Node.js 20+](https://nodejs.org) and [Docker](https://docs.docker.com/get-docker/) (for the bundled PostgreSQL).
 
 ```bash
-npm exec --yes pnpm@11.5.0 -- install
-test -f .env || cp .env.example .env
-npm exec --yes pnpm@11.5.0 -- docker:up
-npm exec --yes pnpm@11.5.0 -- db:generate
-npm exec --yes pnpm@11.5.0 -- db:migrate
-DEPLOYMENT_PROFILE=lite npm exec --yes pnpm@11.5.0 -- build
-DEPLOYMENT_PROFILE=lite npm exec --yes pnpm@11.5.0 -- --filter mcp-server dev
+git clone https://github.com/osirison/engram.git
+cd engram
+./scripts/install.sh --start
 ```
 
-The MCP server starts on `http://localhost:3000`. Check it with:
+That's it. The installer sets everything up and starts a memory server on
+**http://localhost:3000**. Prefer to launch it yourself? Drop `--start` and run
+the command it prints when it's done.
+
+Check that it's alive:
 
 ```bash
 curl http://localhost:3000/health
 ```
 
-### standard — default multi-tenant
+> Want the multi-tenant setup (auth, API keys, per-agent access)? Run
+> `./scripts/install.sh --standard` instead. Both profiles run on Postgres
+> alone — see the [developer guide](docs/SETUP.md).
 
-The default when `DEPLOYMENT_PROFILE` is unset. Adds the multi-tenant auth
-stack — JWT sessions, per-agent API keys, organizations, and Postgres-backed
-rate limiting — on top of the same Postgres storage. Best for shared or
-production deployments.
+## Connect your AI assistant
 
-```bash
-npm exec --yes pnpm@11.5.0 -- install
-test -f .env || cp .env.example .env
-npm exec --yes pnpm@11.5.0 -- docker:up
-npm exec --yes pnpm@11.5.0 -- db:generate
-npm exec --yes pnpm@11.5.0 -- db:migrate
-npm exec --yes pnpm@11.5.0 -- build
-npm exec --yes pnpm@11.5.0 -- --filter mcp-server dev
-```
+Point Claude Desktop or Claude Code at the running server, then ask it to call
+the `ping` tool to confirm the connection. The short walkthrough — including the
+ready-made config file — is in
+[the MCP client setup guide](docs/SETUP.md#mcp-client-setup).
 
-The MCP server starts on `http://localhost:3000` by default. Check it with:
+## What can it do?
 
-```bash
-curl http://localhost:3000/health
-```
+Once connected, your assistant gains a memory tool set: `remember` and `recall`
+for everyday use, plus full memory CRUD, hybrid semantic + keyword search,
+short-term ↔ long-term promotion, and admin maintenance tools. Poke at every
+tool live with the [MCP Inspector](docs/SETUP.md#mcp-inspector).
 
-To stop local infrastructure without deleting data:
+## Learn more
 
-```bash
-npm exec --yes pnpm@11.5.0 -- docker:down
-```
+| I want to…                                        | Go to                                                          |
+| ------------------------------------------------- | -------------------------------------------------------------- |
+| Install, run, and configure ENGRAM in depth       | [Developer guide](docs/SETUP.md)                               |
+| Browse the full documentation                     | [engram.events/docs](https://engram.events/docs/)              |
+| Get started on the docs site                      | [Getting started](https://engram.events/docs/getting-started/) |
+| Use ENGRAM as shared memory for a fleet of agents | [Agent memory contract](docs/agent-memory-contract.md)         |
+| Contribute to ENGRAM                              | [AGENTS.md](AGENTS.md)                                         |
 
-To remove containers and local volumes:
-
-```bash
-npm exec --yes pnpm@11.5.0 -- docker:clean
-```
-
-After installing pnpm globally, you can use the shorter `pnpm <command>` form
-shown in the command table below. Detailed setup, profile selection, and
-profile-to-profile migration runbook live in [docs/SETUP.md](docs/SETUP.md).
-Release SLO and quality gates live in [docs/RELEASE_GATES.md](docs/RELEASE_GATES.md).
-
-## Common Commands
-
-| Task                                   | Command                        |
-| -------------------------------------- | ------------------------------ |
-| Start PostgreSQL (pgvector), then wait | `pnpm docker:up`               |
-| Start full Inspector stack             | `pnpm docker:inspector:up`     |
-| Stop full Inspector stack              | `pnpm docker:inspector:down`   |
-| Tail Inspector stack logs              | `pnpm docker:inspector:logs`   |
-| Start the MCP server                   | `pnpm --filter mcp-server dev` |
-| Start the web app                      | `pnpm --filter web dev`        |
-| Start the docs app                     | `pnpm --filter docs dev`       |
-| Generate Prisma client                 | `pnpm db:generate`             |
-| Run Prisma migrations                  | `pnpm db:migrate`              |
-| Open Prisma Studio                     | `pnpm db:studio`               |
-| Build all workspaces                   | `pnpm build`                   |
-| Lint all workspaces                    | `pnpm lint`                    |
-| Type-check all workspaces              | `pnpm typecheck`               |
-| Test all workspaces                    | `pnpm test`                    |
-| Check documentation links              | `pnpm docs:check`              |
-| Format source files                    | `pnpm format`                  |
-
-## Project Layout
-
-| Path                                                             | Purpose                                      |
-| ---------------------------------------------------------------- | -------------------------------------------- |
-| [apps/mcp-server](apps/mcp-server)                               | Main NestJS MCP server                       |
-| [apps/web](apps/web)                                             | Web application workspace                    |
-| [apps/docs](apps/docs)                                           | Documentation application workspace          |
-| [apps/vscode-copilot-compressor](apps/vscode-copilot-compressor) | VS Code chat compression extension workspace |
-| [packages/core](packages/core)                                   | Core MCP types, registry, and tools          |
-| [packages/config](packages/config)                               | Environment validation and types             |
-| [packages/database](packages/database)                           | Prisma database module                       |
-| [packages/vector-store](packages/vector-store)                   | pgvector vector store module                 |
-| [packages/embeddings](packages/embeddings)                       | Embedding generation and caching             |
-| [packages/memory-stm](packages/memory-stm)                       | Short-term memory package                    |
-| [packages/memory-ltm](packages/memory-ltm)                       | Long-term memory package                     |
-| [packages/ui](packages/ui)                                       | Shared React components                      |
-| [prisma](prisma)                                                 | Prisma schema and migrations                 |
-| [docker](docker)                                                 | Local infrastructure initialization          |
-
-## More Information
-
-| Topic                                     | Link                                                                                 |
-| ----------------------------------------- | ------------------------------------------------------------------------------------ |
-| Detailed local setup and MCP client setup | [docs/SETUP.md](docs/SETUP.md)                                                       |
-| Release SLOs and quality gates            | [docs/RELEASE_GATES.md](docs/RELEASE_GATES.md)                                       |
-| Current roadmap                           | [docs/roadmap.md](docs/roadmap.md)                                                   |
-| Marketing site domain/TLS runbook         | [docs/MARKETING_SITE_DOMAIN.md](docs/MARKETING_SITE_DOMAIN.md)                       |
-| MCP server details                        | [apps/mcp-server/README.md](apps/mcp-server/README.md)                               |
-| Web app details                           | [apps/web/README.md](apps/web/README.md)                                             |
-| Docs app details                          | [apps/docs/README.md](apps/docs/README.md)                                           |
-| VS Code compressor extension              | [apps/vscode-copilot-compressor/README.md](apps/vscode-copilot-compressor/README.md) |
-| MCP tool development                      | [packages/core/src/mcp/tools/README.md](packages/core/src/mcp/tools/README.md)       |
-| Database package                          | [packages/database/README.md](packages/database/README.md)                           |
-| Database usage examples                   | [packages/database/USAGE.md](packages/database/USAGE.md)                             |
-| Embeddings package                        | [packages/embeddings/README.md](packages/embeddings/README.md)                       |
-| Agent and contributor instructions        | [AGENTS.md](AGENTS.md)                                                               |
-
-## Environment
-
-Local defaults live in [.env.example](.env.example). Docker Compose uses these
-host port settings by default:
-
-| Service           | Host port setting                   | Purpose                                            |
-| ----------------- | ----------------------------------- | -------------------------------------------------- |
-| PostgreSQL        | `POSTGRES_PORT`, defaults to `5432` | Primary datastore (memories, vectors, auth state)  |
-| Ollama (optional) | `OLLAMA_PORT`, defaults to `11434`  | Local embeddings (`--profile ollama` compose flag) |
-
-When a host port is already in use, update the matching port value and URL in
-`.env` before starting Docker. For PostgreSQL, change both `POSTGRES_PORT` and
-the port inside `DATABASE_URL`.
-
-## MCP Client Setup
-
-Build the server before connecting it to an MCP client:
-
-```bash
-npm exec --yes pnpm@11.5.0 -- build
-```
-
-Then copy [claude_desktop_config.json.example](claude_desktop_config.json.example)
-to your MCP client configuration location and update the absolute path to
-`apps/mcp-server/dist/main.js`. See [docs/SETUP.md](docs/SETUP.md) for the full
-client setup flow.
-
-## MCP Inspector
-
-The MCP Inspector has no official Docker image on GHCR — running
-`docker run ghcr.io/modelcontextprotocol/inspector:latest` will fail with a
-registry error. Use one of the two approaches below instead.
-
-### Option A — host-run (simplest)
-
-With the MCP server already running on `http://localhost:3000`, start the
-inspector in a separate terminal:
-
-```bash
-npm exec --yes pnpm@11.5.0 -- inspector
-```
-
-Then open:
-
-```text
-http://localhost:6274/?transport=streamable-http&serverUrl=http%3A%2F%2Flocalhost%3A3000%2Fmcp
-```
-
-Port 6274 is the Inspector UI and port 6277 is the proxy. If either port is
-already in use (e.g. from a previous run), kill the stale process before
-restarting.
-
-### Option B — Docker (inspector in a container)
-
-First ensure the base infrastructure is up (`pnpm docker:up`) and the MCP
-server is running on the host. Then start the Inspector container:
-
-```bash
-npm exec --yes pnpm@11.5.0 -- docker:inspector:up
-```
-
-The container reaches the host-side MCP server via `host.docker.internal`.
-Open the Inspector UI at:
-
-```text
-http://localhost:6274/?transport=streamable-http&serverUrl=http%3A%2F%2Fhost.docker.internal%3A3000%2Fmcp
-```
-
-Stop the container with:
-
-```bash
-npm exec --yes pnpm@11.5.0 -- docker:inspector:down
-```
+Licensed under the terms in [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ back on demand — so your agents stop re-learning what they already knew.
 
 ## Quick start
 
-You need [Node.js 20+](https://nodejs.org) and [Docker](https://docs.docker.com/get-docker/) (for the bundled PostgreSQL).
+You need [Node.js 22.13.0+](https://nodejs.org) and [Docker](https://docs.docker.com/get-docker/) (for the bundled PostgreSQL).
 
 ```bash
 git clone https://github.com/osirison/engram.git

--- a/apps/docs/src/content/docs/getting-started/first-memory.mdx
+++ b/apps/docs/src/content/docs/getting-started/first-memory.mdx
@@ -95,7 +95,7 @@ this is enforced.
 Start the server with the HTTP transport:
 
 ```bash
-DEPLOYMENT_PROFILE=memory \
+DEPLOYMENT_PROFILE=lite \
 MCP_TRANSPORT=streamable-http \
   pnpm --filter mcp-server dev
 ```
@@ -139,8 +139,8 @@ curl -sS \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"recall","arguments":{"userId":"qp","query":"what is the source of truth?"}}}'
 ```
 
-> The `memory` profile is single-user, so it serves HTTP without an auth gate.
-> A multi-tenant (`enterprise`) Streamable HTTP server refuses to start without
+> The `lite` profile is single-user, so it serves HTTP without an auth gate.
+> A multi-tenant (`standard`) Streamable HTTP server refuses to start without
 > `AUTH_REQUIRED=true` (or an explicit `ALLOW_UNAUTHENTICATED_HTTP=true`); on
 > an authenticated server, add an `Authorization: Bearer <api-key>` header to
 > every request — see

--- a/apps/docs/src/content/docs/getting-started/index.mdx
+++ b/apps/docs/src/content/docs/getting-started/index.mdx
@@ -35,10 +35,10 @@ The legacy value `enterprise` is an accepted alias for `standard`. The old
 
 ## Prerequisites (both profiles)
 
-- Node.js 20 or newer with npm
+- Node.js 22.13.0 or newer with npm
 - Git
 - Docker and Docker Compose v2 — to run the bundled PostgreSQL container
-  (image `pgvector/pgvector:pg16+`). Or point `DATABASE_URL` at your own Postgres
+  (image `pgvector/pgvector:pg17`). Or point `DATABASE_URL` at your own Postgres
   with the `pgvector` extension.
 - Optional: pnpm on your `PATH` (the repository pins `pnpm@11.5.0`)
 

--- a/apps/docs/src/content/docs/getting-started/index.mdx
+++ b/apps/docs/src/content/docs/getting-started/index.mdx
@@ -6,38 +6,41 @@ sidebar:
   label: Overview
 ---
 
-Engram runs in one of three deployment profiles, selected by the
-`DEPLOYMENT_PROFILE` environment variable. Pick the profile that matches the
-durability, scale, and infrastructure you want, then follow the matching
-tutorial.
+Engram runs in one of two deployment profiles, selected by the
+`DEPLOYMENT_PROFILE` environment variable. Both run on **PostgreSQL alone**
+(pgvector included) — pick the one that matches whether you need multi-tenant
+auth, then follow the matching tutorial.
 
-| Profile              | `DEPLOYMENT_PROFILE` | External dependencies     | Use it for                                         |
-| -------------------- | -------------------- | ------------------------- | -------------------------------------------------- |
-| Memory               | `memory`             | None                      | Demos, CI smoke tests, exploring the MCP surface   |
-| Lite                 | `lite`               | Postgres only             | Single-host deployments needing at-rest encryption |
-| Enterprise (default) | `enterprise`         | Postgres + Redis + Qdrant | Production, cluster scale, queued reindex          |
+| Profile              | `DEPLOYMENT_PROFILE` | External dependencies | Use it for                                                |
+| -------------------- | -------------------- | --------------------- | --------------------------------------------------------- |
+| Lite                 | `lite`               | Postgres only         | A personal, single-user local memory server               |
+| Standard (default)   | `standard`           | Postgres only         | Shared or production deployments — auth, API keys, tenancy |
+
+The legacy value `enterprise` is an accepted alias for `standard`. The old
+`memory` profile was removed — every profile now runs on Postgres.
 
 ## Which page do I want?
 
-- **[Quick start](/docs/getting-started/quick-start/)** — the `memory` profile:
-  zero external services, three commands to a running MCP server. Start here if
-  you just want to try Engram.
-- **[Installation](/docs/getting-started/installation/)** — the full
-  `enterprise` profile setup (Postgres + Redis + Qdrant via Docker Compose),
-  plus the `lite` profile variant with an encrypted local store.
+- **[Quick start](/docs/getting-started/quick-start/)** — the fastest path: one
+  command sets up the `lite` profile and starts a running MCP server. Start here
+  if you just want to try Engram.
+- **[Installation](/docs/getting-started/installation/)** — manual setup for both
+  the `lite` and `standard` profiles, plus the command and infrastructure
+  reference.
 - **[Store your first memory](/docs/getting-started/first-memory/)** — call
   `create_memory`, `recall`, and `get_memory` end-to-end against a running
   server.
 - **[MCP client setup](/docs/getting-started/mcp-client-setup/)** — connect
   Claude Desktop or Claude Code to your server.
 
-## Prerequisites (all profiles)
+## Prerequisites (both profiles)
 
 - Node.js 20 or newer with npm
 - Git
+- Docker and Docker Compose v2 — to run the bundled PostgreSQL container
+  (image `pgvector/pgvector:pg16+`). Or point `DATABASE_URL` at your own Postgres
+  with the `pgvector` extension.
 - Optional: pnpm on your `PATH` (the repository pins `pnpm@11.5.0`)
-- Optional: Docker and Docker Compose v2 (only for the `enterprise` profile)
-- Optional: `openssl` (to generate `LOCAL_ENCRYPTION_KEY` for the `lite` profile)
 
 When `pnpm` is not installed, replace the leading `pnpm` in any command with
 `npm exec --yes pnpm@11.5.0 --`. For example:

--- a/apps/docs/src/content/docs/getting-started/installation.mdx
+++ b/apps/docs/src/content/docs/getting-started/installation.mdx
@@ -1,32 +1,34 @@
 ---
 title: Installation
-description: Full Engram setup for the enterprise profile (Postgres + Redis + Qdrant) and the lite profile (encrypted local store over Postgres).
+description: Full Engram setup for the standard (multi-tenant) and lite (single-user) profiles — both on PostgreSQL with pgvector.
 sidebar:
   order: 3
 ---
 
-This tutorial sets up the two persistent profiles. The `enterprise` profile is
-the default and the primary production target; the `lite` profile is a leaner
-single-host variant. For the zero-dependency `memory` profile, see the
+This tutorial sets up the two deployment profiles by hand. **Both run on
+PostgreSQL alone** (pgvector included); they differ only in whether the
+multi-tenant auth stack is wired. For the one-command path, see the
 [quick start](/docs/getting-started/quick-start/).
 
 All commands run from the repository root. If `pnpm` is not on your `PATH`,
 replace the leading `pnpm` with `npm exec --yes pnpm@11.5.0 --`.
 
-## Enterprise profile
+## Standard profile (default)
 
-The Enterprise profile uses Postgres, Redis, and Qdrant. Hybrid
-lexical + semantic retrieval is enabled out of the box, and the full
-reindex / queue / cancel / retry maintenance tool set is exposed.
+The `standard` profile is the default and the primary production target. It adds
+JWT sessions, per-agent API keys, organizations, and Postgres-backed rate
+limiting on top of the shared storage. Hybrid lexical + semantic retrieval is
+enabled out of the box, and the full reindex / queue / cancel / retry maintenance
+tool set is exposed.
 
 ```bash
 pnpm install
 test -f .env || cp .env.example .env
-DEPLOYMENT_PROFILE=enterprise pnpm docker:up
-DEPLOYMENT_PROFILE=enterprise pnpm db:generate
-DEPLOYMENT_PROFILE=enterprise pnpm db:migrate
-DEPLOYMENT_PROFILE=enterprise pnpm build
-DEPLOYMENT_PROFILE=enterprise pnpm --filter mcp-server dev
+pnpm docker:up
+pnpm db:generate
+pnpm db:migrate:deploy
+pnpm build
+pnpm --filter mcp-server dev
 ```
 
 Open a second terminal and verify the server:
@@ -35,15 +37,36 @@ Open a second terminal and verify the server:
 curl http://localhost:3000/health
 ```
 
-The health response should report `ok` when PostgreSQL, Redis, and Qdrant are
-ready.
+The health response reports `ok` when the process and PostgreSQL are ready.
 
-### Embeddings (local by default)
+## Lite profile (single-user)
+
+The `lite` profile is a single-user variant with the same durable Postgres
+storage as `standard`, minus the auth/organization stack — there is no login or
+API-key surface to configure. Set `DEPLOYMENT_PROFILE=lite` on the build and dev
+commands:
+
+```bash
+pnpm install
+test -f .env || cp .env.example .env
+pnpm docker:up
+pnpm db:generate
+pnpm db:migrate:deploy
+DEPLOYMENT_PROFILE=lite pnpm build
+DEPLOYMENT_PROFILE=lite pnpm --filter mcp-server dev
+```
+
+Moving a `lite` deployment up to `standard` later needs no data migration — both
+use the same Postgres tables. Switch the profile and provide the auth
+configuration (`AUTH_REQUIRED`, `JWT_SECRET`, API keys); see
+[MCP client setup](/docs/getting-started/mcp-client-setup/).
+
+## Embeddings (local by default)
 
 Semantic recall needs an embedding provider; the default is **Ollama**
-(`EMBEDDING_PROVIDER=ollama`) — local, no API key. Either install Ollama on
-the host ([ollama.com/download](https://ollama.com/download)) and pull the
-default model:
+(`EMBEDDING_PROVIDER=ollama`) — local, no API key. Either install Ollama on the
+host ([ollama.com/download](https://ollama.com/download)) and pull the default
+model:
 
 ```bash
 ollama pull nomic-embed-text
@@ -56,12 +79,12 @@ docker compose --profile ollama up -d
 docker compose exec ollama ollama pull nomic-embed-text
 ```
 
-To use OpenAI instead, set `EMBEDDING_PROVIDER=openai` and `OPENAI_API_KEY`
-in `.env`. Without a reachable provider, writes still succeed — memories are
-stored without vectors and backfilled by a later reindex
+To use OpenAI instead, set `EMBEDDING_PROVIDER=openai` and `OPENAI_API_KEY` in
+`.env`. Without a reachable provider, writes still succeed — memories are stored
+without vectors and backfilled by a later reindex
 ([Configure embeddings](/docs/how-to/configure-embeddings/)).
 
-### Start specific workspaces
+## Start specific workspaces
 
 Run one workspace at a time during local development.
 
@@ -74,9 +97,9 @@ Run one workspace at a time during local development.
 The MCP server and web app both use port `3000` by default, so do not run those
 two commands at the same time unless you change `PORT` for one of them.
 
-### Local infrastructure
+## Local infrastructure
 
-Docker Compose starts the backing services used by the MCP server.
+Docker Compose starts the PostgreSQL container used by the MCP server.
 
 | Task                          | Command               |
 | ----------------------------- | --------------------- |
@@ -89,116 +112,51 @@ Docker Compose starts the backing services used by the MCP server.
 
 Default host ports:
 
-| Service     | Environment setting | Default |
-| ----------- | ------------------- | ------- |
-| PostgreSQL  | `POSTGRES_PORT`     | `5432`  |
-| Redis       | `REDIS_PORT`        | `6379`  |
-| Qdrant HTTP | `QDRANT_HTTP_PORT`  | `6333`  |
-| Qdrant gRPC | `QDRANT_GRPC_PORT`  | `6334`  |
+| Service           | Environment setting | Default |
+| ----------------- | ------------------- | ------- |
+| PostgreSQL        | `POSTGRES_PORT`     | `5432`  |
+| Ollama (optional) | `OLLAMA_PORT`       | `11434` |
 
 If Docker reports that a port is already allocated, edit `.env` before starting
 services. Keep each service URL aligned with the host port. For example,
 `POSTGRES_PORT=5433` also needs `DATABASE_URL` to use `localhost:5433`.
 
-### Database commands
+## Database commands
 
 | Task                                   | Command                  |
 | -------------------------------------- | ------------------------ |
 | Generate Prisma client                 | `pnpm db:generate`       |
+| Deploy migrations (unattended)         | `pnpm db:migrate:deploy` |
 | Create and run a development migration | `pnpm db:migrate`        |
-| Deploy migrations                      | `pnpm db:migrate:deploy` |
 | Push schema without a migration        | `pnpm db:push`           |
 | Reset the local database               | `pnpm db:reset`          |
 | Open Prisma Studio                     | `pnpm db:studio`         |
 
-Use `pnpm db:migrate` for schema changes that should be committed. Use
-`pnpm db:push` only for short-lived local experiments.
+Use `pnpm db:migrate:deploy` to apply committed migrations unattended (the
+installer does this). Use `pnpm db:migrate` when authoring a new schema change,
+and `pnpm db:push` only for short-lived local experiments.
 
-### Enterprise recovery
+## Recovery
 
-For a single-node local stack, reset with `docker:clean` followed by
-`docker:up` and `db:migrate`:
+For a single-node local stack, reset by clearing the database volume and
+re-migrating:
 
 ```bash
-DEPLOYMENT_PROFILE=enterprise pnpm docker:clean
-DEPLOYMENT_PROFILE=enterprise pnpm docker:up
-DEPLOYMENT_PROFILE=enterprise pnpm db:migrate
+pnpm docker:clean
+pnpm docker:up
+pnpm db:migrate:deploy
 ```
 
-If the vector store drifted from Postgres (embeddings missing or stale),
-reindex from the source of truth:
+If the vector store drifted from Postgres (embeddings missing or stale), reindex
+from the source of truth:
 
 ```bash
-DEPLOYMENT_PROFILE=enterprise \
 MCP_ADMIN_TOKEN="$MCP_ADMIN_TOKEN" \
   pnpm --filter mcp-server reindex
 ```
 
 The CLI is cursor-resumable; pass `--cursor <id>` to continue from a previous
 run.
-
-## Lite profile
-
-The Lite profile persists memories to an AES-256-GCM encrypted file store at
-`LOCAL_DATA_DIR` (default `~/.engram/data`). Postgres is the source of truth
-for the server; Redis and Qdrant are absent.
-
-```bash
-pnpm install
-DEPLOYMENT_PROFILE=lite \
-LOCAL_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
-  pnpm db:migrate
-DEPLOYMENT_PROFILE=lite \
-LOCAL_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
-  pnpm build
-DEPLOYMENT_PROFILE=lite \
-LOCAL_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
-  pnpm --filter mcp-server dev
-```
-
-`LOCAL_ENCRYPTION_KEY` must be a 32-byte (256-bit) key. Base64-encode the raw
-bytes; the secure-startup helper decodes it. Generate a fresh key per host —
-export it once and reuse the same value across the commands above — and never
-commit it.
-
-Verify:
-
-```bash
-curl http://localhost:3000/health
-ls -ld ~/.engram/data
-stat -c '%a %n' ~/.engram/data/*.json
-```
-
-The directory must be `0700` and every file `0600`. The server refuses to start
-if any file is group- or world-readable.
-
-### Lite recovery
-
-If the directory is missing, the server recreates it on startup with the
-correct `0700` / `0600` modes. If a file has the wrong mode, the server refuses
-to start. Fix the mode and restart:
-
-```bash
-chmod 0700 ~/.engram/data
-find ~/.engram/data -type f -exec chmod 0600 {} +
-DEPLOYMENT_PROFILE=lite \
-LOCAL_ENCRYPTION_KEY="<your-key>" \
-  pnpm --filter mcp-server dev
-```
-
-If the key is lost, the encrypted records are unrecoverable. Wipe and restart
-with a fresh key:
-
-```bash
-rm -rf ~/.engram/data
-DEPLOYMENT_PROFILE=lite \
-LOCAL_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
-  pnpm --filter mcp-server dev
-```
-
-For production runs, the server refuses to start without
-`LOCAL_ENCRYPTION_KEY`. In development it derives an ephemeral key with a
-warning so you can iterate without provisioning credentials.
 
 ## Troubleshooting
 
@@ -215,18 +173,15 @@ Regenerate Prisma after schema or dependency changes:
 pnpm db:generate
 ```
 
-Check direct service health:
+Check server health directly:
 
 ```bash
 curl http://localhost:3000/health
-curl http://localhost:6333/health
 ```
 
 ## Next steps
 
 - [Store your first memory](/docs/getting-started/first-memory/)
 - [MCP client setup](/docs/getting-started/mcp-client-setup/)
-- [Migrate lite → enterprise](/docs/how-to/profile-migration/) when a lite
-  deployment outgrows a single host.
 - [Deploy to production](/docs/how-to/deploy-production/) with the hardened
   Docker image.

--- a/apps/docs/src/content/docs/getting-started/mcp-client-setup.mdx
+++ b/apps/docs/src/content/docs/getting-started/mcp-client-setup.mdx
@@ -35,9 +35,8 @@ Edit it so the `args` value points to the absolute path of
       "command": "node",
       "args": ["/absolute/path/to/your/engram/apps/mcp-server/dist/main.js"],
       "env": {
-        "DATABASE_URL": "postgresql://postgres:password@localhost:5432/engram",
-        "REDIS_URL": "redis://localhost:6379",
-        "QDRANT_URL": "http://localhost:6333",
+        "DATABASE_URL": "postgresql://engram:dev_password@localhost:5432/engram",
+        "DEPLOYMENT_PROFILE": "lite",
         "NODE_ENV": "production"
       }
     }
@@ -45,8 +44,9 @@ Edit it so the `args` value points to the absolute path of
 }
 ```
 
-Add `"DEPLOYMENT_PROFILE": "memory"` (or `lite` / `enterprise`) to the `env`
-block to pick a profile; leaner profiles need fewer of the datastore URLs.
+Set `"DEPLOYMENT_PROFILE"` to `"lite"` (single-user, shown above) or
+`"standard"` (multi-tenant). Both profiles need only `DATABASE_URL` — Postgres is
+the sole backing service.
 
 Copy the file into Claude Desktop's config location and restart the client:
 
@@ -93,8 +93,8 @@ unset. Mint a key with the steps in
   `AUTH_REQUIRED=true` refuses to start in every `NODE_ENV`** unless the
   operator explicitly sets `ALLOW_UNAUTHENTICATED_HTTP=true` — an acknowledged
   trusted-network escape hatch (for example a loopback-bound, single-operator
-  host). Multi-tenant means the `enterprise` profile; the `memory` and `lite`
-  profiles are single-user, so the gate does not apply to them.
+  host). Multi-tenant means the `standard` profile; the `lite` profile is
+  single-user, so the gate does not apply to it.
 - The recommended posture for any shared server: `AUTH_REQUIRED=true`, one
   least-privilege API key per agent, and a loopback (`127.0.0.1`) bind. Setting
   `AUTH_REQUIRED=true` also requires a `JWT_SECRET` of at least 32 characters.

--- a/apps/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/src/content/docs/getting-started/quick-start.mdx
@@ -9,7 +9,7 @@ The fastest path to a running Engram server is the `lite` profile, set up by the
 bundled installer. It is single-user with no auth to configure, and it persists
 memories to PostgreSQL just like `standard`.
 
-You need [Node.js 20+](https://nodejs.org) and
+You need [Node.js 22.13.0+](https://nodejs.org) and
 [Docker](https://docs.docker.com/get-docker/) (for the bundled PostgreSQL).
 
 ## 1. Clone, install, run

--- a/apps/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/src/content/docs/getting-started/quick-start.mdx
@@ -1,33 +1,31 @@
 ---
 title: Quick start
-description: Run the Engram MCP server with the memory profile — no external services, three commands.
+description: Run the Engram MCP server with the lite profile — one command from a fresh clone to a running server.
 sidebar:
   order: 2
 ---
 
-The `memory` profile boots with **no external services**. Short-term and
-long-term memory are in-process; embeddings degrade to lexical-only when no
-embedding backend is reachable. Data is lost on process exit — use it for
-demos, CI smoke tests, and exploring the MCP tool surface.
+The fastest path to a running Engram server is the `lite` profile, set up by the
+bundled installer. It is single-user with no auth to configure, and it persists
+memories to PostgreSQL just like `standard`.
 
-## 1. Install, build, run
+You need [Node.js 20+](https://nodejs.org) and
+[Docker](https://docs.docker.com/get-docker/) (for the bundled PostgreSQL).
 
-From a fresh clone of the repository:
-
-```bash
-pnpm install
-DEPLOYMENT_PROFILE=memory pnpm build
-DEPLOYMENT_PROFILE=memory pnpm --filter mcp-server dev
-```
-
-No `pnpm` on your `PATH`? Replace the leading `pnpm` with
-`npm exec --yes pnpm@11.5.0 --`:
+## 1. Clone, install, run
 
 ```bash
-npm exec --yes pnpm@11.5.0 -- install
-DEPLOYMENT_PROFILE=memory npm exec --yes pnpm@11.5.0 -- build
-DEPLOYMENT_PROFILE=memory npm exec --yes pnpm@11.5.0 -- --filter mcp-server dev
+git clone https://github.com/osirison/engram.git
+cd engram
+./scripts/install.sh --start
 ```
+
+The installer copies `.env`, installs dependencies, starts PostgreSQL, runs
+migrations, builds, and — with `--start` — launches the MCP server on
+`http://localhost:3000`. It is idempotent, so you can re-run it any time. Drop
+`--start` to have it print the start command instead of launching.
+
+Prefer to wire each step yourself? See [Installation](/docs/getting-started/installation/).
 
 ## 2. Verify the server is up
 
@@ -37,41 +35,32 @@ In a second terminal:
 curl http://localhost:3000/health
 ```
 
-The health response reports `ok` with only the process-level `memory-store`
-indicator. Postgres, Redis, and Qdrant indicators are not present in this
-profile.
+The health response reports `ok` with the process and database indicators.
 
 ## 3. Optional: local embeddings for hybrid recall
 
-The default embedding provider is **Ollama** — local, no API key. If an
-Ollama server is running ([ollama.com/download](https://ollama.com/download))
-with the default model pulled, hybrid semantic recall works with zero extra
-configuration:
+The default embedding provider is **Ollama** — local, no API key. If an Ollama
+server is running ([ollama.com/download](https://ollama.com/download)) with the
+default model pulled, hybrid semantic recall works with zero extra configuration:
 
 ```bash
 ollama pull nomic-embed-text
 ```
 
 If Ollama is unreachable, the server degrades gracefully (memories are stored
-without vectors). No Ollama at all? The deterministic hash provider gives
-stable — but not semantic — similarity without any model:
+without vectors and can be backfilled by a later reindex). No Ollama at all? The
+deterministic hash provider gives stable — but not semantic — similarity without
+any model:
 
 ```bash
-DEPLOYMENT_PROFILE=memory \
+DEPLOYMENT_PROFILE=lite \
 EMBEDDING_PROVIDER=local \
   pnpm --filter mcp-server dev
 ```
 
-## Recovery
-
-There is nothing to recover — the process owns its data. Stop the process and
-restart to wipe the in-memory state. There is no on-disk persistence and no
-checkpoint.
-
 > `DEPLOYMENT_PROFILE` is read at module-load time. If the server exits
 > immediately, confirm the variable is set in the same shell that runs the
-> install / build / dev commands — changing it after the process boots has no
-> effect.
+> build / dev commands — changing it after the process boots has no effect.
 
 ## Next steps
 
@@ -79,5 +68,5 @@ checkpoint.
   `create_memory` → `recall` → `get_memory` round trip.
 - [MCP client setup](/docs/getting-started/mcp-client-setup/) — point Claude
   Desktop or Claude Code at the server.
-- [Installation](/docs/getting-started/installation/) — move up to the `lite`
-  or `enterprise` profile when you need persistence.
+- [Installation](/docs/getting-started/installation/) — the `standard` profile
+  when you need multi-tenant auth and API keys.

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/instrumentation-express": "^0.67.0",
     "@opentelemetry/instrumentation-http": "^0.219.0",
     "@opentelemetry/sdk-node": "^0.219.0",
-    "axios": "^1.16.1",
+    "axios": "^1.18.0",
     "express": "^5.0.0",
     "helmet": "^8.2.0",
     "nestjs-pino": "^4.6.1",

--- a/claude_desktop_config.json.example
+++ b/claude_desktop_config.json.example
@@ -4,9 +4,8 @@
       "command": "node",
       "args": ["/absolute/path/to/your/engram/apps/mcp-server/dist/main.js"],
       "env": {
-        "DATABASE_URL": "postgresql://postgres:password@localhost:5432/engram",
-        "REDIS_URL": "redis://localhost:6379",
-        "QDRANT_URL": "http://localhost:6333",
+        "DATABASE_URL": "postgresql://engram:dev_password@localhost:5432/engram",
+        "DEPLOYMENT_PROFILE": "lite",
         "NODE_ENV": "production"
       }
     }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,13 +1,330 @@
 ---
-title: ENGRAM Setup
-description: Local development, MCP client setup, and profile migration runbook for ENGRAM
+title: ENGRAM Developer Guide
+description: Install, run, configure, and connect the ENGRAM MCP memory server — profiles, commands, MCP client setup, and the Inspector.
 ---
 
-This page has moved to the ENGRAM Developer Docs:
+The [README](../README.md) gets you running in one command. This guide is the
+in-repo reference for everything underneath it: prerequisites, the deployment
+profiles, manual setup, the command surface, connecting an MCP client, and the
+MCP Inspector.
 
-- Profile picker and prerequisites: [Getting started](https://engram.events/docs/getting-started/)
-- Memory profile (zero dependencies): [Quick start](https://engram.events/docs/getting-started/quick-start/)
-- Enterprise and lite profiles, infrastructure and database commands, recovery,
-  troubleshooting: [Installation](https://engram.events/docs/getting-started/installation/)
-- Claude Desktop / Claude Code configuration: [MCP client setup](https://engram.events/docs/getting-started/mcp-client-setup/)
-- Lite → enterprise migration runbook: [Migrate lite to enterprise](https://engram.events/docs/how-to/profile-migration/)
+The full documentation site lives at
+[engram.events/docs](https://engram.events/docs/).
+
+## The one-command installer
+
+From a fresh clone, [`scripts/install.sh`](../scripts/install.sh) does the whole
+setup — copies `.env`, installs dependencies, starts PostgreSQL, runs migrations,
+and builds:
+
+```bash
+./scripts/install.sh            # lite profile (default), then prints the start command
+./scripts/install.sh --start    # same, then launches the server on :3000
+./scripts/install.sh --standard # multi-tenant profile (auth, API keys, rate limits)
+```
+
+It is idempotent — re-run it any time. If you don't have Docker, point
+`DATABASE_URL` at your own PostgreSQL (with the `pgvector` extension) and the
+installer skips the bundled container.
+
+## Prerequisites
+
+- Node.js 20 or newer with npm
+- Git
+- Optional: `pnpm@11.5.0` on your `PATH`
+- Optional: Docker and Docker Compose v2 — to run the bundled PostgreSQL
+  container (image `pgvector/pgvector:pg16+`)
+
+ENGRAM pins `pnpm@11.5.0` in [package.json](../package.json). Every command below
+uses `pnpm`; when `pnpm` is not on your `PATH`, replace the leading `pnpm` with
+`npm exec --yes pnpm@11.5.0 --`. For example, `pnpm install` becomes
+`npm exec --yes pnpm@11.5.0 -- install`.
+
+## Deployment profiles
+
+ENGRAM ships two profiles. **Both run on PostgreSQL alone** — the same storage,
+vectors (pgvector), and durability — and both expose the full MCP tool set,
+including the queued reindex / cancel / retry maintenance tools. The server reads
+`DEPLOYMENT_PROFILE`; when it is unset, `standard` is the default.
+
+| Profile            | `DEPLOYMENT_PROFILE` | Tenancy                                                   | Backing services      |
+| ------------------ | -------------------- | --------------------------------------------------------- | --------------------- |
+| Lite               | `lite`               | Single user — auth/organization stack not wired           | PostgreSQL (pgvector) |
+| Standard (default) | `standard`           | Multi-tenant — auth, API keys, organizations, rate limits | PostgreSQL (pgvector) |
+
+The legacy value `enterprise` is accepted as an alias for `standard`. The old
+`memory` profile was removed — every profile now runs on Postgres, so the server
+rejects `DEPLOYMENT_PROFILE=memory` with guidance to pick `lite` or `standard`.
+
+- **Lite** — best for a personal machine running a local memory server. Same
+  durable Postgres storage as `standard`, minus the multi-tenant auth/organization
+  stack, so there is no login or API-key surface to configure.
+- **Standard** — best for shared or production deployments. Adds JWT sessions,
+  per-agent API keys, organizations, and Postgres-backed rate limiting on top of
+  the same storage.
+
+## Manual setup
+
+If you'd rather not use the installer, run the steps yourself. Both profiles use
+the same flow; only the profile passed to `build` (and to the server at runtime)
+differs.
+
+### Lite (single-user)
+
+```bash
+pnpm install
+test -f .env || cp .env.example .env
+pnpm docker:up
+pnpm db:generate
+pnpm db:migrate:deploy
+DEPLOYMENT_PROFILE=lite pnpm build
+DEPLOYMENT_PROFILE=lite pnpm --filter mcp-server dev
+```
+
+### Standard (multi-tenant, default)
+
+```bash
+pnpm install
+test -f .env || cp .env.example .env
+pnpm docker:up
+pnpm db:generate
+pnpm db:migrate:deploy
+pnpm build
+pnpm --filter mcp-server dev
+```
+
+The MCP server starts on `http://localhost:3000`. Verify it in a second terminal:
+
+```bash
+curl http://localhost:3000/health
+```
+
+Stop the database without deleting data with `pnpm docker:down`; remove the
+containers and local volumes with `pnpm docker:clean`.
+
+## Common commands
+
+| Task                                   | Command                        |
+| -------------------------------------- | ------------------------------ |
+| Start PostgreSQL (pgvector), then wait | `pnpm docker:up`               |
+| Stop the database, keep data           | `pnpm docker:down`             |
+| Stop the database, delete data         | `pnpm docker:clean`            |
+| Start the MCP server                   | `pnpm --filter mcp-server dev` |
+| Start the web app                      | `pnpm --filter web dev`        |
+| Start the docs app                     | `pnpm --filter docs dev`       |
+| Generate Prisma client                 | `pnpm db:generate`             |
+| Deploy migrations (unattended)         | `pnpm db:migrate:deploy`       |
+| Create a dev migration                 | `pnpm db:migrate`              |
+| Open Prisma Studio                     | `pnpm db:studio`               |
+| Build all workspaces                   | `pnpm build`                   |
+| Lint all workspaces                    | `pnpm lint`                    |
+| Type-check all workspaces              | `pnpm typecheck`               |
+| Test all workspaces                    | `pnpm test`                    |
+| Check documentation links              | `pnpm docs:check`              |
+| Format source files                    | `pnpm format`                  |
+
+## Environment
+
+Local defaults live in [.env.example](../.env.example). Docker Compose uses these
+host ports by default:
+
+| Service           | Host port setting                   | Purpose                                            |
+| ----------------- | ----------------------------------- | -------------------------------------------------- |
+| PostgreSQL        | `POSTGRES_PORT`, defaults to `5432` | Primary datastore (memories, vectors, auth state)  |
+| Ollama (optional) | `OLLAMA_PORT`, defaults to `11434`  | Local embeddings (`--profile ollama` compose flag) |
+
+When a host port is already in use, update the matching port value and URL in
+`.env` before starting Docker. For PostgreSQL, change both `POSTGRES_PORT` and the
+port inside `DATABASE_URL`.
+
+### Embeddings
+
+The embedding provider is selected by `EMBEDDING_PROVIDER`:
+
+- `ollama` (default) — a local Ollama server, no API key. Install Ollama
+  ([ollama.com/download](https://ollama.com/download)) and run
+  `ollama pull nomic-embed-text`, or start the bundled container with
+  `docker compose --profile ollama up -d`.
+- `openai` — requires `OPENAI_API_KEY`.
+- `local` — a deterministic hash provider, for testing.
+- `disabled` — no embeddings.
+
+When no provider is reachable, writes still succeed: memories are stored without
+a vector and can be backfilled later with a reindex. See
+[.env.example](../.env.example) for the full list of embedding variables.
+
+## MCP client setup
+
+Build the server before connecting a client:
+
+```bash
+pnpm build
+```
+
+### Claude Desktop (stdio)
+
+Claude Desktop spawns the server as a subprocess. Copy the example config from
+the repository root:
+
+```bash
+cp claude_desktop_config.json.example claude_desktop_config.json
+```
+
+Edit the `args` path to the absolute location of
+`apps/mcp-server/dist/main.js` in your checkout:
+
+```json
+{
+  "mcpServers": {
+    "engram": {
+      "command": "node",
+      "args": ["/absolute/path/to/your/engram/apps/mcp-server/dist/main.js"],
+      "env": {
+        "DATABASE_URL": "postgresql://engram:dev_password@localhost:5432/engram",
+        "DEPLOYMENT_PROFILE": "lite",
+        "NODE_ENV": "production"
+      }
+    }
+  }
+}
+```
+
+Copy the file into Claude Desktop's config location and restart the client:
+
+| Operating system | Config path                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| Linux            | `~/.config/Claude/claude_desktop_config.json`                     |
+| macOS            | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows          | `%APPDATA%\Claude\claude_desktop_config.json`                     |
+
+Then ask the client to call the `ping` tool to confirm connectivity.
+
+### Claude Code (Streamable HTTP)
+
+To share one persistent server across sessions and agents, run it with
+`MCP_TRANSPORT=streamable-http` and register it in the repository's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "engram": {
+      "type": "http",
+      "url": "http://127.0.0.1:3000/mcp",
+      "headers": {
+        "Authorization": "Bearer ${ENGRAM_API_KEY:-}"
+      }
+    }
+  }
+}
+```
+
+The `${ENGRAM_API_KEY:-}` default keeps the file parseable when the key is unset.
+
+### Authentication (read before sharing a server)
+
+- `AUTH_REQUIRED` defaults to **`false`**. A single-user stdio server spawned by
+  your own client needs no key, and the `lite` profile is single-user, so the
+  auth gate does not apply to it.
+- On the multi-tenant `standard` profile, a Streamable HTTP server **refuses to
+  start without `AUTH_REQUIRED=true`** in every `NODE_ENV`, unless the operator
+  explicitly sets `ALLOW_UNAUTHENTICATED_HTTP=true` — an acknowledged
+  trusted-network escape hatch (for example a loopback-bound, single-operator
+  host). Without a gate, the tenant `userId` is read from the request body and is
+  spoofable by any process that can reach the port.
+- Recommended posture for any shared server: `AUTH_REQUIRED=true`, one
+  least-privilege API key per agent, and a loopback (`127.0.0.1`) bind. Setting
+  `AUTH_REQUIRED=true` also requires a `JWT_SECRET` of at least 32 characters.
+
+For an HTTP server, the repository's verification script checks the full MCP
+handshake and the auth gate:
+
+```bash
+AUTH_REQUIRED=true ./scripts/verify-engram-server.sh
+```
+
+## MCP Inspector
+
+The MCP Inspector has no official Docker image on GHCR — running
+`docker run ghcr.io/modelcontextprotocol/inspector:latest` will fail with a
+registry error. Use one of the two approaches below instead.
+
+### Option A — host-run (simplest)
+
+With the MCP server already running on `http://localhost:3000`, start the
+Inspector in a separate terminal:
+
+```bash
+pnpm inspector
+```
+
+Then open:
+
+```text
+http://localhost:6274/?transport=streamable-http&serverUrl=http%3A%2F%2Flocalhost%3A3000%2Fmcp
+```
+
+Port 6274 is the Inspector UI and port 6277 is the proxy. If either port is
+already in use (for example from a previous run), kill the stale process before
+restarting.
+
+### Option B — Docker (Inspector in a container)
+
+First ensure the base infrastructure is up (`pnpm docker:up`) and the MCP server
+is running on the host. Then start the Inspector container:
+
+```bash
+pnpm docker:inspector:up
+```
+
+The container reaches the host-side MCP server via `host.docker.internal`. Open
+the Inspector UI at:
+
+```text
+http://localhost:6274/?transport=streamable-http&serverUrl=http%3A%2F%2Fhost.docker.internal%3A3000%2Fmcp
+```
+
+Stop the container with `pnpm docker:inspector:down`.
+
+## Reindex and backfill
+
+After changing the embedding model or its dimensionality, rebuild the vector
+index from Postgres (the source of truth). The admin MCP tools
+(`reindex_memories`, `queue_reindex_memories`, and friends) require an
+`adminToken` matching `MCP_ADMIN_TOKEN`; there is also a CLI:
+
+```bash
+pnpm --filter mcp-server reindex --recreate --regenerate
+```
+
+`--recreate` drops the old index and rebuilds it at the new dimensionality;
+`--regenerate` recomputes embeddings and writes them back to Postgres. The CLI is
+cursor-resumable (`--cursor <id>`).
+
+## Project layout
+
+| Path                                              | Purpose                                     |
+| ------------------------------------------------- | ------------------------------------------- |
+| [apps/mcp-server](../apps/mcp-server)             | Main NestJS MCP server                      |
+| [apps/web](../apps/web)                           | Web application workspace                   |
+| [apps/docs](../apps/docs)                         | Documentation site workspace                |
+| [packages/core](../packages/core)                 | Core MCP types, registry, and tools         |
+| [packages/config](../packages/config)             | Environment validation and profile taxonomy |
+| [packages/database](../packages/database)         | Prisma database module                      |
+| [packages/vector-store](../packages/vector-store) | pgvector vector store module                |
+| [packages/embeddings](../packages/embeddings)     | Embedding generation                        |
+| [packages/memory-stm](../packages/memory-stm)     | Short-term memory package                   |
+| [packages/memory-ltm](../packages/memory-ltm)     | Long-term memory package                    |
+| [prisma](../prisma)                               | Prisma schema and migrations                |
+| [docker](../docker)                               | Local infrastructure initialization         |
+
+## More information
+
+| Topic                                   | Link                                                                              |
+| --------------------------------------- | --------------------------------------------------------------------------------- |
+| Full documentation site                 | [engram.events/docs](https://engram.events/docs/)                                 |
+| Agent and contributor instructions      | [AGENTS.md](../AGENTS.md)                                                         |
+| Shared memory contract for agent fleets | [agent-memory-contract.md](agent-memory-contract.md)                              |
+| Release SLOs and quality gates          | [RELEASE_GATES.md](RELEASE_GATES.md)                                              |
+| Current roadmap                         | [roadmap.md](roadmap.md)                                                          |
+| MCP server details                      | [apps/mcp-server/README.md](../apps/mcp-server/README.md)                         |
+| MCP tool development                    | [packages/core/src/mcp/tools/README.md](../packages/core/src/mcp/tools/README.md) |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -29,11 +29,11 @@ installer skips the bundled container.
 
 ## Prerequisites
 
-- Node.js 20 or newer with npm
+- Node.js 22.13.0 or newer with npm
 - Git
 - Optional: `pnpm@11.5.0` on your `PATH`
 - Optional: Docker and Docker Compose v2 — to run the bundled PostgreSQL
-  container (image `pgvector/pgvector:pg16+`)
+  container (image `pgvector/pgvector:pg17`)
 
 ENGRAM pins `pnpm@11.5.0` in [package.json](../package.json). Every command below
 uses `pnpm`; when `pnpm` is not on your `PATH`, replace the leading `pnpm` with

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,15 @@ overrides:
   undici: '>=6.27.0 <7'
   hono: '>=4.12.25'
   vite: '>=8.0.16 <8.1.0'
+  fast-uri: '>=3.1.4 <4'
+  '@opentelemetry/propagator-jaeger': '>=2.9.0 <3'
+  '@opentelemetry/core': '>=2.9.0 <3'
+  '@opentelemetry/resources': '>=2.9.0 <3'
+  '@opentelemetry/context-async-hooks': '>=2.9.0 <3'
+  '@opentelemetry/sdk-metrics': '>=2.9.0 <3'
+  '@opentelemetry/sdk-trace-base': '>=2.9.0 <3'
+  '@opentelemetry/sdk-trace-node': '>=2.9.0 <3'
+  '@opentelemetry/exporter-zipkin': '>=2.9.0 <3'
 
 importers:
 
@@ -175,7 +184,7 @@ importers:
         version: 1.29.0(zod@4.4.3)
       '@nestjs/axios':
         specifier: ^4.0.1
-        version: 4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.1)(rxjs@7.8.2)
+        version: 4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.19.0)(rxjs@7.8.2)
       '@nestjs/common':
         specifier: ^11.1.24
         version: 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -193,7 +202,7 @@ importers:
         version: 6.1.3(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)
       '@nestjs/terminus':
         specifier: ^11.1.1
-        version: 11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)(@nestjs/axios@4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.1)(rxjs@7.8.2))(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)(@nestjs/axios@4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.19.0)(rxjs@7.8.2))(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -210,8 +219,8 @@ importers:
         specifier: ^0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.1)
       axios:
-        specifier: ^1.16.1
-        version: 1.16.1
+        specifier: ^1.18.0
+        version: 1.19.0
       express:
         specifier: ^5.0.0
         version: 5.2.1
@@ -2801,14 +2810,14 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@opentelemetry/context-async-hooks@2.8.0':
-    resolution: {integrity: sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==}
+  '@opentelemetry/context-async-hooks@2.10.0':
+    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.8.0':
-    resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -2873,8 +2882,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-zipkin@2.8.0':
-    resolution: {integrity: sha512-Mj84UkEa17BK2o903VTXW3wM8CrSZexGs4tRGVZVIMM9ni1T6TuGx5IrRfoWKAbshx42D5/kc7YV+axypLPYyA==}
+  '@opentelemetry/exporter-zipkin@2.10.0':
+    resolution: {integrity: sha512-7gsvgf0UDoJ4l9ObrwBmz5G/ZogiPk+lq+g5GpLp24YQF/vPM/BSsnOfcLnfinast5ASUgLo78uSC/ObjlnXgg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
@@ -2921,14 +2930,14 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/propagator-jaeger@2.8.0':
-    resolution: {integrity: sha512-Xnz9zZvvQzUw+9DrOn0MomR7BxFCkA2pcfXBQuHC28ndJpSbjLs7knzYb05kw5SyCjSsEWombkZMgGcJSk8JVg==}
+  '@opentelemetry/propagator-jaeger@2.10.0':
+    resolution: {integrity: sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/resources@2.8.0':
-    resolution: {integrity: sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==}
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -2939,8 +2948,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
-  '@opentelemetry/sdk-metrics@2.8.0':
-    resolution: {integrity: sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==}
+  '@opentelemetry/sdk-metrics@2.10.0':
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
@@ -2951,17 +2960,23 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-base@2.8.0':
-    resolution: {integrity: sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==}
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-node@2.8.0':
-    resolution: {integrity: sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==}
+  '@opentelemetry/sdk-trace-node@2.10.0':
+    resolution: {integrity: sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/semantic-conventions@1.41.1':
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
@@ -5036,8 +5051,8 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -6070,8 +6085,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11168,10 +11183,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@nestjs/axios@4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.1)(rxjs@7.8.2)':
+  '@nestjs/axios@4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.19.0)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      axios: 1.16.1
+      axios: 1.19.0
       rxjs: 7.8.2
 
   '@nestjs/cli@11.0.21(@types/node@25.9.1)(prettier@3.8.3)':
@@ -11288,7 +11303,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)(@nestjs/axios@4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.1)(rxjs@7.8.2))(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)(@nestjs/axios@4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.19.0)(rxjs@7.8.2))(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -11299,7 +11314,7 @@ snapshots:
     optionalDependencies:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.8.1
-      '@nestjs/axios': 4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.1)(rxjs@7.8.2)
+      '@nestjs/axios': 4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.19.0)(rxjs@7.8.2)
       '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3)
 
   '@nestjs/testing@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(@nestjs/platform-express@11.1.24)':
@@ -11367,14 +11382,14 @@ snapshots:
   '@opentelemetry/configuration@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       yaml: 2.9.0
 
-  '@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -11383,7 +11398,7 @@ snapshots:
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
@@ -11393,7 +11408,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.219.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
@@ -11402,93 +11417,93 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.219.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-metrics-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-metrics-otlp-http@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-metrics-otlp-proto@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-metrics-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-prometheus@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-zipkin@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-zipkin@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/instrumentation-express@0.67.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
@@ -11497,7 +11512,7 @@ snapshots:
   '@opentelemetry/instrumentation-http@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       forwarded-parse: 2.1.2
@@ -11516,14 +11531,14 @@ snapshots:
   '@opentelemetry/otlp-exporter-base@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-grpc-exporter-base@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
 
@@ -11531,49 +11546,49 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.219.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/propagator-b3@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/propagator-jaeger@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/propagator-jaeger@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.219.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-node@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.219.0
       '@opentelemetry/configuration': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-logs-otlp-grpc': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-logs-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-logs-otlp-proto': 0.219.0(@opentelemetry/api@1.9.1)
@@ -11584,34 +11599,42 @@ snapshots:
       '@opentelemetry/exporter-trace-otlp-grpc': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-proto': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-zipkin': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/propagator-b3': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/propagator-jaeger': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-node': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-trace-node@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
@@ -13572,14 +13595,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13822,7 +13845,7 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.16.1:
+  axios@1.19.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
@@ -15001,7 +15024,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,26 @@ overrides:
   # on 8.0.x — the range Astro resolves today — and off the 8.1.x releases that
   # are too new for the minimum-release-age gate.
   vite: '>=8.0.16 <8.1.0'
+  # Patched 3.1.x line for GHSA-4c8g-83qw-93j6 / CVE-2026-13676 / CVE-2026-16221
+  # (host confusion + policy-bypass via improper Unicode hostname handling).
+  # Pulled transitively by ajv (^3). Kept in 3.x for ajv compatibility.
+  fast-uri: '>=3.1.4 <4'
+  # Patched 2.9+ for CVE-2026-59892 (DoS via malformed HTTP header decoding in
+  # the Jaeger propagator), pulled transitively by @opentelemetry/sdk-node. The
+  # rest of the @opentelemetry/* 2.x STABLE family is aligned to the same line
+  # so the graph resolves to a single @opentelemetry/core — overriding only
+  # propagator-jaeger drags in a second core@2.10 alongside the 2.8 family and
+  # silently breaks OTel context propagation. The 0.219.x experimental packages
+  # (sdk-node, exporters, instrumentation) are a separate version line and are
+  # intentionally left untouched.
+  '@opentelemetry/propagator-jaeger': '>=2.9.0 <3'
+  '@opentelemetry/core': '>=2.9.0 <3'
+  '@opentelemetry/resources': '>=2.9.0 <3'
+  '@opentelemetry/context-async-hooks': '>=2.9.0 <3'
+  '@opentelemetry/sdk-metrics': '>=2.9.0 <3'
+  '@opentelemetry/sdk-trace-base': '>=2.9.0 <3'
+  '@opentelemetry/sdk-trace-node': '>=2.9.0 <3'
+  '@opentelemetry/exporter-zipkin': '>=2.9.0 <3'
 
 # Allow openai to use zod v4 (openai declares a peer dep on zod ^3 but only uses
 # it for its optional structured-output helpers, which we don't use).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# ENGRAM one-command installer.
+#
+# Sets ENGRAM up end-to-end — dependencies, database, and a build that is ready
+# to run — so you can go from a fresh clone to a running memory server in a
+# single command. Every step is idempotent, so it is safe to re-run.
+#
+# Usage:
+#   ./scripts/install.sh [--lite | --standard] [--start]
+#
+# Profiles (details in docs/SETUP.md):
+#   --lite       Single-user. No auth/API-key surface. Postgres only. (default)
+#   --standard   Multi-tenant: auth, API keys, rate limits. Postgres only.
+#
+# Flags:
+#   --start      Launch the MCP server (foreground) once setup finishes.
+#   -h, --help   Show this help and exit.
+#
+# Requirements:
+#   - Node.js 20+ (ships with npm)
+#   - Docker + Docker Compose v2 for the bundled Postgres — OR point
+#     DATABASE_URL at your own Postgres that has the pgvector extension and
+#     skip Docker.
+
+set -euo pipefail
+
+# ── Locate the repo root (this script lives in <root>/scripts) ────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+if [ -t 1 ]; then
+  BOLD=$'\033[1m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RED=$'\033[31m'; RESET=$'\033[0m'
+else
+  BOLD=""; GREEN=""; YELLOW=""; RED=""; RESET=""
+fi
+info() { printf '%s==>%s %s\n' "${GREEN}${BOLD}" "$RESET" "$*"; }
+warn() { printf '%swarning:%s %s\n' "${YELLOW}${BOLD}" "$RESET" "$*" >&2; }
+die()  { printf '%serror:%s %s\n' "${RED}${BOLD}" "$RESET" "$*" >&2; exit 1; }
+step() { printf '\n%s%s%s\n' "$BOLD" "$*" "$RESET"; }
+
+usage() {
+  cat <<'EOF'
+ENGRAM installer — from a fresh clone to a running memory server.
+
+Usage:
+  ./scripts/install.sh [--lite | --standard] [--start]
+
+Profiles:
+  --lite       Single-user, no auth. Postgres only. (default)
+  --standard   Multi-tenant: auth, API keys, rate limits. Postgres only.
+
+Flags:
+  --start      Launch the MCP server once setup finishes.
+  -h, --help   Show this help and exit.
+EOF
+}
+
+# ── Parse arguments ───────────────────────────────────────────────────────────
+PROFILE="lite"
+START=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --lite)     PROFILE="lite" ;;
+    --standard) PROFILE="standard" ;;
+    --start)    START=1 ;;
+    -h|--help)  usage; exit 0 ;;
+    *)          usage >&2; die "unknown option: $1" ;;
+  esac
+  shift
+done
+
+step "ENGRAM installer — profile: ${PROFILE}"
+
+# ── Preflight: Node.js 20+ ────────────────────────────────────────────────────
+command -v node >/dev/null 2>&1 \
+  || die "Node.js 20+ is required but 'node' was not found. Install it from https://nodejs.org."
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "$NODE_MAJOR" -lt 20 ]; then
+  die "Node.js 20+ is required (found $(node -v)). Upgrade from https://nodejs.org."
+fi
+info "Node $(node -v) detected."
+
+# ── Pick a package manager: global pnpm, else the pinned pnpm via npm ─────────
+if command -v pnpm >/dev/null 2>&1; then
+  PM=(pnpm)
+else
+  command -v npm >/dev/null 2>&1 \
+    || die "Neither 'pnpm' nor 'npm' was found. Install Node.js 20+ (which bundles npm)."
+  info "pnpm not on PATH — using the pinned pnpm@11.5.0 through npm."
+  PM=(npm exec --yes pnpm@11.5.0 --)
+fi
+
+# ── Detect Docker (for the bundled Postgres) ──────────────────────────────────
+DOCKER_OK=0
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  if docker info >/dev/null 2>&1; then
+    DOCKER_OK=1
+  else
+    warn "Docker is installed but its daemon is not reachable. Start Docker, or point DATABASE_URL at your own Postgres."
+  fi
+else
+  warn "Docker with Compose v2 was not found. The bundled Postgres will not start — point DATABASE_URL at your own Postgres (with the pgvector extension)."
+fi
+
+# ── 1. Environment file ───────────────────────────────────────────────────────
+step "1/5  Environment"
+if [ -f .env ]; then
+  info ".env already exists — leaving it untouched."
+else
+  cp .env.example .env
+  info "Created .env from .env.example."
+fi
+
+# ── 2. Dependencies ───────────────────────────────────────────────────────────
+step "2/5  Install dependencies"
+"${PM[@]}" install
+
+# ── 3. Database ───────────────────────────────────────────────────────────────
+step "3/5  Database"
+if [ "$DOCKER_OK" -eq 1 ]; then
+  info "Starting PostgreSQL (pgvector) via Docker…"
+  "${PM[@]}" docker:up
+else
+  warn "Skipping 'docker:up'. The next step needs a reachable Postgres at DATABASE_URL."
+fi
+info "Generating the Prisma client…"
+"${PM[@]}" db:generate
+info "Applying migrations…"
+"${PM[@]}" db:migrate:deploy
+
+# ── 4. Build ──────────────────────────────────────────────────────────────────
+step "4/5  Build"
+if [ "$PROFILE" = "lite" ]; then
+  DEPLOYMENT_PROFILE=lite "${PM[@]}" build
+else
+  "${PM[@]}" build
+fi
+
+# ── 5. Embeddings (optional, non-fatal) ───────────────────────────────────────
+step "5/5  Embeddings (optional)"
+OLLAMA_URL="${OLLAMA_URL:-http://localhost:11434}"
+if ! command -v curl >/dev/null 2>&1; then
+  info "Skipping the embeddings check ('curl' not found). Semantic recall uses a local Ollama server by default."
+elif curl -fsS --max-time 2 "${OLLAMA_URL}/api/tags" >/dev/null 2>&1; then
+  info "Ollama reachable at ${OLLAMA_URL} — semantic recall is available (pull the model with: ollama pull nomic-embed-text)."
+else
+  warn "No Ollama server at ${OLLAMA_URL}. Memories still store and recall lexically; for semantic recall install Ollama (https://ollama.com/download) then 'ollama pull nomic-embed-text', or run 'docker compose --profile ollama up -d'."
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+if [ "$PROFILE" = "lite" ]; then
+  START_CMD="DEPLOYMENT_PROFILE=lite ${PM[*]} --filter mcp-server dev"
+else
+  START_CMD="${PM[*]} --filter mcp-server dev"
+fi
+
+step "✓ ENGRAM is ready (profile: ${PROFILE})."
+
+if [ "$START" -eq 1 ]; then
+  info "Starting the MCP server on http://localhost:3000 — press Ctrl-C to stop."
+  if [ "$PROFILE" = "lite" ]; then
+    exec env DEPLOYMENT_PROFILE=lite "${PM[@]}" --filter mcp-server dev
+  else
+    exec "${PM[@]}" --filter mcp-server dev
+  fi
+fi
+
+cat <<EOF
+
+Next steps:
+  1. Start the server:
+       ${START_CMD}
+  2. Check it is up (in a second terminal):
+       curl http://localhost:3000/health
+  3. Connect Claude Desktop / Claude Code — see the MCP client setup in docs/SETUP.md.
+
+Re-run this installer any time (safe & idempotent), or pass --start to launch the
+server automatically. Full developer guide: docs/SETUP.md
+EOF

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@
 #   -h, --help   Show this help and exit.
 #
 # Requirements:
-#   - Node.js 20+ (ships with npm)
+#   - Node.js 22.13.0+ (ships with npm)
 #   - Docker + Docker Compose v2 for the bundled Postgres — OR point
 #     DATABASE_URL at your own Postgres that has the pgvector extension and
 #     skip Docker.
@@ -73,12 +73,11 @@ done
 
 step "ENGRAM installer — profile: ${PROFILE}"
 
-# ── Preflight: Node.js 20+ ────────────────────────────────────────────────────
+# ── Preflight: Node.js 22.13.0+ (matches package.json "engines.node") ─────────
 command -v node >/dev/null 2>&1 \
-  || die "Node.js 20+ is required but 'node' was not found. Install it from https://nodejs.org."
-NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
-if [ "$NODE_MAJOR" -lt 20 ]; then
-  die "Node.js 20+ is required (found $(node -v)). Upgrade from https://nodejs.org."
+  || die "Node.js 22.13.0+ is required but 'node' was not found. Install it from https://nodejs.org."
+if ! node -e 'const v=process.versions.node.split(".").map(Number),r=[22,13,0];process.exit((v[0]>r[0]||(v[0]===r[0]&&(v[1]>r[1]||(v[1]===r[1]&&v[2]>=r[2]))))?0:1)'; then
+  die "Node.js 22.13.0+ is required (found $(node -v)). Upgrade from https://nodejs.org."
 fi
 info "Node $(node -v) detected."
 
@@ -87,7 +86,7 @@ if command -v pnpm >/dev/null 2>&1; then
   PM=(pnpm)
 else
   command -v npm >/dev/null 2>&1 \
-    || die "Neither 'pnpm' nor 'npm' was found. Install Node.js 20+ (which bundles npm)."
+    || die "Neither 'pnpm' nor 'npm' was found. Install Node.js 22.13.0+ (which bundles npm)."
   info "pnpm not on PATH — using the pinned pnpm@11.5.0 through npm."
   PM=(npm exec --yes pnpm@11.5.0 --)
 fi


### PR DESCRIPTION
## What & why

Lower the entry level: a new user should be able to install ENGRAM and get going with one command, with the deep detail moved off the front page.

- **New `scripts/install.sh`** — fresh clone → running memory server in one command. Default `lite` (single-user, no auth); `--standard`, `--start`, `--help`. Idempotent, unattended migrations (`db:migrate:deploy`), and it *warns rather than hard-fails* on missing Docker/Ollama (embeddings degrade gracefully).
- **Slim, friendly `README.md`** — punchy intro of what ENGRAM does + a one-command quick start + a "connect your assistant" pointer. All the tables/runbooks moved out.
- **`docs/SETUP.md` rewritten** from a stale stub into the accurate in-repo developer guide (prerequisites, profiles, manual setup, command reference, MCP client setup, MCP Inspector). The Inspector host-run/Docker instructions previously lived *only* in the README — preserved here.
- **Fixed `claude_desktop_config.json.example`** — dropped the removed `REDIS_URL`/`QDRANT_URL`; added `DEPLOYMENT_PROFILE`.
- **Refreshed the hosted `getting-started` docs** (index, quick-start, installation, mcp-client-setup, first-memory) to today's reality: two profiles (`lite`/`standard`), **Postgres-only**. Removed the retired `memory` profile, Redis, Qdrant, `enterprise`, and the obsolete encrypted-file-store `lite` (now Postgres-backed).

## Verification

- `bash -n scripts/install.sh` clean; exercised `--help` and unknown-option paths.
- `pnpm docs:check` passes (frontmatter + relative-link integrity across all `.md`).
- `prettier --check` clean; the lint-staged pre-commit hook ran on commit.
- **Not executed end-to-end on purpose** — the installer runs `docker:up` + migrations, which would touch the live local server (`:3100`) and Postgres on this machine. Safe to run on a clean clone.

## Follow-up (out of scope for this PR)

Docs staleness is broader than the getting-started path. Still referencing removed Redis/Qdrant/`memory`/`enterprise`:
- `apps/mcp-server/README.md`
- `apps/docs` `architecture/*` and several `how-to/*` (backup-and-restore, change-vector-backend, profile-migration, deploy-production, reindex-embeddings) and `reference/*` pages
- auto-generated TypeDoc under `apps/docs/.../reference/api/_media/*` (regenerated by `pnpm docs:generate`)
- `docs/agent-memory-contract.md` (passing mentions)

Can follow with a dedicated docs de-stale PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)