### PR TITLE
fix(compose): bind published ports to loopback

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,7 +19,9 @@ services:
       POSTGRES_USER: engram_test
       POSTGRES_PASSWORD: test_password
     ports:
-      - '5433:5432'
+      # Loopback only. This one ships a literal password, so an all-interfaces
+      # bind would be trivially usable by anyone on the same network.
+      - '127.0.0.1:5433:5432'
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U engram_test -d engram_test']
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-engram}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev_password}
     ports:
-      - '${POSTGRES_PORT:-5432}:5432'
+      # Bound to loopback: a bare '5432:5432' publishes on 0.0.0.0, and Docker's
+      # DNAT traverses FORWARD, bypassing the host firewall zone entirely.
+      - '127.0.0.1:${POSTGRES_PORT:-5432}:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
@@ -26,7 +28,8 @@ services:
     container_name: engram-ollama
     profiles: ['ollama']
     ports:
-      - '${OLLAMA_PORT:-11434}:11434'
+      # Loopback only: Ollama has no authentication whatsoever.
+      - '127.0.0.1:${OLLAMA_PORT:-11434}:11434'
     volumes:
       - ollama_data:/root/.ollama
     healthcheck:


### PR DESCRIPTION
## Why

The dev and test compose files published their ports on `0.0.0.0`. **A host firewall does not mitigate this.**

Docker DNATs published ports in `nat` PREROUTING; the traffic then traverses **FORWARD**, where firewalld's shipped policy accepts it:

```
policy docker-forwarding:  ingress-zones: ANY -> egress-zones: docker -> target: ACCEPT
```

`ANY` includes the most restrictive zones. The packet never reaches the INPUT chain that the host's zone governs, so a published container port is reachable from the subnet **even with the host firewall's default zone set to `drop`**.

Found during a workstation audit: `engram-postgres` was published as `0.0.0.0:5432` on a laptop whose firewall was at its most restrictive setting, and which regularly joins untrusted WiFi.

## Severity, honestly

| Service | Was | Auth behind it |
| --- | --- | --- |
| `postgres` (dev) | `0.0.0.0:5432` | SCRAM-SHA-256 — password required |
| `ollama` (dev, profile-gated) | `0.0.0.0:11434` | **none at all** |
| `postgres-test` | `0.0.0.0:5433` | literal `test_password` in the file |

Postgres is the *least* severe case — it authenticates. `ollama` is why this is worth doing now rather than later: Ollama has no authentication whatsoever, so a single `--profile ollama` on a café or conference network exposes an open LLM API. `docker-compose.test.yml` ships a literal password, so its bind was trivially usable by anyone on the same subnet.

## Why this is safe

No functional change. Every consumer either runs on the host or reaches these services by name over `engram-network`, and container-to-container traffic does not go through published ports at all.

This also aligns dev and test with the convention the repo **already follows** elsewhere — `docker-compose.prod.yml:61` (`\${MCP_BIND_ADDR:-127.0.0.1}`) and `docker-compose.inspector.yml:6-7` were already loopback-bound. Dev and test were the outliers.

## Verification

`docker compose config` resolves all three to loopback:

```
docker-compose.yml   (--profile ollama)   host_ip: 127.0.0.1  published: "11434"
docker-compose.yml                        host_ip: 127.0.0.1  published: "5432"
docker-compose.test.yml                   host_ip: 127.0.0.1  published: "5433"
```

Both files pass `docker compose config`.

> [!NOTE]
> The `.github/workflows/*.yml` service containers also use `5432:5432`, deliberately left alone — those run in ephemeral CI runners, not on a machine that joins untrusted networks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)