### PR TITLE
docs(ops): record that Dependency audit is now a required check

### DIFF
--- a/docs/ops/dependency-automation.md
+++ b/docs/ops/dependency-automation.md
@@ -61,9 +61,10 @@ merges through the API and GitHub rejects anything that violates it.
 
 **Status (2026-08-02):** the advisory backlog that used to hold automerge shut
 was cleared, and `Dependency audit` was promoted from an informational job to a
-**required** status check — so a dependency PR can no longer land alongside a
-fresh advisory, whichever merge path is used. It is now one of 11 required
-contexts on `main`.
+**required** status check on `main` — so a dependency PR can no longer land
+alongside a fresh advisory, whichever merge path is used. (`gh api
+repos/osirison/engram/branches/main/protection/required_status_checks` lists
+the current set.)
 
 Because it is required, it must report on **every** PR: keep the `audit` job
 free of `if:` conditions, `needs:`, and path filters. A required check that

--- a/docs/ops/dependency-automation.md
+++ b/docs/ops/dependency-automation.md
@@ -54,19 +54,20 @@ propagation). 0.x minors are therefore treated as breaking and reviewed.
 
 Renovate performs its own merge (`platformAutomerge: false`) rather than
 handing off to GitHub's native auto-merge. That is deliberate and stricter:
-GitHub's auto-merge only waits for the **required** checks, and
-`Dependency audit` is _not_ one of them — so a dependency PR could otherwise
-land while introducing a fresh advisory. Renovate requires the whole branch
-status to be green, so a red audit blocks the merge. Branch protection still
-applies on top; Renovate merges through the API and GitHub rejects anything
-that violates it.
+GitHub's auto-merge only waits for the **required** checks, so anything left
+informational could otherwise be red at merge time. Renovate requires the whole
+branch status to be green. Branch protection still applies on top; Renovate
+merges through the API and GitHub rejects anything that violates it.
 
-**Status:** the advisory backlog that used to hold this shut was cleared on
-2026-08-02 (`pnpm audit` is clean for production _and_ dev dependencies), so
-automerge is live. Promoting `Dependency audit` from an informational job to a
-**required** status check is the remaining step — it is not required today, so
-branch protection alone would still let a dependency PR land alongside a fresh
-advisory; only Renovate's own all-checks-green rule currently prevents that.
+**Status (2026-08-02):** the advisory backlog that used to hold automerge shut
+was cleared, and `Dependency audit` was promoted from an informational job to a
+**required** status check — so a dependency PR can no longer land alongside a
+fresh advisory, whichever merge path is used. It is now one of 11 required
+contexts on `main`.
+
+Because it is required, it must report on **every** PR: keep the `audit` job
+free of `if:` conditions, `needs:`, and path filters. A required check that
+never reports blocks every PR rather than failing one.
 
 > Branch protection also requires **conversation resolution**, and the Copilot
 > reviewer comments automatically. So "automerge" means _merges once nothing is

--- a/renovate.json5
+++ b/renovate.json5
@@ -70,16 +70,19 @@
 
   // Renovate does its own merge rather than handing off to GitHub's native
   // auto-merge. This is deliberate and stricter: GitHub's auto-merge only
-  // waits for the *required* checks, so a PR could land with the
-  // (non-required) `Dependency audit` red. Renovate's own automerge requires
-  // the whole branch status to be green, so a red audit blocks the merge.
-  // Branch protection still applies on top — Renovate merges through the API
-  // and GitHub rejects anything that violates it.
+  // waits for the *required* checks, so any job left informational could be
+  // red at merge time. Renovate's own automerge requires the whole branch
+  // status to be green. (`Dependency audit` became a required check on
+  // 2026-08-02, so that one is now covered by both paths.) Branch protection
+  // still applies on top — Renovate merges through the API and GitHub rejects
+  // anything that violates it.
   platformAutomerge: false,
   automergeStrategy: 'squash',
 
-  // Keep the review queue survivable. There is an existing advisory backlog;
-  // these limits stop it arriving as 30 simultaneous PRs.
+  // Keep the review queue survivable. The initial advisory backlog was cleared
+  // on 2026-08-02, but the first Renovate run still has a whole tree of
+  // upgrades to propose; these limits stop that arriving as 30 simultaneous
+  // PRs.
   prConcurrentLimit: 5,
   prHourlyLimit: 2,
   branchConcurrentLimit: 8,


### PR DESCRIPTION
Follow-up to #281. `Dependency audit` has been promoted from an informational job to a **required** status check on `main` (10 → 11 required contexts). This updates the two places that documented it as *not* required, since that reasoning was load-bearing.

## Why it was safe to promote

- The backlog is clear: `pnpm audit` is green for production **and** dev, and `npm audit` is green in `apps/marketing-site`. 0 open Dependabot alerts.
- The `audit` job has no `if:`, no `needs:`, and the CI workflow has no path filters — so it reports on every PR. A required check that *can be skipped* never reports and blocks every PR rather than failing one (the trap hit in #279). That constraint is now written down next to the job.

## What this changes in practice

`platformAutomerge: false` was justified partly by "GitHub's auto-merge only waits for required checks, and `Dependency audit` isn't one". Half of that is now moot — but the setting still earns its keep for every *other* non-required job, so it stays. Both comments were reworded rather than deleted.

Branch protection was edited surgically: a snapshot was taken first, only `required_status_checks.contexts` changed, and a diff of the full protection object confirms conversation resolution, linear history, force-push and deletion rules are byte-identical.

Docs-only; no runtime change. `renovate-config` validated against `renovate@44.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CL7DoudQdjFrJNq5Uxq57s