### PR TITLE
chore: de-stale code comments (Redis/BullMQ) and lite-smoke CI

### DIFF
--- a/.github/workflows/profile-matrix.yml
+++ b/.github/workflows/profile-matrix.yml
@@ -127,7 +127,7 @@ jobs:
       - run: pnpm db:migrate:deploy
       - run: pnpm test
 
-  # ─── smoke: profile-lite (Postgres + encrypted local store) ───────────
+  # ─── smoke: profile-lite (Postgres only) ─────────────────────────────
   smoke-profile-lite:
     name: Smoke (profile=lite)
     runs-on: ubuntu-latest
@@ -149,7 +149,6 @@ jobs:
     env:
       DEPLOYMENT_PROFILE: lite
       DATABASE_URL: postgresql://test:test@localhost:5432/engram_test
-      LOCAL_DATA_DIR: /tmp/engram-lite-smoke
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -159,16 +158,12 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
-      - name: Generate encryption key
-        run: echo "LOCAL_ENCRYPTION_KEY=$(openssl rand -base64 32)" >> $GITHUB_ENV
       - run: pnpm install --frozen-lockfile
       - run: pnpm db:generate
       - run: pnpm db:migrate:deploy
       - run: pnpm build
       - name: Boot profile-lite
         run: |
-          mkdir -p "$LOCAL_DATA_DIR"
-          chmod 0700 "$LOCAL_DATA_DIR"
           pnpm --filter mcp-server start:prod &
           SERVER_PID=$!
           for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
@@ -193,14 +188,10 @@ jobs:
         run: |
           curl -sf http://127.0.0.1:3000/health/metrics \
             | grep -E '^engram_deployment_profile_info\{profile="lite"\} 1$'
-      - name: Encrypted data dir perms
-        run: |
-          stat -c '%a' "$LOCAL_DATA_DIR" | grep -q '^700$'
       - name: Cleanup
         if: always()
         run: |
           pkill -f 'apps/mcp-server/dist/main.js' || true
-          rm -rf "$LOCAL_DATA_DIR"
 
   # ─── smoke: profile-standard (Postgres only) ──────────────────────────
   smoke-profile-standard:

--- a/apps/mcp-server/src/auth/auth-resolver.service.ts
+++ b/apps/mcp-server/src/auth/auth-resolver.service.ts
@@ -33,8 +33,8 @@ function firstHeader(value: string | string[] | undefined): string | undefined {
  * {@link AuthIdentity} otherwise. A presented-but-invalid credential is never
  * silently downgraded to anonymous.
  *
- * When a {@link JwtRevocationService} is wired (the standard profile), verified
- * JWTs are additionally checked against the `jti` denylist so
+ * When a {@link JwtRevocationService} is wired (the standard profile, with JWT
+ * auth configured), verified JWTs are additionally checked against the `jti` denylist so
  * logged-out tokens are rejected for their remaining lifetime.
  */
 @Injectable()
@@ -114,7 +114,7 @@ export class AuthResolver {
     }
 
     // Revocation (jti denylist) check — present only when a denylist store
-    // is wired (the standard profile). Fail-closed: a denylist store error rejects the token
+    // is wired (multi-tenant profile + JWT configured). Fail-closed: a denylist store error rejects the token
     // rather than accepting a possibly-revoked one, matching the API-key
     // posture above where a verification error never authenticates.
     if (this.revocation) {

--- a/apps/mcp-server/src/auth/auth-resolver.service.ts
+++ b/apps/mcp-server/src/auth/auth-resolver.service.ts
@@ -33,8 +33,8 @@ function firstHeader(value: string | string[] | undefined): string | undefined {
  * {@link AuthIdentity} otherwise. A presented-but-invalid credential is never
  * silently downgraded to anonymous.
  *
- * When a {@link JwtRevocationService} is wired (enterprise profile — requires
- * Redis), verified JWTs are additionally checked against the `jti` denylist so
+ * When a {@link JwtRevocationService} is wired (the standard profile), verified
+ * JWTs are additionally checked against the `jti` denylist so
  * logged-out tokens are rejected for their remaining lifetime.
  */
 @Injectable()
@@ -113,8 +113,8 @@ export class AuthResolver {
       };
     }
 
-    // Revocation (jti denylist) check — present only when Redis is wired
-    // (enterprise). Fail-closed: a denylist store error rejects the token
+    // Revocation (jti denylist) check — present only when a denylist store
+    // is wired (the standard profile). Fail-closed: a denylist store error rejects the token
     // rather than accepting a possibly-revoked one, matching the API-key
     // posture above where a verification error never authenticates.
     if (this.revocation) {

--- a/apps/mcp-server/src/auth/auth.controller.ts
+++ b/apps/mcp-server/src/auth/auth.controller.ts
@@ -210,7 +210,7 @@ export class AuthController {
 
   /**
    * Logout invalidates *both* halves of the interactive credential pair:
-   * the Redis session named by the cookie, and the JWT via the `jti`
+   * the Postgres session named by the cookie, and the JWT via the `jti`
    * denylist (entry TTL = remaining token lifetime). The JWT is found from
    * the session record (which stores the paired `jti`/`exp`) and/or the
    * `Authorization: Bearer` header on the logout request itself.

--- a/apps/mcp-server/src/auth/mcp-rate-limit.middleware.ts
+++ b/apps/mcp-server/src/auth/mcp-rate-limit.middleware.ts
@@ -30,7 +30,7 @@ function jsonRpcId(body: unknown): unknown {
 }
 
 /**
- * Express middleware for `/mcp` applying Redis-backed fixed-window rate limits.
+ * Express middleware for `/mcp` applying Postgres-backed fixed-window rate limits.
  * Authenticated requests are metered per-user (and per-org when applicable);
  * unauthenticated requests are metered per client IP. Per-tool overrides apply
  * to the user/IP bucket. Exceeding any applicable bucket yields a 429 with

--- a/apps/mcp-server/src/export.cli.ts
+++ b/apps/mcp-server/src/export.cli.ts
@@ -11,7 +11,7 @@
  * Options:
  *   --user <id>        Owner whose memories to export (required)
  *   --out <dir>        Output directory (default ./engram-export)
- *   --include-stm      Also export short-term (Redis) memories (default off)
+ *   --include-stm      Also export short-term memories (default off)
  *   --tag <t>          Only memories carrying this tag (repeatable)
  *   --scope <s>        Only memories in this scope namespace
  *   --type <t>         Restrict to one tier: short-term | long-term

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -311,7 +311,7 @@ async function bootstrap(): Promise<void> {
     logger.error('Failed to start MCP handler:', error);
   }
 
-  // Run NestJS lifecycle hooks (Redis/Prisma disconnect, metrics registry
+  // Run NestJS lifecycle hooks (Prisma disconnect, metrics registry
   // clear, MCP transport close, scheduler interval cleanup) on SIGTERM/SIGINT
   // and drain in-flight requests instead of dropping them. enableShutdownHooks
   // wires the signal handling itself; we deliberately avoid a manual handler

--- a/apps/mcp-server/src/memory/dto/export.dto.ts
+++ b/apps/mcp-server/src/memory/dto/export.dto.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 export const exportToolSchema = z
   .object({
     userId: userIdSchema,
-    /** Include short-term (Redis) memories. Default false — LTM only. */
+    /** Include short-term memories. Default false — LTM only. */
     includeStm: z.boolean().optional(),
     tags: z.array(z.string()).optional(),
     dateFrom: z.string().datetime().optional(),

--- a/apps/mcp-server/src/memory/dto/list-memories.dto.ts
+++ b/apps/mcp-server/src/memory/dto/list-memories.dto.ts
@@ -1,7 +1,7 @@
 import { cursorIdSchema, userIdSchema } from '@engram/database';
 import { z } from 'zod';
 
-// A page cursor is either an LTM id cursor (cuid) or a Redis SCAN cursor
+// A page cursor is either an LTM id cursor (cuid) or a Postgres STM cursor
 // (non-negative integer string) used when paging the short-term tier. Accepting
 // both lets `list_memories(type: 'short-term')` page STM through the same tool
 // instead of a bespoke one (WP2 T2/D1).

--- a/apps/mcp-server/src/memory/export/export.types.ts
+++ b/apps/mcp-server/src/memory/export/export.types.ts
@@ -7,12 +7,12 @@ export type ExportTypeFilter = 'short-term' | 'long-term';
 
 /**
  * Options for {@link MemoryExportService.export}. STM is excluded by default
- * (PLAN §4.6): it is transient Redis-backed working memory, so exporting it
+ * (PLAN §4.6): it is transient Postgres-backed working memory, so exporting it
  * would capture ephemeral state.
  */
 export interface MemoryExportOptions {
   userId: string;
-  /** Include short-term (Redis) memories. Default false — LTM only. */
+  /** Include short-term memories. Default false — LTM only. */
   includeStm?: boolean;
   tags?: string[];
   dateFrom?: Date;

--- a/apps/mcp-server/src/memory/memory.controller.ts
+++ b/apps/mcp-server/src/memory/memory.controller.ts
@@ -1696,7 +1696,7 @@ export class MemoryController {
    * that profile-memory does not advertise tools that depend on
    * external services, and profile-lite keeps the synchronous reindex
    * while hiding the resumable-queue / cancellation tools that rely
-   * on a BullMQ worker.
+   * on the Postgres-backed reindex queue.
    */
   getMcpTools(): Tool[] {
     // Handlers, bound to this controller instance, keyed by tool name. The tool

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -216,7 +216,7 @@ export interface ListMemoryOptions {
   search?: string;
   /**
    * Restrict the listing to a single tier. `'short-term'` queries the Postgres STM store
-   * only, paging via its SCAN cursor; `'long-term'` queries Postgres (LTM) only.
+   * only, paging via its cursor; `'long-term'` queries Postgres (LTM) only.
    * When omitted, both tiers are merged (legacy behaviour — do not build stable
    * pagination on the merge; see `listMemories`).
    */

--- a/apps/mcp-server/src/memory/memory.service.ts
+++ b/apps/mcp-server/src/memory/memory.service.ts
@@ -215,7 +215,7 @@ export interface ListMemoryOptions {
   tags?: string[];
   search?: string;
   /**
-   * Restrict the listing to a single tier. `'short-term'` queries Redis (STM)
+   * Restrict the listing to a single tier. `'short-term'` queries the Postgres STM store
    * only, paging via its SCAN cursor; `'long-term'` queries Postgres (LTM) only.
    * When omitted, both tiers are merged (legacy behaviour — do not build stable
    * pagination on the merge; see `listMemories`).
@@ -456,7 +456,7 @@ export class MemoryService {
     // on every page (its cursor only advances LTM), so any caller that needs
     // stable pagination asks for exactly one tier.
     if (options.type === 'short-term') {
-      // STM only — page through Redis via its SCAN cursor.
+      // STM only — page through the Postgres STM store via its cursor.
       const stm = await this.stm.list(userId, {
         limit,
         cursor: options.cursor,

--- a/apps/mcp-server/src/security/client-error.util.ts
+++ b/apps/mcp-server/src/security/client-error.util.ts
@@ -10,7 +10,7 @@ import { ZodError } from 'zod';
  *   2. `ClientFacingError` — messages we authored for the caller (auth
  *      failures, unavailable-in-profile notices, …).
  *
- * Everything else (Prisma, Redis, embedding-provider, vector-store errors)
+ * Everything else (Prisma, embedding-provider, vector-store errors)
  * is replaced with a generic message so internal details — connection
  * strings, table names, provider quotas — never reach a client. The full
  * error is still logged server-side by the handler before rethrowing.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -2,7 +2,7 @@
  * @engram/auth — authentication & authorization primitives for ENGRAM.
  *
  * Framework-agnostic building blocks (plain classes + interfaces). The NestJS
- * wiring, Redis store adapters, and HTTP controller live in the host app
+ * wiring, Postgres store adapters, and HTTP controller live in the host app
  * (`apps/mcp-server/src/auth`), which composes these with config and DI.
  */
 

--- a/packages/auth/src/jwt/jwt-revocation.service.ts
+++ b/packages/auth/src/jwt/jwt-revocation.service.ts
@@ -4,7 +4,7 @@
  * JWTs are stateless: once issued, an HS256 token verifies until `exp`
  * (7 days by default) no matter what happens server-side. This service makes
  * individual tokens revocable by recording their `jti` in a denylist store
- * (Redis in the host app) with a TTL equal to the token's *remaining*
+ * (Postgres in the host app) with a TTL equal to the token's *remaining*
  * lifetime — the entry expires exactly when the token itself would, so the
  * denylist never grows beyond the set of still-live revoked tokens.
  *
@@ -22,7 +22,7 @@ const DENYLIST_PREFIX = 'auth:jwt:denylist:';
 
 /**
  * Key/value store backing the `jti` denylist. Structurally a subset of
- * `SessionStore`, so the host's Redis session store satisfies it as-is.
+ * `SessionStore`, so the host's Postgres session store satisfies it as-is.
  * Every write carries an explicit TTL so entries cannot leak.
  */
 export interface JwtDenylistStore {

--- a/packages/auth/src/ratelimit/rate-limit-store.ts
+++ b/packages/auth/src/ratelimit/rate-limit-store.ts
@@ -1,8 +1,8 @@
 /**
  * Counter store backing the fixed-window rate limiter.
  *
- * The package defines the interface; the host application provides a Redis
- * implementation (atomic `INCR` + first-hit `EXPIRE`). Unit tests use an
+ * The package defines the interface; the host application provides a concrete
+ * implementation (the app ships a Postgres-backed store). Unit tests use an
  * in-memory fake driven by an injectable clock.
  */
 export interface RateLimitIncrementResult {

--- a/packages/auth/src/session/session-store.ts
+++ b/packages/auth/src/session/session-store.ts
@@ -2,7 +2,7 @@
  * Key/value store backing sessions and one-time OAuth state.
  *
  * The package defines only the interface; the host application provides a
- * concrete implementation (Redis in enterprise). Unit tests use an in-memory
+ * concrete implementation (Postgres in the standard profile). Unit tests use an in-memory
  * fake. Every write carries an explicit TTL so entries cannot leak.
  */
 export interface SessionStore {

--- a/packages/vector-store/src/vector-store.interface.ts
+++ b/packages/vector-store/src/vector-store.interface.ts
@@ -78,7 +78,7 @@ export interface VectorSearchResult {
 /**
  * Backend-agnostic vector storage contract.
  *
- * Implementations wrap a concrete engine (Qdrant, pgvector, ...) so the memory
+ * Implementations wrap a concrete engine (pgvector) so the memory
  * layer can perform the vector lifecycle (upsert / delete / search) without
  * depending on a specific database.
  */


### PR DESCRIPTION
Low-risk follow-up to the docs de-stale (#276/#277): the **published docs** are now accurate, but a set of **code comments** and one **CI job** still described the pre-simplification (Redis/Qdrant/BullMQ) world. No behavior change.

## Comments (fixed only the ones that misstate *current* behavior)

- STM / rate-limits / sessions / JWT-denylist are **Postgres-backed, not Redis** (`memory.service`, `mcp-rate-limit.middleware`, `auth-resolver`, `auth.controller`, and the `@engram/auth` package interfaces).
- The reindex queue runs on **Postgres job rows, not a BullMQ worker** (`memory.controller`).
- Short-term export DTOs no longer say "(Redis) memories"; the `VectorStore` interface wraps **pgvector** only; `main.ts` / `client-error` drop Redis from their lists.

**Deliberately kept** (accurate historical/design context, not false claims): the `postgres-stm.adapter` "parity with Redis" notes, `postgres-rate-limit`/`postgres-session` "matches the old Redis semantics" comments, `pgvector` "no separate Qdrant service", and `profile.ts`'s "retired Redis/Qdrant services". The `@engram/eval` `recall-fixtures` are synthetic test data and were left untouched.

## CI

- `profile-matrix.yml` lite-smoke job: removed the dead `LOCAL_DATA_DIR` / `LOCAL_ENCRYPTION_KEY` env, the encryption-key generation, the data-dir mkdir/chmod, and the "Encrypted data dir perms" check. The runtime never reads `LOCAL_*` (verified — `secure-startup`/`MemoryLiteModule` aren't wired into any profile), so the lite server boots Postgres-only.

## Verification

Affected packages build + typecheck clean; comment/CI changes carry no runtime surface. A separate PR removes the now-fully-dead `packages/memory-lite` + `apps/mcp-server/src/migration/` code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)