### PR TITLE
ops: automated dependency upgrades and vulnerability tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
       - name: Validate renovate.json5
         run: npx --yes --package renovate renovate-config-validator --strict
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,20 @@ jobs:
         # step surfaces the next one automatically instead of by hand.
         run: pnpm audit --prod --audit-level=high
 
+  renovate-config:
+    name: Renovate config
+    runs-on: ubuntu-latest
+    # A config error does not degrade Renovate gracefully — it aborts the
+    # whole repository run, so no upgrade PRs and no security PRs are opened
+    # at all, with a single config-warning issue as the only signal. Catch it
+    # on the PR that introduces it instead.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate renovate.json5
+        run: npx --yes --package renovate renovate-config-validator --strict
+
   docker-build:
     name: Docker build (mcp-server)
     runs-on: ubuntu-latest

--- a/.github/workflows/vulnerability-watch.yml
+++ b/.github/workflows/vulnerability-watch.yml
@@ -1,0 +1,178 @@
+name: Vulnerability watch
+
+# Continuous visibility for advisories that Renovate cannot close on its own.
+#
+# Renovate (renovate.json5) opens PRs whenever a fixed version exists. This
+# workflow covers the remainder — advisories with no patched release yet, ones
+# stuck behind a transitive parent, and anything needing a `pnpm-workspace.yaml`
+# override bump (which Renovate does not manage) — by keeping a single tracking
+# issue in sync with the live audit. Without it, an unfixable advisory is only
+# ever visible as a red CI job on whichever PR happens to run next.
+#
+# It maintains ONE issue, located by a hidden sentinel in the body rather than
+# by title, so renaming or relabelling the issue during triage cannot cause the
+# job to file duplicates.
+
+on:
+  schedule:
+    # Daily at 06:23 UTC, off the :00 congestion window.
+    - cron: '23 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: vulnerability-watch
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Audit production dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      ISSUE_TITLE: 'Security: unresolved dependency advisories'
+      # Hidden marker used to find the tracking issue. Never change it.
+      SENTINEL: '<!-- vulnerability-watch-tracking-issue -->'
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+
+      - name: Run audit
+        id: audit
+        # `pnpm audit` exits non-zero both for "advisories found" AND for
+        # infrastructure failures (registry unreachable, proxy error,
+        # unparseable lockfile). Those must not be conflated: a network blip
+        # would otherwise overwrite the real advisory list with a stack trace,
+        # or — worse — a broken audit could never close the issue.
+        #
+        # The discriminator is the "Severity:" summary line, which pnpm only
+        # prints once it has actually completed an audit.
+        run: |
+          set +e
+          pnpm audit --prod --audit-level=high > audit.txt 2>&1
+          code=$?
+          set -e
+          cat audit.txt
+
+          summary="$(grep -E '^Severity:' audit.txt | tail -1 || true)"
+
+          if [ "$code" -eq 0 ]; then
+            echo "state=clean" >> "$GITHUB_OUTPUT"
+          elif [ -n "$summary" ]; then
+            echo "state=findings" >> "$GITHUB_OUTPUT"
+            echo "summary=$summary" >> "$GITHUB_OUTPUT"
+          else
+            echo "state=broken" >> "$GITHUB_OUTPUT"
+            echo "::error::pnpm audit failed without producing a summary — treating as an infrastructure failure, not as findings. The tracking issue was left untouched."
+            exit 1
+          fi
+
+      - name: Build issue body
+        if: steps.audit.outputs.state == 'findings'
+        env:
+          SUMMARY: ${{ steps.audit.outputs.summary }}
+        run: |
+          {
+            echo "$SENTINEL"
+            echo "Automated by [\`vulnerability-watch\`](.github/workflows/vulnerability-watch.yml)."
+            echo "Last run: \`$(date -u '+%Y-%m-%d %H:%M UTC')\` · [run log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            echo
+            echo "**${SUMMARY}**"
+            echo
+            echo "Renovate opens PRs automatically wherever a fixed version exists"
+            echo "(see the Dependency dashboard). What remains here needs an upstream"
+            echo "release, a \`pnpm-workspace.yaml\` override bump, or an accepted-risk note."
+            echo
+            echo '<details><summary>Full <code>pnpm audit --prod --audit-level=high</code> output</summary>'
+            echo
+            echo '```text'
+            # Truncate by LINES, not bytes: the output is mostly multibyte
+            # box-drawing characters and a byte cut can split a UTF-8
+            # sequence (and the closing fence must survive either way).
+            head -n 700 audit.txt
+            echo '```'
+            echo
+            echo '</details>'
+          } > issue-body.md
+
+      - name: Find the tracking issue
+        id: find
+        if: steps.audit.outputs.state != 'broken'
+        # Server-side search on the sentinel, so neither a retitle, a label
+        # change, nor >50 security issues can hide it.
+        run: |
+          set -euo pipefail
+          number="$(gh issue list --state all --limit 100 \
+            --search "\"vulnerability-watch-tracking-issue\" in:body" \
+            --json number --jq '.[0].number // empty')"
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+          echo "Tracking issue: ${number:-none}"
+
+      - name: Open or update the tracking issue
+        if: steps.audit.outputs.state == 'findings'
+        run: |
+          set -euo pipefail
+          number='${{ steps.find.outputs.number }}'
+          if [ -z "$number" ]; then
+            gh issue create --title "$ISSUE_TITLE" \
+              --body-file issue-body.md --label security --label dependencies
+            echo "Opened a new tracking issue."
+          else
+            gh issue edit "$number" --body-file issue-body.md
+            state="$(gh issue view "$number" --json state --jq '.state')"
+            if [ "$state" = "CLOSED" ]; then gh issue reopen "$number"; fi
+            echo "Updated tracking issue #$number."
+          fi
+
+      - name: Close the tracking issue when clean
+        if: steps.audit.outputs.state == 'clean'
+        run: |
+          set -euo pipefail
+          number='${{ steps.find.outputs.number }}'
+          if [ -z "$number" ]; then
+            echo "Clean, and no tracking issue exists."
+            exit 0
+          fi
+          state="$(gh issue view "$number" --json state --jq '.state')"
+          if [ "$state" = "OPEN" ]; then
+            gh issue comment "$number" --body \
+              "No high or critical advisories in production dependencies as of $(date -u '+%Y-%m-%d %H:%M UTC'). Closing."
+            gh issue close "$number"
+            echo "Closed tracking issue #$number."
+          else
+            echo "Clean, and the tracking issue is already closed."
+          fi
+
+      - name: Job summary
+        if: always()
+        env:
+          STATE: ${{ steps.audit.outputs.state }}
+          SUMMARY: ${{ steps.audit.outputs.summary }}
+        run: |
+          {
+            echo "### Vulnerability watch"
+            echo
+            case "$STATE" in
+              clean)    echo "No high or critical advisories in production dependencies." ;;
+              findings) echo "**${SUMMARY}**"; echo; echo "Tracking issue updated." ;;
+              broken)   echo "The audit did not complete (infrastructure failure). The tracking issue was left untouched." ;;
+              *)        echo "The audit step did not run — see the failed step above." ;;
+            esac
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ops/dependency-automation.md
+++ b/docs/ops/dependency-automation.md
@@ -1,0 +1,145 @@
+---
+title: Dependency automation
+description: How ENGRAM keeps its dependencies current and turns published advisories into pull requests — Renovate policy, the vulnerability watch, and the supply-chain quarantine.
+---
+
+ENGRAM upgrades its dependencies automatically. Three pieces do the work:
+
+| Piece                                                                    | Runs                           | Job                                                          |
+| ------------------------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------ |
+| [Renovate](../../renovate.json5)                                         | Monday 07:00; security anytime | Opens (and mostly merges) upgrade PRs                        |
+| [`vulnerability-watch`](../../.github/workflows/vulnerability-watch.yml) | Daily 06:23 UTC                | Tracks advisories Renovate **cannot** fix                    |
+| `Dependency audit` (in [`ci.yml`](../../.github/workflows/ci.yml))       | Every PR                       | Fails on high/critical advisories in production dependencies |
+
+`renovate.json5` is itself validated by a `Renovate config` CI job, because a
+config error does not degrade gracefully — it aborts the entire Renovate run,
+so _no_ upgrade PRs and _no_ security PRs get opened, with only a
+config-warning issue as the signal.
+
+## What merges by itself, and what does not
+
+| Update                               | Automerge | Notes                                                              |
+| ------------------------------------ | --------- | ------------------------------------------------------------------ |
+| Patch / minor (≥ 1.0.0)              | ✅ yes    | Grouped into one PR                                                |
+| Lint + type tooling (dev)            | ✅ yes    | Separate group so tooling churn stays out of the way               |
+| Security fix (patch / minor)         | ✅ yes    | Opens immediately, skips the queue and the quarantine              |
+| **0.x minor** (e.g. `0.219 → 0.220`) | ❌ no     | Below 1.0.0 a "minor" is a breaking change — see below             |
+| Major                                | ❌ no     | One PR per major, labelled `major-upgrade`                         |
+| Security fix that is a major         | ❌ no     | Inherits the major rule — a breaking change is never merged unseen |
+| GitHub Actions (`uses:` bumps)       | ❌ no     | Edits CI files that hold `GITHUB_TOKEN`                            |
+| Lockfile maintenance (monthly)       | ❌ no     | Re-resolves the whole tree; quarantine does not apply              |
+| Node / pnpm / `@types/node`          | ❌ no     | CI runner versions must move with it                               |
+
+### Two rules in `renovate.json5` that are easy to break
+
+1. **`packageRules` apply in order and later rules win.** Every "never
+   automerge this" rule must sit _after_ the grouping and automerge rules, or
+   it is silently overridden. (The majors rule is deliberately below the
+   ecosystem groups for exactly this reason.)
+2. **A grouped PR automerges only if every member is automergeable.** So a
+   rule that sets `automerge: false` must also set `groupName: null` —
+   otherwise one non-automergeable package (`@types/node` publishes most
+   weeks) quietly freezes automerge for the whole batch it lands in.
+
+### 0.x is not "minor"
+
+Roughly 43 dependency ranges here sit below 1.0.0, including the
+`@opentelemetry/*` `0.219.x` experimental line. Renovate types `0.219 → 0.220`
+as a minor, but semver promises nothing below 1.0.0, and this family's breaks
+are runtime-only — they typecheck and then fail in production (see the note in
+`pnpm-workspace.yaml` about a lone propagator bump silently breaking context
+propagation). 0.x minors are therefore treated as breaking and reviewed.
+
+## Automerge waits for _all_ checks, not just the required ones
+
+Renovate performs its own merge (`platformAutomerge: false`) rather than
+handing off to GitHub's native auto-merge. That is deliberate and stricter:
+GitHub's auto-merge only waits for the **required** checks, and
+`Dependency audit` is _not_ one of them — so a dependency PR could otherwise
+land while introducing a fresh advisory. Renovate requires the whole branch
+status to be green, so a red audit blocks the merge. Branch protection still
+applies on top; Renovate merges through the API and GitHub rejects anything
+that violates it.
+
+**Consequence today:** there is a standing advisory backlog in `apps/web` and
+`apps/docs`, so `Dependency audit` is red on every branch and nothing will
+automerge until it is cleared. That is the gate working as intended, not a
+misconfiguration — and once the backlog is fixed, automerge starts working with
+no config change. Clearing it, then promoting `Dependency audit` to a required
+status check, is the intended next step.
+
+> Branch protection also requires **conversation resolution**, and the Copilot
+> reviewer comments automatically. So "automerge" means _merges once nothing is
+> outstanding_, not _merges unattended_.
+
+## The supply-chain quarantine
+
+Renovate will not propose a release younger than **3 days**, so a compromised
+publish has time to be caught and yanked. Security fixes bypass it — once an
+advisory is public the vulnerable version is already known, and waiting is
+strictly worse.
+
+Two real limits to understand:
+
+- The gate filters **candidate releases during lookup**. It does not inspect
+  transitively-resolved packages, and it does not apply to the monthly
+  **lockfile maintenance** branch, which re-resolves the whole tree. That
+  branch is never automerged for this reason.
+- It is a _proposal-time_ gate, not an install-time one.
+
+### On `minimumReleaseAge` in `pnpm-workspace.yaml`
+
+pnpm supports the same idea at install time, and enabling it _would_ close the
+transitive and lockfile-maintenance gaps above. It is currently **off**, and
+turning it on is a deliberate trade-off rather than a free win:
+
+pnpm enforces it by verifying **every lockfile entry** on
+`pnpm install --frozen-lockfile`. Verified here: with a 3-day window,
+`fast-uri@3.1.5` — pinned the previous day to close CVE-2026-16221 — failed
+with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`, which fails that install step in
+every CI job on every branch, not just the branch that introduced it. Recovering
+means adding the package to `minimumReleaseAgeExclude` (the existing
+`recharts@3.9.1` entry is the fossil of exactly this) or waiting out the window
+with CI red.
+
+Renovate does maintain `minimumReleaseAgeExclude` for its own vulnerability
+PRs, so the two can be made to cooperate. If you enable it, budget for the
+exclude list needing hand-maintenance whenever a fresh version is pinned
+outside Renovate. The vestigial `minimumReleaseAgeExclude` key is inert while
+`minimumReleaseAge` is unset.
+
+## What Renovate does _not_ manage
+
+**`overrides:` in `pnpm-workspace.yaml`.** Renovate's pnpm-workspace schema
+reads only `packages`, the catalogs, and the `minimumReleaseAge*` keys — not
+the overrides block. Those overrides are where this repo's CVE remediations
+live (`undici <7`, `vite <8.1`, `fast-uri <4`, the `@opentelemetry/*` 2.x
+family), each with a comment explaining what breaks without it.
+
+So **raising an override floor for a new advisory is a human task.** Renovate
+will not open that PR and will not list it on the dashboard. The
+`vulnerability-watch` issue is where that work surfaces. The
+`pinned-review-required` label still exists and fires for those packages when
+they _also_ appear in a `package.json`, but do not rely on it as the only
+signal.
+
+`apps/marketing-site` is likewise ignored: it sits outside the pnpm workspace
+and carries its own `package-lock.json`.
+
+## Where to look
+
+- **Dependency dashboard** — a permanent issue listing everything pending,
+  rate-limited, or awaiting approval. The best single view of the queue.
+- **`Security: unresolved dependency advisories`** — maintained by
+  `vulnerability-watch`, holding what Renovate cannot fix. It is located by a
+  hidden sentinel in the body, so retitling or relabelling it during triage is
+  safe. It closes itself when the audit comes back clean, and is deliberately
+  left untouched when the audit fails for infrastructure reasons.
+- **GitHub Security tab** — vulnerability alerts are enabled; Dependabot's own
+  PRs are intentionally off so they do not duplicate Renovate's.
+
+## Rate limits
+
+Renovate is capped at 5 open PRs and 2 new PRs per hour, so an advisory backlog
+cannot arrive as dozens of simultaneous PRs. Raise the limits in
+`renovate.json5` for a one-off catch-up, then put them back.

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,258 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+
+  // ── ENGRAM dependency automation ────────────────────────────────────────
+  // Keeps the monorepo on current libraries and turns published advisories
+  // into PRs automatically.
+  //
+  // Two things about this file are load-bearing and easy to break:
+  //
+  //  1. packageRules are applied IN ORDER and later rules win. Every
+  //     "never automerge this" rule therefore lives AFTER the grouping and
+  //     automerge rules, or it is silently overridden.
+  //  2. A group branch automerges only if EVERY member of the group is
+  //     automergeable. So a rule that sets `automerge: false` must also set
+  //     `groupName: null`, or it disables automerge for the whole batch it
+  //     happens to land in.
+  //
+  // See docs/ops/dependency-automation.md for the policy this encodes.
+  // ────────────────────────────────────────────────────────────────────────
+
+  extends: [
+    'config:recommended',
+    ':dependencyDashboard',
+    ':semanticCommits',
+    'security:openssf-scorecard',
+    // NB: lockfile maintenance is configured explicitly below, not via a
+    // `:maintainLockFiles*` preset — two sources would fight over the schedule.
+  ],
+
+  timezone: 'Europe/London',
+
+  // Regular upgrade runs land as a Monday-morning batch; security PRs are
+  // exempt from this schedule (see vulnerabilityAlerts) and open immediately.
+  schedule: ['before 07:00 on monday'],
+
+  // The Dependency Dashboard issue is the single place to see everything
+  // pending, rate-limited, or blocked — including advisories with no fix yet.
+  dependencyDashboard: true,
+  dependencyDashboardTitle: 'Dependency dashboard',
+  dependencyDashboardOSVVulnerabilitySummary: 'unresolved',
+
+  // apps/marketing-site is deliberately OUTSIDE the pnpm workspace
+  // (pnpm-workspace.yaml `- '!apps/marketing-site'`) and carries its own
+  // package-lock.json. Renovate would otherwise treat it as an npm project
+  // and open PRs whose lockfile the root install does not manage.
+  ignorePaths: ['**/node_modules/**', 'apps/marketing-site/**'],
+
+  // Conventional commits — commitlint here allows: feat|fix|refactor|perf|
+  // style|test|docs|build|ops|chore with a lowercase subject. Renovate only
+  // lowercases the subject when it builds the prefix itself from
+  // semanticCommitType, so never set `commitMessagePrefix` (that path skips
+  // the lowercasing and emits "…: Update dependency …", which fails
+  // commitlint's subject-case rule).
+  semanticCommits: 'enabled',
+  semanticCommitType: 'chore',
+  semanticCommitScope: 'deps',
+  commitMessageLowerCase: 'auto',
+
+  // 3-day supply-chain quarantine: skip releases younger than this so a
+  // compromised publish has time to be yanked. Security fixes override it.
+  // NOTE: this filters *candidate releases during lookup*. It does NOT apply
+  // to transitive resolution or to lockFileMaintenance — see the runbook.
+  minimumReleaseAge: '3 days',
+  // Required for the age gate to actually hold; without it other internal
+  // checks can let a too-young release through.
+  internalChecksFilter: 'strict',
+
+  // Renovate does its own merge rather than handing off to GitHub's native
+  // auto-merge. This is deliberate and stricter: GitHub's auto-merge only
+  // waits for the *required* checks, so a PR could land with the
+  // (non-required) `Dependency audit` red. Renovate's own automerge requires
+  // the whole branch status to be green, so a red audit blocks the merge.
+  // Branch protection still applies on top — Renovate merges through the API
+  // and GitHub rejects anything that violates it.
+  platformAutomerge: false,
+  automergeStrategy: 'squash',
+
+  // Keep the review queue survivable. There is an existing advisory backlog;
+  // these limits stop it arriving as 30 simultaneous PRs.
+  prConcurrentLimit: 5,
+  prHourlyLimit: 2,
+  branchConcurrentLimit: 8,
+
+  // Rebase a PR when its branch goes stale so CI results stay meaningful.
+  rebaseWhen: 'behind-base-branch',
+
+  labels: ['dependencies'],
+
+  // Refreshes the whole transitive tree monthly, catching drift that no
+  // direct-dependency bump would. It re-resolves rather than looking up
+  // candidates, so the 3-day quarantine does NOT apply — hence never
+  // automerged (see the explicit rule below).
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ['before 07:00 on the first day of the month'],
+    commitMessageAction: 'refresh',
+  },
+
+  // ── packageRules — ORDER MATTERS, later rules win ──────────────────────
+  packageRules: [
+    // ── 1. Ecosystem groups ─────────────────────────────────────────────
+    // Related packages must move together: splitting them produces version
+    // skew that typechecks but breaks at runtime (see the @opentelemetry
+    // note in pnpm-workspace.yaml, where a lone propagator bump pulled in a
+    // second @opentelemetry/core and broke context propagation).
+    // Scoped to non-breaking updates so majors stay one-per-PR (rule 4).
+    {
+      matchUpdateTypes: ['patch', 'minor', 'pin', 'digest'],
+      matchPackageNames: ['@opentelemetry/**'],
+      groupName: 'opentelemetry',
+    },
+    {
+      matchUpdateTypes: ['patch', 'minor', 'pin', 'digest'],
+      matchPackageNames: ['@nestjs/**'],
+      groupName: 'nestjs',
+    },
+    {
+      matchUpdateTypes: ['patch', 'minor', 'pin', 'digest'],
+      matchPackageNames: ['@prisma/**', 'prisma'],
+      groupName: 'prisma',
+    },
+    {
+      matchUpdateTypes: ['patch', 'minor', 'pin', 'digest'],
+      matchPackageNames: ['@astrojs/**', 'astro', 'starlight**'],
+      groupName: 'astro and starlight',
+    },
+    {
+      matchUpdateTypes: ['patch', 'minor', 'pin', 'digest'],
+      matchPackageNames: [
+        'next',
+        'next-auth',
+        '@auth/**',
+        'react',
+        'react-dom',
+        '@types/react',
+        '@types/react-dom',
+      ],
+      groupName: 'next and react',
+    },
+    {
+      matchUpdateTypes: ['patch', 'minor', 'pin', 'digest'],
+      matchPackageNames: ['vitest', '@vitest/**', 'jest', 'jest-**', 'ts-jest'],
+      groupName: 'test runners',
+    },
+
+    // ── 2. Patch + minor: grouped and automerged once CI is green ───────
+    {
+      matchUpdateTypes: ['patch', 'minor', 'pin', 'digest'],
+      automerge: true,
+      groupName: 'patch and minor updates',
+      // Dev tooling churns most; keep it out of the main group's way.
+      // Negation-only is the correct form here — adding a leading '*' is a
+      // hard config error ("* along with other patterns") that aborts the
+      // whole Renovate run.
+      matchPackageNames: ['!@types/**', '!eslint**', '!@typescript-eslint/**'],
+    },
+    {
+      matchUpdateTypes: ['patch', 'minor'],
+      matchPackageNames: ['@types/**', 'eslint**', '@typescript-eslint/**'],
+      matchDepTypes: ['devDependencies'],
+      automerge: true,
+      groupName: 'lint and type tooling',
+    },
+
+    // ── 3. 0.x releases: a "minor" is a breaking change ─────────────────
+    // semver says nothing below 1.0.0 is stable, and Renovate types
+    // 0.219.0 → 0.220.0 as `minor`. This repo has ~43 ranges on 0.x,
+    // including the @opentelemetry/* 0.219.x experimental line whose breaks
+    // are runtime-only (they typecheck, then fail in production).
+    {
+      matchCurrentVersion: '/^0\\./',
+      matchUpdateTypes: ['minor'],
+      automerge: false,
+      groupName: null,
+      labels: ['dependencies', 'major-upgrade'],
+    },
+
+    // ── 4. Majors: never automerged, one PR each ────────────────────────
+    // Placed after the ecosystem groups so `groupName: null` actually wins.
+    {
+      matchUpdateTypes: ['major'],
+      automerge: false,
+      groupName: null,
+      labels: ['dependencies', 'major-upgrade'],
+      minimumReleaseAge: '7 days',
+    },
+
+    // ── 5. CI workflow edits always get a human ─────────────────────────
+    // The github-actions manager rewrites `uses:` refs in .github/workflows.
+    // Those jobs hold GITHUB_TOKEN (e.g. the trivy scan and the release
+    // workflow), so a third-party action must never start executing there
+    // without someone reading the diff.
+    {
+      matchManagers: ['github-actions'],
+      automerge: false,
+      groupName: null,
+      labels: ['dependencies', 'toolchain'],
+    },
+
+    // ── 6. Lockfile maintenance: reviewed, never automerged ─────────────
+    // It re-resolves the transitive tree with no age filtering.
+    {
+      matchUpdateTypes: ['lockFileMaintenance'],
+      automerge: false,
+      groupName: null,
+      labels: ['dependencies', 'toolchain'],
+    },
+
+    // ── 7. Toolchain pins ───────────────────────────────────────────────
+    // A bump here has to move the CI setup-node / pnpm versions with it.
+    {
+      matchPackageNames: ['pnpm', 'node', '@types/node'],
+      automerge: false,
+      groupName: null,
+      labels: ['dependencies', 'toolchain'],
+    },
+
+    // ── 8. Packages constrained by a workspace override ─────────────────
+    // pnpm-workspace.yaml `overrides` carry deliberate upper bounds with
+    // comments explaining what breaks without them.
+    //
+    // IMPORTANT: Renovate does NOT parse the `overrides:` block of
+    // pnpm-workspace.yaml (its schema reads only `packages`, the catalogs,
+    // and the minimumReleaseAge keys). This rule therefore only fires for
+    // packages that ALSO appear in some package.json. Raising an override
+    // floor for a new CVE remains a human task — the vulnerability-watch
+    // issue is where that lands.
+    {
+      matchPackageNames: ['undici', 'vite', 'fast-uri', 'multer', 'form-data', 'hono'],
+      automerge: false,
+      groupName: null,
+      labels: ['dependencies', 'pinned-review-required'],
+    },
+  ],
+
+  // ── Security advisories: fastest path, quarantine waived ──────────────
+  // A published advisory means the vulnerable version is already public, so
+  // waiting out a release-age window is strictly worse than shipping the fix.
+  vulnerabilityAlerts: {
+    enabled: true,
+    schedule: ['at any time'],
+    minimumReleaseAge: null,
+    labels: ['dependencies', 'security'],
+    // Use semanticCommitType, NOT commitMessagePrefix: the prefix path skips
+    // Renovate's subject lowercasing and emits "fix(deps): Update dependency
+    // …", which this repo's commitlint rejects (subject-case).
+    semanticCommitType: 'fix',
+    // `automerge` is deliberately unset. vulnerabilityAlerts merges on top of
+    // packageRules, so leaving it unset lets a security fix inherit the same
+    // policy as everything else: patch/minor automerges once CI is green, a
+    // major (or a 0.x minor) still waits for a human. Setting it true here
+    // would override that and land breaking majors unreviewed.
+  },
+
+  // OSV-backed detection in addition to GitHub advisories, so a vulnerability
+  // is surfaced even before it lands in the GitHub Advisory Database.
+  osvVulnerabilityAlerts: true,
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -172,7 +172,7 @@
       matchUpdateTypes: ['minor'],
       automerge: false,
       groupName: null,
-      labels: ['dependencies', 'major-upgrade'],
+      addLabels: ['dependencies', 'major-upgrade'],
     },
 
     // ── 4. Majors: never automerged, one PR each ────────────────────────
@@ -181,7 +181,7 @@
       matchUpdateTypes: ['major'],
       automerge: false,
       groupName: null,
-      labels: ['dependencies', 'major-upgrade'],
+      addLabels: ['dependencies', 'major-upgrade'],
       minimumReleaseAge: '7 days',
     },
 
@@ -194,7 +194,7 @@
       matchManagers: ['github-actions'],
       automerge: false,
       groupName: null,
-      labels: ['dependencies', 'toolchain'],
+      addLabels: ['dependencies', 'toolchain'],
     },
 
     // ── 6. Lockfile maintenance: reviewed, never automerged ─────────────
@@ -203,7 +203,7 @@
       matchUpdateTypes: ['lockFileMaintenance'],
       automerge: false,
       groupName: null,
-      labels: ['dependencies', 'toolchain'],
+      addLabels: ['dependencies', 'toolchain'],
     },
 
     // ── 7. Toolchain pins ───────────────────────────────────────────────
@@ -212,7 +212,7 @@
       matchPackageNames: ['pnpm', 'node', '@types/node'],
       automerge: false,
       groupName: null,
-      labels: ['dependencies', 'toolchain'],
+      addLabels: ['dependencies', 'toolchain'],
     },
 
     // ── 8. Packages constrained by a workspace override ─────────────────
@@ -229,7 +229,7 @@
       matchPackageNames: ['undici', 'vite', 'fast-uri', 'multer', 'form-data', 'hono'],
       automerge: false,
       groupName: null,
-      labels: ['dependencies', 'pinned-review-required'],
+      addLabels: ['dependencies', 'pinned-review-required'],
     },
   ],
 


### PR DESCRIPTION
Adds a pipeline that keeps dependencies current and turns published advisories into PRs, without handing a bot unreviewed authority over breaking changes.

## Pieces

| Piece | Runs | Job |
| --- | --- | --- |
| `renovate.json5` | Monday 07:00; security anytime | Opens (and mostly merges) upgrade PRs |
| `.github/workflows/vulnerability-watch.yml` | Daily 06:23 UTC | Tracks advisories Renovate **cannot** fix, in one self-closing issue |
| `Renovate config` job in `ci.yml` | Every PR | A config error aborts the *entire* Renovate run — catch it on the PR that introduces it |

Plus, applied directly to the repo: **GitHub vulnerability alerts enabled** (they were off, and Renovate's security detection reads them), Dependabot's own PRs left off so they don't duplicate Renovate, and the five labels the pipeline needs created (all were missing — `gh issue create` would have failed).

## Policy

Patch/minor automerge; **majors, 0.x minors, GitHub Actions bumps, lockfile maintenance, toolchain and override-pinned packages always get a human**. A 3-day supply-chain quarantine on non-security updates; security fixes bypass it and open immediately.

## Notable findings from building it

- **A 3-day quarantine in pnpm breaks CI outright.** `minimumReleaseAge` makes `pnpm install --frozen-lockfile` verify *every* lockfile entry, and `fast-uri@3.1.5` (yesterday's CVE pin) is younger than the cutoff — failing that install step in all 10 required checks, on every branch. The quarantine therefore lives at Renovate's proposal layer. Documented with the evidence so it isn't re-added blindly.
- **Renovate does not read `overrides:` from `pnpm-workspace.yaml`** (its schema covers only `packages`, catalogs and the `minimumReleaseAge*` keys). That's where this repo's CVE remediations live, so raising an override floor stays a human task — stated plainly in the runbook rather than left as a false sense of coverage.
- **Automerge waits for *all* checks, not just required ones** (`platformAutomerge: false`). GitHub's native auto-merge only waits for required checks, and `Dependency audit` isn't one — so a dep PR could land while introducing a fresh advisory. Consequence: with the current 31-advisory backlog, nothing automerges until it's cleared. That's the gate working, and it starts working with no config change once the backlog is fixed.

## Verification

`renovate-config-validator --strict` on the latest Renovate (a `matchPackageNames: ['*', …]` form I'd used first is a **hard error** that aborts the whole run — caught before merge); workflow YAML parsed and every `run` block `bash -n`'d; `docs:check` and prettier clean.

An adversarial review pass (3 lenses, executing Renovate's own `applyPackageRules`/`generateBranchConfig` and running commitlint on the exact subjects Renovate would emit) found 11 defects in the first draft — group-automerge poisoning, a commit subject that fails commitlint, majors silently regrouped by rule order, and more. All fixed here.

## Needs one action from you

Install the Renovate GitHub App on the repo: **https://github.com/apps/renovate** → Configure → osirison/engram. Nothing runs until then. Renovate's first PR will be an onboarding PR describing what it plans to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)