### PR TITLE
fix(deps): floor ip-address at 10.3.1 for SSRF advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ overrides:
   brace-expansion@^1: '>=1.1.18 <2'
   brace-expansion@^2: '>=2.1.4 <3'
   brace-expansion@^5: '>=5.0.9 <6'
+  ip-address: '>=10.3.1 <11'
 
 importers:
 
@@ -6535,8 +6536,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -14931,7 +14932,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
 
   express@5.2.1:
     dependencies:
@@ -15617,7 +15618,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,6 +94,16 @@ overrides:
   'brace-expansion@^1': '>=1.1.18 <2'
   'brace-expansion@^2': '>=2.1.4 <3'
   'brace-expansion@^5': '>=5.0.9 <6'
+  # --- 2026-08-05 -----------------------------------------------------------
+  # SSRF / trust-boundary bypass: Address4 decodes leading-zero octets as
+  # decimal ('010.0.0.1' -> 10.0.0.1) while the resolver that later dials the
+  # host reads them as octal, so an allowlist check and the connection it
+  # guards can disagree about which address was meant.
+  # GHSA-mwp4-54f8-5fhr / CVE-2026-69192, fixed in 10.3.1.
+  # Pulled transitively via @modelcontextprotocol/sdk > express-rate-limit on
+  # five workspace paths; nothing depends on it directly. Only 10.x is live, so
+  # the bound is the real major.
+  ip-address: '>=10.3.1 <11'
 
 # Allow openai to use zod v4 (openai declares a peer dep on zod ^3 but only uses
 # it for its optional structured-output helpers, which we don't use).


### PR DESCRIPTION
## What

Adds an upper-bounded floor for `ip-address` to the `pnpm-workspace.yaml` overrides:

```yaml
ip-address: '>=10.3.1 <11'
```

## Why

`GHSA-mwp4-54f8-5fhr` / `CVE-2026-69192` (HIGH). `Address4` decodes leading-zero octets as **decimal** (`010.0.0.1` → `10.0.0.1`) while the resolver that later dials the host reads them as **octal** — so an allowlist check and the connection it guards can disagree about which address was meant. That is an SSRF / trust-boundary bypass.

Nothing depends on it directly; it arrives via `@modelcontextprotocol/sdk > express-rate-limit` across five workspace paths. Only the 10.x line is live, so the bound is the real major — consistent with the upper-bounding rule documented above the 2026-08-02 sweep.

## Impact

This advisory was published after `main`'s last CI run and is currently **red on `main`**, failing two required checks:

| Check | Detector |
| --- | --- |
| `Dependency audit` | `pnpm audit --audit-level=high` |
| `Docker build (mcp-server)` | trivy image scan |

It is also blocking #284, which is an unrelated compose change that touches no dependency files.

## Verification

```
$ pnpm audit --audit-level=high ; echo $?
0
```

Before: `4 vulnerabilities found — 3 moderate | 1 high`
After: &nbsp;`1 vulnerabilities found — 1 moderate`

The lockfile delta is exactly one package, `10.2.0 → 10.4.0`, with no other resolution churn:

```
-  ip-address@10.2.0:
+  ip-address@10.4.0:
-      ip-address: 10.2.0
+      ip-address: 10.4.0
```

Found while auditing a workstation that runs these containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)